### PR TITLE
fix: replace stale example ids in interactive graphql & sdk examples

### DIFF
--- a/docs/_data/graphql-api/examples/atom-with-vault.md
+++ b/docs/_data/graphql-api/examples/atom-with-vault.md
@@ -46,7 +46,7 @@ export const atomVaultQueries = [
   }
 }`,
     variables: {
-      atomId: '0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21',
+      atomId: '0x906527aae4af914b1ac01ff9adfdda5dafde3b5e21f84045e0660b0a15c07769',
       curveId: '1'
     }
   }

--- a/docs/_data/graphql-api/examples/price-history.md
+++ b/docs/_data/graphql-api/examples/price-history.md
@@ -35,7 +35,7 @@ export const priceHistoryQueries = [
   }
 }`,
     variables: {
-      termId: '0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21',
+      termId: '0x91815a7b50440bb9ff022f5d02c8b8d41154a71eb473b45ca4bf4e1f833d7512',
       curveId: '1',
       days: 30
     }

--- a/docs/_data/intuition-sdk/migration-guide.mdx
+++ b/docs/_data/intuition-sdk/migration-guide.mdx
@@ -514,10 +514,10 @@ const tripleData = await getTriple('54670')
 import { getAtomDetails, getTripleDetails } from '@0xintuition/sdk'
 
 const atomData = await getAtomDetails(
-  '0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21',
+  '0x906527aae4af914b1ac01ff9adfdda5dafde3b5e21f84045e0660b0a15c07769',
 )
 const tripleData = await getTripleDetails(
-  '0x4957d3f442acc301ad71e73f26efd6af78647f57dacf2b3a686d91fa773fe0b6',
+  '0xc4e64dbc3d69293d28259653d9b15d2ab3f6aa1aa0b1a489e5250974cd089730',
 )
 ```
 

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -268,7 +268,7 @@ Retrieve detailed information about an atom using its ID:
 import { getAtomDetails } from '@0xintuition/sdk'
 
 const atomData = await getAtomDetails(
-  '0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21'
+  '0x906527aae4af914b1ac01ff9adfdda5dafde3b5e21f84045e0660b0a15c07769'
 )
 
 console.log('Atom data:', atomData)
@@ -283,7 +283,7 @@ Retrieve information about a triple relationship:
 import { getTripleDetails } from '@0xintuition/sdk'
 
 const tripleData = await getTripleDetails(
-  '0x4957d3f442acc301ad71e73f26efd6af78647f57dacf2b3a686d91fa773fe0b6'
+  '0xc4e64dbc3d69293d28259653d9b15d2ab3f6aa1aa0b1a489e5250974cd089730'
 )
 
 console.log('Triple data:', tripleData)

--- a/docs/_data/tutorials/queries/related-claims.mdx
+++ b/docs/_data/tutorials/queries/related-claims.mdx
@@ -83,7 +83,7 @@ export const relationshipQueries = [
   }
 }`,
     variables: {
-      atomId: '0xf12dba36ffebb8e05ae49d3f9220b1994295662ccdc573f44aff7b51f8ad8fd6',
+      atomId: '0x906527aae4af914b1ac01ff9adfdda5dafde3b5e21f84045e0660b0a15c07769',
       limit: 20
     }
   },
@@ -186,7 +186,7 @@ export const relationshipQueries = [
   }
 }`,
     variables: {
-      termId: '0xffb30efde2b49a7deadd920a7df684595ed4a291a582033c16b0795796965600'
+      termId: '0xc4e64dbc3d69293d28259653d9b15d2ab3f6aa1aa0b1a489e5250974cd089730'
     }
   }
 ];

--- a/src/components/GraphQLPlayground.tsx
+++ b/src/components/GraphQLPlayground.tsx
@@ -233,7 +233,7 @@ const QUERY_EXAMPLES: QueryExample[] = [
   }
 }`,
     variables: {
-      termId: '0xf12dba36ffebb8e05ae49d3f9220b1994295662ccdc573f44aff7b51f8ad8fd6',
+      termId: '0x906527aae4af914b1ac01ff9adfdda5dafde3b5e21f84045e0660b0a15c07769',
     },
   },
   {
@@ -279,7 +279,7 @@ const QUERY_EXAMPLES: QueryExample[] = [
   }
 }`,
     variables: {
-      termId: '0xffb30efde2b49a7deadd920a7df684595ed4a291a582033c16b0795796965600',
+      termId: '0xc4e64dbc3d69293d28259653d9b15d2ab3f6aa1aa0b1a489e5250974cd089730',
     },
   },
  


### PR DESCRIPTION
## What & why

Stale placeholder example IDs across our interactive GraphQL playground examples and SDK code snippets no longer resolve on-chain (dead on both testnet and mainnet). Because the interactive playground runs live on `testnet.intuition.sh`, those examples silently returned `null` when a reader clicked **Run**, and the copy-paste SDK snippets returned `null` too.

This is the same class of fix as #79 ("replace placeholder IDs with real on-chain data"), extended to the files and the playground component that #79 did not touch.

## Changes

Replaced **4 stale IDs** across **10 call sites / 6 files** with **3 live, verified IDs**:

- `0x9065…` — intuitionbilly.eth (atom lookups)
- `0xc4e64dbc…` — a live `has tag` triple (triple lookups)
- `0x91815a7b…` — "Intuition Use Case List" (price-history; 19 daily buckets)

Two commits, split by surface:

- **Interactive playground examples** — `src/components/GraphQLPlayground.tsx`, `tutorials/queries/related-claims.mdx`, `graphql-api/examples/{atom-with-vault,price-history}.md`
- **SDK copy-paste snippets** — `intuition-sdk/migration-guide.mdx`, `quick-start/using-the-sdk.md`

## Validation

- Every replacement ID was **executed against the live endpoint** and confirmed to return non-empty data (e.g. price-history → 19 daily buckets; related-claims → 20 subject + 20 object triples).
- The 4 originals were confirmed **dead on both testnet and mainnet** before replacement.
- Separately validated **all 91 GraphQL operations** in the files #79 skipped (`tutorials/`, `intuition-sdk/`, and the `graphql-api` overview / best-practices / examples / subscriptions / mutations / getting-started files) against live mainnet schema introspection — all structurally valid. These dead-ID fixes were the only user-facing breakage found.
