### PR TITLE
fix: update calculateAtomId docs to require Hex type input

### DIFF
--- a/docs/_data/intuition-sdk/atoms-guide.md
+++ b/docs/_data/intuition-sdk/atoms-guide.md
@@ -133,8 +133,9 @@ Before creating an atom, check if it already exists:
 
 ```typescript
 import { calculateAtomId, getAtomDetails } from '@0xintuition/sdk'
+import { toHex } from 'viem'
 
-const atomId = calculateAtomId('developer')
+const atomId = calculateAtomId(toHex('developer'))
 const exists = await getAtomDetails(atomId)
 
 if (exists) {
@@ -536,24 +537,25 @@ Calculate the atom ID from atom data without querying the blockchain.
 #### Function Signature
 
 ```typescript
-function calculateAtomId(atomData: string): Hex
+function calculateAtomId(atomData: Hex): Hex
 ```
 
 #### Basic Example
 
 ```typescript
 import { calculateAtomId } from '@0xintuition/sdk'
+import { toHex } from 'viem'
 
 // Calculate ID for a string atom
-const atomId = calculateAtomId('developer')
+const atomId = calculateAtomId(toHex('developer'))
 console.log('Atom ID:', atomId)
 
-// Calculate ID for an Ethereum address
-const addressAtomId = calculateAtomId('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+// Calculate ID for an Ethereum address (already hex, but toHex ensures proper encoding)
+const addressAtomId = calculateAtomId(toHex('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'))
 console.log('Address Atom ID:', addressAtomId)
 
 // Calculate ID for IPFS URI
-const ipfsAtomId = calculateAtomId('ipfs://bafkreib...')
+const ipfsAtomId = calculateAtomId(toHex('ipfs://bafkreib...'))
 console.log('IPFS Atom ID:', ipfsAtomId)
 ```
 
@@ -563,10 +565,11 @@ console.log('IPFS Atom ID:', ipfsAtomId)
 
 ```typescript
 import { calculateAtomId, getAtomDetails, createAtomFromString } from '@0xintuition/sdk'
+import { toHex } from 'viem'
 
 async function createAtomIfNotExists(data: string) {
-  // Calculate ID
-  const atomId = calculateAtomId(data)
+  // Calculate ID (convert string to hex first)
+  const atomId = calculateAtomId(toHex(data))
 
   try {
     // Check if exists

--- a/docs/_data/intuition-sdk/examples/find-existing-entities.md
+++ b/docs/_data/intuition-sdk/examples/find-existing-entities.md
@@ -23,7 +23,7 @@ import {
   createAtomFromString,
   createTripleStatement,
 } from '@0xintuition/sdk'
-import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
+import { createPublicClient, createWalletClient, http, parseEther, toHex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import type { Hex } from 'viem'
 
@@ -127,7 +127,7 @@ async function main() {
   // 4. Calculate IDs offline
   console.log('\n=== Offline ID Calculation ===\n')
 
-  const calculatedAtomId = calculateAtomId('NewAtom')
+  const calculatedAtomId = calculateAtomId(toHex('NewAtom'))
   console.log('Predicted atom ID for "NewAtom":', calculatedAtomId)
 
   const calculatedTripleId = calculateTripleId(tsId, compilesTo.state.termId, jsId)


### PR DESCRIPTION
## Summary
- Updated `calculateAtomId` function signature to show it requires `Hex` type input instead of `string`
- Added `toHex` import from viem to all code examples
- Fixed all `calculateAtomId()` calls to use `toHex()` to convert strings to hex format

This fixes the documentation mismatch where examples showed passing plain strings like `'developer'` or `'NewAtom'`, but the actual SDK implementation requires a hex-encoded string (0x-prefixed).

**Files changed:**
- `docs/_data/intuition-sdk/atoms-guide.md`
- `docs/_data/intuition-sdk/examples/find-existing-entities.md`

## Test plan
- [ ] Verify the updated code examples compile without lint errors
- [ ] Confirm the function signature matches the actual SDK implementation

**Slack thread:** https://intuition-systems.slack.com/archives/C0AFT55SQF4/p1776457332794299?thread_ts=1776456051.552199&cid=C0AFT55SQF4

https://claude.ai/code/session_01M9noPs9691tdGVHwPdbxwT