### PR TITLE
fix: correct mainnet/testnet labeling on intuition-network page

### DIFF
--- a/docs/_data/intuition-network/index.md
+++ b/docs/_data/intuition-network/index.md
@@ -48,7 +48,14 @@ The Intuition testnet is currently active for development and testing.
 
 ### Mainnet
 
-> Coming soon! Testnet is currently active for development.
+The Intuition mainnet is live.
+
+- **Chain ID:** 1155
+- **RPC URL:** https://rpc.intuition.systems
+- **Explorer:** https://explorer.intuition.systems
+- **Currency:** $TRUST
+
+See the [Mainnet page](/docs/intuition-network/mainnet) for hub, bridge, explorer, and RPC details.
 
 ## Running a Node
 

--- a/docs/_data/intuition-network/mainnet.md
+++ b/docs/_data/intuition-network/mainnet.md
@@ -6,7 +6,7 @@ sidebar_position: 0
 
 # Intuition Mainnet
 
-Welcome to the Intuition Mainnet - your development and testing environment for building on the Intuition Network.
+Welcome to the Intuition Mainnet — the live Intuition network for building on the knowledge graph.
 
 Intuition leverages **Caldera's Metalayer** infrastructure to provide seamless cross-chain bridging capabilities. As part of Caldera's **Internet of Chains**, we benefit from a robust, interconnected ecosystem of blockchain networks.
 
@@ -23,7 +23,7 @@ Intuition leverages **Caldera's Metalayer** infrastructure to provide seamless c
 
 
 ## Bridging & Hub
-Vist the Intuition Testnet Hub at: 
+Visit the Intuition Mainnet Hub at: 
 - [https://hub.intuition.systems](https://hub.intuition.systems)
 - [https://intuition.hub.caldera.xyz/](https://intuition.hub.caldera.xyz)
 
@@ -33,14 +33,14 @@ The hub creates essential information about the network plus actions like easily
 
 ## Explorer
 
-Access the Intuition Testnet Explorer directly at: 
+Access the Intuition Mainnet Explorer directly at: 
 - [https://explorer.intuition.systems](https://explorer.intuition.systems)
 
-The Intuition Explorer is a comprehensive blockchain explorer built on Blockscout, providing detailed insights into all network activity on the Intuition testnet. Monitor transactions, explore blocks, and analyze network performance with this powerful exploration tool.
+The Intuition Explorer is a comprehensive blockchain explorer built on Blockscout, providing detailed insights into all network activity on the Intuition mainnet. Monitor transactions, explore blocks, and analyze network performance with this powerful exploration tool.
 
 ## RPC
 
-Access the Intuition Testnet RPC directly at: 
+Access the Intuition Mainnet RPC directly at: 
 - [https://rpc.intuition.systems/http](https://rpc.intuition.systems/http)
 
 The Intuition RPC accepts JSON-RPC requests and returns JSON-RPC responses. It provides programmatic access to the Intuition network.


### PR DESCRIPTION
## What & why

The Intuition mainnet is live (chain ID **1155**, verified live against `rpc.intuition.systems` → `eth_chainId` `0x483`), but the network docs lagged and contradicted themselves. MK flagged the page.

## Changes

**`intuition-network/index.md`** — the Mainnet section was a stale stub (`> Coming soon! Testnet is currently active for development.`) even though mainnet is live and has a full page. Replaced with the real config (chain ID, RPC, explorer, currency) + a link to the mainnet page.

**`intuition-network/mainnet.md`** — the config table was already correct, but the prose still said "Testnet" throughout and described mainnet as a *"development and testing environment."* Fixed:
- intro framing (mainnet is the live network, not a dev/test env)
- "Testnet" → "Mainnet" on the Hub / Explorer / RPC labels (+ a "Vist" typo)

## Verification

- `rpc.intuition.systems` `eth_chainId` → `0x483` (1155) ✓
- `testnet.rpc.intuition.systems` `eth_chainId` → `0x350b` (13579) ✓
- Mainnet config matches `quick-start/network-details.md`.

No config values changed — this is a labeling/staleness fix only.
