### PR TITLE
feat: document gated pinning API key

### DIFF
--- a/.github/workflows/validate-graphql.yml
+++ b/.github/workflows/validate-graphql.yml
@@ -57,6 +57,8 @@ jobs:
           fi
 
       - name: Fetch fresh schema snapshots
+        env:
+          INTUITION_PIN_API_KEY: ${{ secrets.INTUITION_PIN_API_KEY }}
         run: node scripts/validate-graphql-queries.js --update-schema
 
       - name: Check for schema changes

--- a/docs/_data/graphql-api/mutations/images/overview.md
+++ b/docs/_data/graphql-api/mutations/images/overview.md
@@ -8,15 +8,19 @@ keywords: [graphql, mutation, ipfs, image, upload, json]
 
 # Image & IPFS Operations
 
-The Intuition GraphQL API provides mutations for uploading images and JSON data to IPFS (InterPlanetary File System). These operations return IPFS hashes that can be used in atom creation.
+The Intuition GraphQL API provides mutations for uploading images and JSON data to IPFS (InterPlanetary File System). Image uploads return cached image URLs, while JSON uploads return IPFS hashes that can be used in atom creation.
+
+:::important Pinning endpoint and API key
+Image and JSON upload mutations use the public gated pinning endpoint, `https://pin.intuition.systems/v1/graphql`, and require an `apikey` request header. Keep the API key server-side.
+:::
 
 ## Available Operations
 
-| Operation | Description |
-|-----------|-------------|
-| [`uploadImage`](./upload-image) | Upload a base64-encoded image to IPFS |
-| [`uploadImageFromUrl`](./upload-image-from-url) | Upload an image from a URL to IPFS |
-| [`uploadJsonToIpfs`](./upload-json-to-ipfs) | Upload JSON metadata to IPFS |
+| Operation                                       | Description                           |
+| ----------------------------------------------- | ------------------------------------- |
+| [`uploadImage`](./upload-image)                 | Upload a base64-encoded image to IPFS |
+| [`uploadImageFromUrl`](./upload-image-from-url) | Upload an image from a URL to IPFS    |
+| [`uploadJsonToIpfs`](./upload-json-to-ipfs)     | Upload JSON metadata to IPFS          |
 
 ## Use Cases
 
@@ -26,11 +30,12 @@ When creating atoms with images or metadata:
 
 1. Upload image using `uploadImage` or `uploadImageFromUrl`
 2. Upload JSON metadata using `uploadJsonToIpfs`
-3. Use returned IPFS hashes in atom creation
+3. Use the returned image URL and metadata IPFS hash in atom creation
 
 ### Profile Images
 
 Upload profile images for accounts:
+
 - Avatar images
 - Banner images
 - Organization logos
@@ -38,6 +43,7 @@ Upload profile images for accounts:
 ### Metadata Storage
 
 Store structured metadata on IPFS:
+
 - Thing descriptions
 - Organization details
 - Person profiles
@@ -45,68 +51,79 @@ Store structured metadata on IPFS:
 ## Quick Start
 
 ```typescript
-import { GraphQLClient } from 'graphql-request'
-import { API_URL_PROD } from '@0xintuition/graphql'
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
 
-const client = new GraphQLClient(API_URL_PROD)
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
 
 // Upload an image from URL
-const imageResult = await client.request(`
-  mutation UploadImageFromUrl($url: String!) {
-    uploadImageFromUrl(url: $url) {
+const imageResult = await client.request(
+  `
+  mutation UploadImageFromUrl($image: UploadImageFromUrlInput!) {
+    uploadImageFromUrl(image: $image) {
+      images {
+        url
+        safe
+      }
+    }
+  }
+`,
+  {
+    image: { url: 'https://example.com/image.png' },
+  },
+);
+
+// Upload JSON metadata
+const jsonResult = await client.request(
+  `
+  mutation UploadJsonToIpfs($json: jsonb!) {
+    uploadJsonToIpfs(json: $json) {
       hash
-      url
+      name
       size
     }
   }
-`, {
-  url: 'https://example.com/image.png'
-})
+`,
+  {
+    json: {
+      name: 'My Atom',
+      description: 'Description here',
+      image: imageResult.uploadImageFromUrl.images[0].url,
+    },
+  },
+);
 
-// Upload JSON metadata
-const jsonResult = await client.request(`
-  mutation UploadJsonToIpfs($json: JSON!) {
-    uploadJsonToIpfs(json: $json) {
-      hash
-      url
-    }
-  }
-`, {
-  json: {
-    name: 'My Atom',
-    description: 'Description here',
-    image: imageResult.uploadImageFromUrl.url
-  }
-})
-
-console.log('Metadata URL:', jsonResult.uploadJsonToIpfs.url)
-// Use this URL when creating the atom
+console.log('Metadata URI:', `ipfs://${jsonResult.uploadJsonToIpfs.hash}`);
+// Use this URI when creating the atom
 ```
 
-## IPFS URL Format
+## IPFS Response Format
 
-All uploaded content is accessible via IPFS:
+Uploaded JSON content is accessible via IPFS:
 
 ```
 ipfs://<hash>
 ```
 
-The API returns both the raw hash and a gateway URL:
+The exact response shape depends on the mutation. JSON uploads return the raw hash, which you can convert to an IPFS URI:
 
 ```json
 {
-  "hash": "QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy",
-  "url": "ipfs://QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy"
+  "hash": "QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy"
 }
 ```
 
 ## File Size Limits
 
-| Upload Type | Maximum Size |
-|-------------|--------------|
-| Image (base64) | 5 MB |
-| Image from URL | 10 MB |
-| JSON | 1 MB |
+| Upload Type    | Maximum Size |
+| -------------- | ------------ |
+| Image (base64) | 5 MB         |
+| Image from URL | 10 MB        |
+| JSON           | 1 MB         |
 
 ## Supported Image Formats
 

--- a/docs/_data/graphql-api/mutations/images/upload-image-from-url.md
+++ b/docs/_data/graphql-api/mutations/images/upload-image-from-url.md
@@ -6,11 +6,13 @@ description: Upload an image from a URL
 keywords: [graphql, mutation, image, upload, url]
 ---
 
-import GraphQLPlaygroundCustom from '@site/src/components/GraphQLPlaygroundCustom';
-
 # Upload Image from URL
 
 Upload an image by providing its URL. The server fetches, caches, and moderates the image. Returns a `CachedImage` with the hosted URL and safety score.
+
+## Endpoint and Auth
+
+Use the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, with an `apikey` request header. Keep the key in a trusted server runtime.
 
 ## Mutation Structure
 
@@ -33,9 +35,9 @@ mutation UploadImageFromUrl($image: UploadImageFromUrlInput!) {
 
 The mutation takes an `image` argument with the `UploadImageFromUrlInput` type:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `url` | `String` | Yes | URL of the image to upload |
+| Field | Type     | Required | Description                |
+| ----- | -------- | -------- | -------------------------- |
+| `url` | `String` | Yes      | URL of the image to upload |
 
 ```json
 {
@@ -49,15 +51,15 @@ The mutation takes an `image` argument with the `UploadImageFromUrlInput` type:
 
 Returns `UploadImageFromUrlOutput` containing an `images` array of `CachedImage` objects:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `images` | `[CachedImage!]!` | Array of cached image results |
-| `images[].url` | `String!` | Hosted image URL |
-| `images[].original_url` | `String!` | Original source URL |
-| `images[].safe` | `Boolean!` | Whether the image passed moderation |
-| `images[].score` | `jsonb` | Moderation safety score details |
-| `images[].model` | `String` | Moderation model used |
-| `images[].created_at` | `timestamptz!` | Upload timestamp |
+| Field                   | Type              | Description                         |
+| ----------------------- | ----------------- | ----------------------------------- |
+| `images`                | `[CachedImage!]!` | Array of cached image results       |
+| `images[].url`          | `String!`         | Hosted image URL                    |
+| `images[].original_url` | `String!`         | Original source URL                 |
+| `images[].safe`         | `Boolean!`        | Whether the image passed moderation |
+| `images[].score`        | `jsonb`           | Moderation safety score details     |
+| `images[].model`        | `String`          | Moderation model used               |
+| `images[].created_at`   | `timestamptz!`    | Upload timestamp                    |
 
 ## Expected Response
 
@@ -80,40 +82,19 @@ Returns `UploadImageFromUrlOutput` containing an `images` array of `CachedImage`
 }
 ```
 
-## Interactive Example
-
-export const uploadUrlQueries = [
-  {
-    id: 'upload-from-url',
-    title: 'Upload Image from URL',
-    query: `mutation UploadImageFromUrl($image: UploadImageFromUrlInput!) {
-  uploadImageFromUrl(image: $image) {
-    images {
-      url
-      original_url
-      safe
-    }
-  }
-}`,
-    variables: {
-      image: {
-        url: 'https://avatars.githubusercontent.com/u/1234567'
-      }
-    }
-  }
-];
-
-<GraphQLPlaygroundCustom queries={uploadUrlQueries} />
-
 ## Use Cases
 
 ### Import External Images
 
 ```typescript
-import { GraphQLClient } from 'graphql-request'
-import { API_URL_PROD } from '@0xintuition/graphql'
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
 
-const client = new GraphQLClient(API_URL_PROD)
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
 
 async function importExternalImage(imageUrl: string) {
   const mutation = `
@@ -125,17 +106,21 @@ async function importExternalImage(imageUrl: string) {
         }
       }
     }
-  `
+  `;
 
   const result = await client.request(mutation, {
-    image: { url: imageUrl }
-  })
+    image: { url: imageUrl },
+  });
 
-  const cached = result.uploadImageFromUrl.images[0]
-  if (!cached.safe) {
-    throw new Error('Image failed moderation check')
+  const cached = result.uploadImageFromUrl.images[0];
+  if (!cached) {
+    throw new Error('Image host could not be fetched');
   }
-  return cached.url
+
+  if (!cached.safe) {
+    throw new Error('Image failed moderation check');
+  }
+  return cached.url;
 }
 ```
 

--- a/docs/_data/graphql-api/mutations/images/upload-image.md
+++ b/docs/_data/graphql-api/mutations/images/upload-image.md
@@ -6,11 +6,13 @@ description: Upload a base64-encoded image via the API
 keywords: [graphql, mutation, image, upload, base64]
 ---
 
-import GraphQLPlaygroundCustom from '@site/src/components/GraphQLPlaygroundCustom';
-
 # Upload Image
 
 Upload a base64-encoded image. The image is cached and a moderation check is performed. Returns a `CachedImage` with the hosted URL and safety score.
+
+## Endpoint and Auth
+
+Use the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, with an `apikey` request header. Keep the key in a trusted server runtime.
 
 ## Mutation Structure
 
@@ -33,11 +35,11 @@ mutation UploadImage($image: UploadImageInput!) {
 
 The mutation takes an `image` argument with the `UploadImageInput` type:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `data` | `String` | Yes | Base64-encoded image data |
-| `filename` | `String` | Yes | Filename with extension |
-| `contentType` | `String` | Yes | MIME type (e.g. `"image/png"`) |
+| Field         | Type     | Required | Description                    |
+| ------------- | -------- | -------- | ------------------------------ |
+| `data`        | `String` | Yes      | Base64-encoded image data      |
+| `filename`    | `String` | Yes      | Filename with extension        |
+| `contentType` | `String` | Yes      | MIME type (e.g. `"image/png"`) |
 
 ```json
 {
@@ -53,15 +55,15 @@ The mutation takes an `image` argument with the `UploadImageInput` type:
 
 Returns `UploadImageFromUrlOutput` containing an `images` array of `CachedImage` objects:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `images` | `[CachedImage!]!` | Array of cached image results |
-| `images[].url` | `String!` | Hosted image URL |
-| `images[].original_url` | `String!` | Original source URL |
-| `images[].safe` | `Boolean!` | Whether the image passed moderation |
-| `images[].score` | `jsonb` | Moderation safety score details |
-| `images[].model` | `String` | Moderation model used |
-| `images[].created_at` | `timestamptz!` | Upload timestamp |
+| Field                   | Type              | Description                         |
+| ----------------------- | ----------------- | ----------------------------------- |
+| `images`                | `[CachedImage!]!` | Array of cached image results       |
+| `images[].url`          | `String!`         | Hosted image URL                    |
+| `images[].original_url` | `String!`         | Original source URL                 |
+| `images[].safe`         | `Boolean!`        | Whether the image passed moderation |
+| `images[].score`        | `jsonb`           | Moderation safety score details     |
+| `images[].model`        | `String`          | Moderation model used               |
+| `images[].created_at`   | `timestamptz!`    | Upload timestamp                    |
 
 ## Expected Response
 
@@ -91,14 +93,18 @@ Returns `UploadImageFromUrlOutput` containing an `images` array of `CachedImage`
 Handle file uploads from a form:
 
 ```typescript
-import { GraphQLClient } from 'graphql-request'
-import { API_URL_PROD } from '@0xintuition/graphql'
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
 
-const client = new GraphQLClient(API_URL_PROD)
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
 
 async function uploadFileInput(file: File) {
-  const buffer = await file.arrayBuffer()
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)))
+  const buffer = await file.arrayBuffer();
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
 
   const mutation = `
     mutation UploadImage($image: UploadImageInput!) {
@@ -109,17 +115,17 @@ async function uploadFileInput(file: File) {
         }
       }
     }
-  `
+  `;
 
   const result = await client.request(mutation, {
     image: {
       data: base64,
       filename: file.name,
-      contentType: file.type
-    }
-  })
+      contentType: file.type,
+    },
+  });
 
-  return result.uploadImage.images[0]
+  return result.uploadImage.images[0];
 }
 ```
 

--- a/docs/_data/graphql-api/mutations/images/upload-json-to-ipfs.md
+++ b/docs/_data/graphql-api/mutations/images/upload-json-to-ipfs.md
@@ -6,11 +6,13 @@ description: Upload JSON metadata to IPFS
 keywords: [graphql, mutation, ipfs, json, metadata, upload]
 ---
 
-import GraphQLPlaygroundCustom from '@site/src/components/GraphQLPlaygroundCustom';
-
 # Upload JSON to IPFS
 
 Upload JSON metadata to IPFS for use in atom creation. Returns the IPFS hash, name, and size.
+
+## Endpoint and Auth
+
+Use the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, with an `apikey` request header. Keep the key in a trusted server runtime.
 
 ## Mutation Structure
 
@@ -26,9 +28,9 @@ mutation UploadJsonToIpfs($json: jsonb!) {
 
 ## Variables
 
-| Variable | Type | Required | Description |
-|----------|------|----------|-------------|
-| `json` | `jsonb` | Yes | JSON object to upload |
+| Variable | Type    | Required | Description           |
+| -------- | ------- | -------- | --------------------- |
+| `json`   | `jsonb` | Yes      | JSON object to upload |
 
 ```json
 {
@@ -44,11 +46,11 @@ mutation UploadJsonToIpfs($json: jsonb!) {
 
 ## Response Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field  | Type      | Description             |
+| ------ | --------- | ----------------------- |
 | `hash` | `String!` | IPFS content hash (CID) |
-| `name` | `String!` | Filename on IPFS |
-| `size` | `String!` | File size |
+| `name` | `String!` | Filename on IPFS        |
+| `size` | `String!` | File size               |
 
 ## Expected Response
 
@@ -63,32 +65,6 @@ mutation UploadJsonToIpfs($json: jsonb!) {
   }
 }
 ```
-
-## Interactive Example
-
-export const uploadJsonQueries = [
-  {
-    id: 'upload-thing-metadata',
-    title: 'Upload Thing Metadata',
-    query: `mutation UploadJsonToIpfs($json: jsonb!) {
-  uploadJsonToIpfs(json: $json) {
-    hash
-    name
-    size
-  }
-}`,
-    variables: {
-      json: {
-        name: 'Ethereum',
-        description: 'A decentralized blockchain platform',
-        image: 'ipfs://QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy',
-        url: 'https://ethereum.org'
-      }
-    }
-  }
-];
-
-<GraphQLPlaygroundCustom queries={uploadJsonQueries} />
 
 ## Common Metadata Schemas
 
@@ -135,16 +111,20 @@ export const uploadJsonQueries = [
 Upload metadata and use the IPFS hash for atom creation:
 
 ```typescript
-import { GraphQLClient } from 'graphql-request'
-import { API_URL_PROD } from '@0xintuition/graphql'
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
 
-const client = new GraphQLClient(API_URL_PROD)
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
 
 async function prepareAtomMetadata(thing: {
-  name: string
-  description: string
-  image: string
-  url?: string
+  name: string;
+  description: string;
+  image: string;
+  url?: string;
 }) {
   const mutation = `
     mutation UploadJsonToIpfs($json: jsonb!) {
@@ -154,10 +134,10 @@ async function prepareAtomMetadata(thing: {
         size
       }
     }
-  `
+  `;
 
-  const result = await client.request(mutation, { json: thing })
-  return result.uploadJsonToIpfs.hash
+  const result = await client.request(mutation, { json: thing });
+  return result.uploadJsonToIpfs.hash;
 }
 ```
 

--- a/docs/_data/graphql-api/mutations/pin-organization.md
+++ b/docs/_data/graphql-api/mutations/pin-organization.md
@@ -10,6 +10,16 @@ keywords: [graphql, mutation, ipfs, pin, organization, metadata]
 
 Pin an Organization entity to IPFS for use in atom creation.
 
+## Endpoint and Auth
+
+Use the public gated pinning endpoint and send your Intuition pin API key in an `apikey` header:
+
+```text
+https://pin.intuition.systems/v1/graphql
+```
+
+`pinOrganization` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinOrganization` helper.
+
 ## Mutation Structure
 
 ```graphql

--- a/docs/_data/graphql-api/mutations/pin-person.md
+++ b/docs/_data/graphql-api/mutations/pin-person.md
@@ -10,6 +10,16 @@ keywords: [graphql, mutation, ipfs, pin, person, metadata]
 
 Pin a Person entity to IPFS for use in atom creation.
 
+## Endpoint and Auth
+
+Use the public gated pinning endpoint and send your Intuition pin API key in an `apikey` header:
+
+```text
+https://pin.intuition.systems/v1/graphql
+```
+
+`pinPerson` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinPerson` helper.
+
 ## Mutation Structure
 
 ```graphql

--- a/docs/_data/graphql-api/mutations/pin-thing.md
+++ b/docs/_data/graphql-api/mutations/pin-thing.md
@@ -6,11 +6,19 @@ description: Pin Thing metadata to IPFS
 keywords: [graphql, mutation, ipfs, pin, thing, metadata]
 ---
 
-import GraphQLPlaygroundCustom from '@site/src/components/GraphQLPlaygroundCustom';
-
 # Pin Thing Mutation
 
 Pin a "Thing" object (general entity) to IPFS for use in atom creation.
+
+## Endpoint and Auth
+
+Use the public gated pinning endpoint and send your Intuition pin API key in an `apikey` header:
+
+```text
+https://pin.intuition.systems/v1/graphql
+```
+
+Keep the key in a trusted server runtime. Do not pass it in the URL or expose it in public browser environment variables.
 
 ## Mutation Structure
 

--- a/docs/_data/graphql-api/npm-package.mdx
+++ b/docs/_data/graphql-api/npm-package.mdx
@@ -10,7 +10,6 @@ description: Comprehensive guide to use the Intuition GraphQL NPM package
 
 The Intuition GraphQL package provides a type-safe interface for interacting with the Intuition API. It functions as the core data fetching layer, supplying generated types and React Query hooks for easy integration with the semantic knowledge graph.
 
-
 ## Key Features
 
 - React Query hooks for data fetching
@@ -20,7 +19,6 @@ The Intuition GraphQL package provides a type-safe interface for interacting wit
 - Pagination
 - Sorting
 - Filtering
-
 
 ## Installation
 
@@ -67,35 +65,55 @@ bun install @0xintuition/graphql
 Configure the GraphQL client at the root of your application:
 
 ```tsx
-import { configureClient, API_URL_DEV, API_URL_PROD, API_URL_LOCAL } from '@0xintuition/graphql'
+import {
+  configureClient,
+  API_URL_DEV,
+  API_URL_PROD,
+  API_URL_LOCAL,
+  PIN_API_URL,
+} from '@0xintuition/graphql';
 
 // Configure the GraphQL client with desired API URL
 configureClient({
   apiUrl: API_URL_LOCAL, // For local development
-})
+});
 ```
 
 **Available API URLs:**
-- `API_URL_PROD`: `https://testnet.intuition.sh/v1/graphql` (default)
+
+- `API_URL_PROD`: `https://mainnet.intuition.sh/v1/graphql` (default)
 - `API_URL_DEV`: `https://testnet.intuition.sh/v1/graphql`
 - `API_URL_LOCAL`: `http://localhost:8080/v1/graphql`
+- `PIN_API_URL`: `https://pin.intuition.systems/v1/graphql`
 
 If you omit this configuration, the package defaults to `API_URL_PROD`.
+
+Pinning mutations use the public gated pinning endpoint and require an Intuition pin API key. Configure the key from a trusted server runtime before calling generated pinning fetchers or pinning helpers:
+
+```typescript
+import { configureClient } from '@0xintuition/graphql';
+
+configureClient({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
+```
+
+Do not expose `INTUITION_PIN_API_KEY` in public browser environment variables.
 
 ### 2. Server Client Usage
 
 For server-side operations:
 
 ```typescript
-import { createServerClient } from '@0xintuition/graphql'
+import { createServerClient } from '@0xintuition/graphql';
 
 // Basic usage (most common)
-const client = createServerClient({})
+const client = createServerClient({});
 
 // With optional authentication token (rarely needed)
 const clientWithAuth = createServerClient({
-  token: 'your-auth-token'
-})
+  token: 'your-auth-token',
+});
 ```
 
 ### 3. Using Generated Hooks
@@ -115,276 +133,350 @@ function StatsComponent() {
 }
 ```
 
-
 ```tsx
-import { useAtomsQuery, useTriplesQuery, useUserPositionsQuery } from '@0xintuition/graphql'
+import {
+  useAtomsQuery,
+  useTriplesQuery,
+  useUserPositionsQuery,
+} from '@0xintuition/graphql';
 
 function MyComponent() {
   // Query atoms
   const { data: atoms, isLoading: atomsLoading } = useAtomsQuery({
-    variables: { limit: 10 }
-  })
+    variables: { limit: 10 },
+  });
 
   // Query triples
   const { data: triples, isLoading: triplesLoading } = useTriplesQuery({
-    variables: { limit: 10 }
-  })
+    variables: { limit: 10 },
+  });
 
   // Query user positions
   const { data: positions } = useUserPositionsQuery({
-    variables: { userAddress: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6' }
-  })
+    variables: { userAddress: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6' },
+  });
 
   if (atomsLoading || triplesLoading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   return (
     <div>
       <h2>Atoms ({atoms?.atoms?.length || 0})</h2>
-      {atoms?.atoms?.map(atom => (
+      {atoms?.atoms?.map((atom) => (
         <div key={atom.term_id}>
           <strong>{atom.label}</strong> - {atom.type}
         </div>
       ))}
 
       <h2>Triples ({triples?.triples?.length || 0})</h2>
-      {triples?.triples?.map(triple => (
+      {triples?.triples?.map((triple) => (
         <div key={triple.term_id}>
-          {triple.subject.label} - {triple.predicate.label} - {triple.object.label}
+          {triple.subject.label} - {triple.predicate.label} -{' '}
+          {triple.object.label}
         </div>
       ))}
     </div>
-  )
+  );
 }
 ```
 
-
 ## Available React Hooks
+
 The following groups correspond to the query documents in the `src/queries` subdirectory of the package. Hook names are generated from each document and follow the `use<Name>Query` convention. The complete and canonical list may be found in the directory: [`packages/graphql/src/queries`](https://github.com/0xIntuition/intuition-ts/tree/main/packages/graphql/src/queries)
 
 ### Accounts
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useAccountByIdQuery</code></li>
+      <li>
+        <code>useAccountByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useAccountsQuery</code></li>
+      <li>
+        <code>useAccountsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Atoms
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useAtomByIdQuery</code></li>
-      <li><code>useGetAtomQuery</code></li>
+      <li>
+        <code>useAtomByIdQuery</code>
+      </li>
+      <li>
+        <code>useGetAtomQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useAtomsQuery</code></li>
-      <li><code>useGetAtomsQuery</code></li>
+      <li>
+        <code>useAtomsQuery</code>
+      </li>
+      <li>
+        <code>useGetAtomsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Claims
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useClaimByIdQuery</code></li>
+      <li>
+        <code>useClaimByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useClaimsQuery</code></li>
+      <li>
+        <code>useClaimsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Events
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useEventByIdQuery</code></li>
+      <li>
+        <code>useEventByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useEventsQuery</code></li>
+      <li>
+        <code>useEventsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Follows
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useFollowByIdQuery</code></li>
+      <li>
+        <code>useFollowByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useFollowsQuery</code></li>
+      <li>
+        <code>useFollowsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Lists
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useListByIdQuery</code></li>
+      <li>
+        <code>useListByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useListsQuery</code></li>
+      <li>
+        <code>useListsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Points
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>usePointByIdQuery</code></li>
+      <li>
+        <code>usePointByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>usePointsQuery</code></li>
+      <li>
+        <code>usePointsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Positions
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>usePositionByIdQuery</code></li>
+      <li>
+        <code>usePositionByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>usePositionsQuery</code></li>
-      <li><code>useUserPositionsQuery</code></li>
+      <li>
+        <code>usePositionsQuery</code>
+      </li>
+      <li>
+        <code>useUserPositionsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Signals
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useSignalByIdQuery</code></li>
+      <li>
+        <code>useSignalByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useSignalsQuery</code></li>
-      <li><code>useGetSignalsQuery</code></li>
+      <li>
+        <code>useSignalsQuery</code>
+      </li>
+      <li>
+        <code>useGetSignalsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Stats
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get</h4>
     <ul className="uniform-card-list">
-      <li><code>useGetStatsQuery</code></li>
+      <li>
+        <code>useGetStatsQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useStatsQuery</code></li>
+      <li>
+        <code>useStatsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Tags
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useTagByIdQuery</code></li>
+      <li>
+        <code>useTagByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useTagsQuery</code></li>
+      <li>
+        <code>useTagsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Triples
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useTripleByIdQuery</code></li>
+      <li>
+        <code>useTripleByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useTriplesQuery</code></li>
+      <li>
+        <code>useTriplesQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 ### Vaults
+
 <div className="uniform-card-grid-small">
   <div className="uniform-card">
     <h4 className="uniform-card-title">Get by ID</h4>
     <ul className="uniform-card-list">
-      <li><code>useVaultByIdQuery</code></li>
+      <li>
+        <code>useVaultByIdQuery</code>
+      </li>
     </ul>
   </div>
   <div className="uniform-card">
     <h4 className="uniform-card-title">Search &amp; Filter</h4>
     <ul className="uniform-card-list">
-      <li><code>useVaultsQuery</code></li>
+      <li>
+        <code>useVaultsQuery</code>
+      </li>
     </ul>
   </div>
 </div>
 
 These hooks are generated via GraphQL Code Generator and may expand over time as new documents are added. See the package source below for the current and authoritative list.
 
-
 ## Source Code
 
 The GraphQL package source code is available on GitHub: [`intuition-ts/packages/graphql`](https://github.com/0xIntuition/intuition-ts/tree/main/packages/graphql)
-
 
 ## Related Resources
 
 - [GraphQL Code Generator](https://the-guild.dev/graphql/codegen)
 - [React Query Documentation](https://tanstack.com/query)
-

--- a/docs/_data/graphql-api/writes.mdx
+++ b/docs/_data/graphql-api/writes.mdx
@@ -190,7 +190,7 @@ Here's how to prepare metadata for atom creation:
 ```typescript
 import { GraphQLClient } from 'graphql-request';
 import { PIN_API_URL } from '@0xintuition/graphql';
-import { createMultivaultClient } from '@0xintuition/sdk';
+import { createAtomFromIpfsUri } from '@0xintuition/sdk';
 
 const pinClient = new GraphQLClient(PIN_API_URL, {
   headers: {
@@ -232,10 +232,10 @@ const metadataResult = await pinClient.request(
 );
 
 // Step 3: Create atom on-chain (via SDK)
-const multivault = createMultivaultClient(walletClient);
-const atomId = await multivault.createAtom({
-  uri: metadataResult.pinThing.uri,
-});
+const atom = await createAtomFromIpfsUri(
+  { walletClient, publicClient, address },
+  metadataResult.pinThing.uri,
+);
 ```
 
 ## Best Practices

--- a/docs/_data/graphql-api/writes.mdx
+++ b/docs/_data/graphql-api/writes.mdx
@@ -12,11 +12,17 @@ description: Guide to write data using GraphQL mutations in the Intuition API
 
 The Intuition GraphQL API provides mutations for **off-chain operations** like uploading metadata to IPFS. For **on-chain operations** like creating atoms, triples, and positions, you must use the [Intuition SDK](/docs/intuition-sdk/installation-and-setup) or interact directly with the smart contracts.
 
+:::important Pinning endpoint and API key
+Pinning mutations are served from the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, not the read endpoint. Send your Intuition pin API key in an `apikey` request header from a trusted server runtime.
+:::
+
 :::info GraphQL vs Smart Contracts
 **GraphQL mutations** handle:
+
 - Uploading metadata to IPFS (pinThing, pinPerson, pinOrganization)
 
 **Smart contract operations** handle:
+
 - Creating atoms
 - Creating triples
 - Taking positions (depositing/redeeming)
@@ -29,20 +35,21 @@ Use the [SDK](/docs/intuition-sdk/installation-and-setup) for smart contract int
 
 ### IPFS & Metadata Mutations
 
-| Mutation | Description | Documentation |
-|----------|-------------|---------------|
-| `pinThing` | Pin Thing metadata to IPFS | [Pin Thing](/docs/graphql-api/mutations/pin-thing) |
-| `pinPerson` | Pin Person metadata to IPFS | [Pin Person](/docs/graphql-api/mutations/pin-person) |
-| `pinOrganization` | Pin Organization metadata to IPFS | [Pin Organization](/docs/graphql-api/mutations/pin-organization) |
-| `uploadImage` | Upload base64 image to IPFS | [Upload Image](/docs/graphql-api/mutations/images/upload-image) |
-| `uploadImageFromUrl` | Upload image from URL to IPFS | [Upload from URL](/docs/graphql-api/mutations/images/upload-image-from-url) |
-| `uploadJsonToIpfs` | Upload JSON metadata to IPFS | [Upload JSON](/docs/graphql-api/mutations/images/upload-json-to-ipfs) |
+| Mutation             | Description                       | Documentation                                                               |
+| -------------------- | --------------------------------- | --------------------------------------------------------------------------- |
+| `pinThing`           | Pin Thing metadata to IPFS        | [Pin Thing](/docs/graphql-api/mutations/pin-thing)                          |
+| `pinPerson`          | Pin Person metadata to IPFS       | [Pin Person](/docs/graphql-api/mutations/pin-person)                        |
+| `pinOrganization`    | Pin Organization metadata to IPFS | [Pin Organization](/docs/graphql-api/mutations/pin-organization)            |
+| `uploadImage`        | Upload base64 image to IPFS       | [Upload Image](/docs/graphql-api/mutations/images/upload-image)             |
+| `uploadImageFromUrl` | Upload image from URL to IPFS     | [Upload from URL](/docs/graphql-api/mutations/images/upload-image-from-url) |
+| `uploadJsonToIpfs`   | Upload JSON metadata to IPFS      | [Upload JSON](/docs/graphql-api/mutations/images/upload-json-to-ipfs)       |
 
 :::tip Read-Only Operations
 Chart and PnL operations are **queries**, not mutations. See:
+
 - [PnL Queries](/docs/graphql-api/queries/pnl/overview) - Profit & Loss tracking
 - [Chart Queries](/docs/graphql-api/queries/charts/overview) - Chart generation
-:::
+  :::
 
 ## Pin Mutations
 
@@ -59,6 +66,7 @@ mutation PinThing($thing: PinThingInput!) {
 ```
 
 **Variables:**
+
 ```json
 {
   "thing": {
@@ -83,6 +91,7 @@ mutation PinPerson($person: PinPersonInput!) {
 ```
 
 **Variables:**
+
 ```json
 {
   "person": {
@@ -109,6 +118,7 @@ mutation PinOrganization($organization: PinOrganizationInput!) {
 ```
 
 **Variables:**
+
 ```json
 {
   "organization": {
@@ -178,14 +188,19 @@ mutation UploadJsonToIpfs($json: jsonb!) {
 Here's how to prepare metadata for atom creation:
 
 ```typescript
-import { GraphQLClient } from 'graphql-request'
-import { API_URL_PROD } from '@0xintuition/graphql'
-import { createMultivaultClient } from '@0xintuition/sdk'
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+import { createMultivaultClient } from '@0xintuition/sdk';
 
-const graphqlClient = new GraphQLClient(API_URL_PROD)
+const pinClient = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
 
 // Step 1: Upload image to IPFS (via GraphQL)
-const imageResult = await graphqlClient.request(`
+const imageResult = await pinClient.request(
+  `
   mutation UploadImageFromUrl($image: UploadImageFromUrlInput!) {
     uploadImageFromUrl(image: $image) {
       images {
@@ -193,119 +208,108 @@ const imageResult = await graphqlClient.request(`
       }
     }
   }
-`, { image: { url: 'https://example.com/logo.png' } })
+`,
+  { image: { url: 'https://example.com/logo.png' } },
+);
 
 // Step 2: Upload metadata to IPFS (via GraphQL)
-const metadataResult = await graphqlClient.request(`
+const metadataResult = await pinClient.request(
+  `
   mutation PinThing($thing: PinThingInput!) {
     pinThing(thing: $thing) {
       uri
     }
   }
-`, {
-  thing: {
-    name: 'My Project',
-    description: 'Description of my project',
-    image: imageResult.uploadImageFromUrl.images[0].url,
-    url: 'https://example.com'
-  }
-})
+`,
+  {
+    thing: {
+      name: 'My Project',
+      description: 'Description of my project',
+      image: imageResult.uploadImageFromUrl.images[0].url,
+      url: 'https://example.com',
+    },
+  },
+);
 
 // Step 3: Create atom on-chain (via SDK)
-const multivault = createMultivaultClient(walletClient)
+const multivault = createMultivaultClient(walletClient);
 const atomId = await multivault.createAtom({
-  uri: metadataResult.pinThing.uri
-})
+  uri: metadataResult.pinThing.uri,
+});
 ```
 
 ## Best Practices
 
 ### 1. Complete Metadata
-Provide comprehensive metadata for better discoverability:
+
+Provide all required metadata fields for better discoverability:
 
 ```typescript
 const thing = {
-  name: 'Project Name',           // Required
-  description: 'Full description', // Recommended
-  image: 'ipfs://...',            // Recommended
-  url: 'https://...'              // Optional
-}
+  name: 'Project Name', // Required
+  description: 'Full description', // Required
+  image: 'ipfs://...', // Required
+  url: 'https://...', // Required
+};
 ```
 
 ### 2. Use IPFS URLs
+
 Always reference images using IPFS URLs for permanence:
 
 ```typescript
 // Good - permanent
-image: 'ipfs://QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy'
+image: 'ipfs://QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy';
 
 // Avoid - may change
-image: 'https://example.com/image.png'
+image: 'https://example.com/image.png';
 ```
 
 ### 3. Error Handling
 
 ```typescript
 try {
-  const result = await graphqlClient.request(UPLOAD_IMAGE, { image: input })
-  console.log('Uploaded:', result.uploadImage.images[0].url)
+  const result = await pinClient.request(UPLOAD_IMAGE, { image: input });
+  console.log('Uploaded:', result.uploadImage.images[0].url);
 } catch (error) {
   if (error.message.includes('File too large')) {
-    console.error('Image exceeds size limit')
+    console.error('Image exceeds size limit');
   } else if (error.message.includes('Invalid')) {
-    console.error('Invalid image format')
+    console.error('Invalid image format');
   }
 }
 ```
 
 ### 4. Size Limits
 
-| Upload Type | Maximum Size |
-|-------------|--------------|
-| Image (base64) | 5 MB |
-| Image from URL | 10 MB |
-| JSON | 1 MB |
+| Upload Type    | Maximum Size |
+| -------------- | ------------ |
+| Image (base64) | 5 MB         |
+| Image from URL | 10 MB        |
+| JSON           | 1 MB         |
 
 ## TypeScript Integration
 
-Use the `@0xintuition/graphql` package for type-safe mutations:
+Use the `@0xintuition/graphql` package for type-safe pinning on the server:
+
+`requestPinThing` accepts the generated package variable shape directly (`name`, `description`, `image`, `url`). Raw GraphQL requests use the `thing` input wrapper shown in the mutation examples above.
 
 ```typescript
-import {
-  usePinThingMutation,
-  useUploadImageFromUrlMutation
-} from '@0xintuition/graphql'
+import { configureClient, requestPinThing } from '@0xintuition/graphql';
 
-function CreateAtomForm() {
-  const [pinThing] = usePinThingMutation()
-  const [uploadImage] = useUploadImageFromUrlMutation()
+configureClient({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
 
-  const handleSubmit = async (data: FormData) => {
-    // Upload image first
-    const imageResult = await uploadImage({
-      variables: { image: { url: data.imageUrl } }
-    })
-
-    // Then pin metadata
-    const thingResult = await pinThing({
-      variables: {
-        thing: {
-          name: data.name,
-          description: data.description,
-          image: imageResult.data.uploadImageFromUrl.images[0].url,
-          url: data.url
-        }
-      }
-    })
-
-    // Use the IPFS URI for atom creation
-    const ipfsUri = thingResult.data.pinThing.uri
-    // ... create atom via SDK
-  }
-
-  return <form onSubmit={handleSubmit}>...</form>
-}
+const ipfsUri = await requestPinThing({
+  name: 'My Project',
+  description: 'Description of my project',
+  image: 'https://example.com/logo.png',
+  url: 'https://example.com',
+});
 ```
+
+For browser apps, proxy pinning through a server route so the API key is not exposed to users.
 
 ## Related Resources
 

--- a/docs/_data/intuition-sdk/atoms-guide.md
+++ b/docs/_data/intuition-sdk/atoms-guide.md
@@ -33,17 +33,17 @@ The simplest way to create an atom is from a plain string.
 function createAtomFromString(
   config: WriteConfig,
   data: string,
-  deposit?: bigint
-): Promise<AtomCreationResult>
+  deposit?: bigint,
+): Promise<AtomCreationResult>;
 ```
 
 ### Parameters
 
-| Parameter | Type | Description | Required |
-|-----------|------|-------------|----------|
-| `config` | `WriteConfig` | Client configuration with wallet, public client, and contract address | Yes |
-| `data` | `string` | The text string to create an atom from | Yes |
-| `deposit` | `bigint` | Optional initial deposit amount in wei | No |
+| Parameter | Type          | Description                                                           | Required |
+| --------- | ------------- | --------------------------------------------------------------------- | -------- |
+| `config`  | `WriteConfig` | Client configuration with wallet, public client, and contract address | Yes      |
+| `data`    | `string`      | The text string to create an atom from                                | Yes      |
+| `deposit` | `bigint`      | Optional initial deposit amount in wei                                | No       |
 
 ### Basic Example
 
@@ -52,32 +52,32 @@ import {
   createAtomFromString,
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
-} from '@0xintuition/sdk'
-import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
+} from '@0xintuition/sdk';
+import { createPublicClient, createWalletClient, http, parseEther } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 // Setup clients
-const account = privateKeyToAccount('0x...')
+const account = privateKeyToAccount('0x...');
 const publicClient = createPublicClient({
   chain: intuitionTestnet,
   transport: http(),
-})
+});
 const walletClient = createWalletClient({
   chain: intuitionTestnet,
   transport: http(),
   account,
-})
-const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
+});
+const address = getMultiVaultAddressFromChainId(intuitionTestnet.id);
 
 // Create atom
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
   'developer',
-  parseEther('0.01') // Optional: 0.01 TRUST initial deposit
-)
+  parseEther('0.01'), // Optional: 0.01 TRUST initial deposit
+);
 
-console.log('Atom ID:', atom.state.termId)
-console.log('Transaction:', atom.transactionHash)
+console.log('Atom ID:', atom.state.termId);
+console.log('Transaction:', atom.transactionHash);
 ```
 
 ### Common Use Cases
@@ -87,8 +87,8 @@ console.log('Transaction:', atom.transactionHash)
 ```typescript
 const tag = await createAtomFromString(
   { walletClient, publicClient, address },
-  'blockchain'
-)
+  'blockchain',
+);
 ```
 
 #### Creating Simple Identifiers
@@ -96,8 +96,8 @@ const tag = await createAtomFromString(
 ```typescript
 const identifier = await createAtomFromString(
   { walletClient, publicClient, address },
-  'user-role-admin'
-)
+  'user-role-admin',
+);
 ```
 
 #### Creating Predicates for Triples
@@ -106,13 +106,13 @@ const identifier = await createAtomFromString(
 // Create predicate atoms for relationships
 const hasSkill = await createAtomFromString(
   { walletClient, publicClient, address },
-  'hasSkill'
-)
+  'hasSkill',
+);
 
 const worksOn = await createAtomFromString(
   { walletClient, publicClient, address },
-  'worksOn'
-)
+  'worksOn',
+);
 ```
 
 ### Best Practices
@@ -121,10 +121,10 @@ const worksOn = await createAtomFromString(
 
 ```typescript
 // Good - clear and descriptive
-await createAtomFromString(config, 'JavaScript Developer')
+await createAtomFromString(config, 'JavaScript Developer');
 
 // Avoid - too vague
-await createAtomFromString(config, 'dev')
+await createAtomFromString(config, 'dev');
 ```
 
 #### 2. Check for Existing Atoms
@@ -132,15 +132,15 @@ await createAtomFromString(config, 'dev')
 Before creating an atom, check if it already exists:
 
 ```typescript
-import { calculateAtomId, getAtomDetails } from '@0xintuition/sdk'
+import { calculateAtomId, getAtomDetails } from '@0xintuition/sdk';
 
-const atomId = calculateAtomId('developer')
-const exists = await getAtomDetails(atomId)
+const atomId = calculateAtomId('developer');
+const exists = await getAtomDetails(atomId);
 
 if (exists) {
-  console.log('Atom already exists:', atomId)
+  console.log('Atom already exists:', atomId);
 } else {
-  const atom = await createAtomFromString(config, 'developer')
+  const atom = await createAtomFromString(config, 'developer');
 }
 ```
 
@@ -155,35 +155,36 @@ Create atoms from structured JSON-LD objects for rich metadata.
 ```typescript
 function createAtomFromThing(
   config: WriteConfig,
-  thing: PinThingMutationVariables['thing'],
-  deposit?: bigint
-): Promise<AtomCreationResult>
+  data: PinThingMutationVariables,
+  options?: CreateAtomFromThingOptions | bigint,
+): Promise<AtomCreationResult>;
 ```
 
 ### Thing Object Structure
 
 ```typescript
 type Thing = {
-  url?: string          // Primary URL/website
-  name?: string         // Display name
-  description?: string  // Detailed description
-  image?: string        // Image URL
-  tags?: string[]       // Category tags
-  twitter?: string      // Twitter/X profile
-  github?: string       // GitHub repository
-  // Additional schema.org Thing properties supported
-}
+  name: string; // Display name
+  description: string; // Detailed description
+  image: string; // Image URL
+  url: string; // Primary URL/website
+};
 ```
 
 ### Basic Example
 
 ```typescript
 import {
+  configureSdk,
   createAtomFromThing,
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
-} from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+} from '@0xintuition/sdk';
+import { parseEther } from 'viem';
+
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
 
 // Create atom from Thing
 const atom = await createAtomFromThing(
@@ -193,13 +194,12 @@ const atom = await createAtomFromThing(
     name: 'Example Project',
     description: 'A great Web3 project',
     image: 'https://example.com/logo.png',
-    tags: ['web3', 'defi', 'blockchain'],
   },
-  parseEther('0.05')
-)
+  { depositAmount: parseEther('0.05') },
+);
 
-console.log('Atom ID:', atom.state.termId)
-console.log('IPFS URI:', atom.uri) // ipfs://bafkrei...
+console.log('Atom ID:', atom.state.termId);
+console.log('IPFS URI:', atom.uri); // ipfs://bafkrei...
 ```
 
 ### Common Use Cases
@@ -214,9 +214,8 @@ const organization = await createAtomFromThing(
     description: 'Leading blockchain solutions provider',
     url: 'https://acme.com',
     image: 'https://acme.com/brand.png',
-    twitter: 'https://twitter.com/acmecorp',
-  }
-)
+  },
+);
 ```
 
 #### Creating Person Atoms
@@ -228,15 +227,14 @@ const person = await createAtomFromThing(
     name: 'Alice Johnson',
     description: 'Blockchain developer and researcher',
     image: 'https://example.com/alice.jpg',
-    twitter: 'https://twitter.com/alicecodes',
-    github: 'github.com/alice',
-  }
-)
+    url: 'https://example.com/alice',
+  },
+);
 ```
 
 ### How It Works
 
-1. **Pin to IPFS**: The Thing object is automatically pinned to IPFS via the Intuition API
+1. **Pin to IPFS**: The Thing object is automatically pinned to IPFS via the Intuition pinning service using your configured `pinApiKey`
 2. **Generate URI**: An IPFS URI is generated (e.g., `ipfs://bafkrei...`)
 3. **Create Atom**: The atom is created with the IPFS URI as its data
 4. **Return**: Returns the atom details with the IPFS URI
@@ -253,8 +251,8 @@ Create atoms representing Ethereum wallet addresses.
 function createAtomFromEthereumAccount(
   config: WriteConfig,
   address: Address,
-  deposit?: bigint
-): Promise<AtomCreationResult>
+  deposit?: bigint,
+): Promise<AtomCreationResult>;
 ```
 
 ### Basic Example
@@ -264,18 +262,18 @@ import {
   createAtomFromEthereumAccount,
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
-} from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+} from '@0xintuition/sdk';
+import { parseEther } from 'viem';
 
 // Create atom from Ethereum address
 const atom = await createAtomFromEthereumAccount(
   { walletClient, publicClient, address },
   '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
-  parseEther('0.01')
-)
+  parseEther('0.01'),
+);
 
-console.log('Identity Atom ID:', atom.state.termId)
-console.log('Address:', atom.uri)
+console.log('Identity Atom ID:', atom.state.termId);
+console.log('Address:', atom.uri);
 ```
 
 ### Common Use Cases
@@ -286,26 +284,20 @@ console.log('Address:', atom.uri)
 // Create atom for user's wallet
 const userAtom = await createAtomFromEthereumAccount(
   { walletClient, publicClient, address },
-  walletClient.account.address
-)
+  walletClient.account.address,
+);
 ```
 
 #### Building Social Graphs
 
 ```typescript
 // Create atoms for follower relationships
-const alice = await createAtomFromEthereumAccount(
-  config,
-  '0xAlice...'
-)
+const alice = await createAtomFromEthereumAccount(config, '0xAlice...');
 
-const bob = await createAtomFromEthereumAccount(
-  config,
-  '0xBob...'
-)
+const bob = await createAtomFromEthereumAccount(config, '0xBob...');
 
 // Then create a "follows" triple
-const follows = await createAtomFromString(config, 'follows')
+const follows = await createAtomFromString(config, 'follows');
 const triple = await createTripleStatement(config, {
   args: [
     [alice.state.termId],
@@ -314,7 +306,7 @@ const triple = await createTripleStatement(config, {
     [parseEther('0.1')],
   ],
   value: parseEther('0.1'),
-})
+});
 ```
 
 ---
@@ -329,8 +321,8 @@ Create atoms representing smart contract addresses.
 function createAtomFromSmartContract(
   config: WriteConfig,
   contractAddress: Address,
-  deposit?: bigint
-): Promise<AtomCreationResult>
+  deposit?: bigint,
+): Promise<AtomCreationResult>;
 ```
 
 ### Basic Example
@@ -340,17 +332,17 @@ import {
   createAtomFromSmartContract,
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
-} from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+} from '@0xintuition/sdk';
+import { parseEther } from 'viem';
 
 // Create atom for Uniswap contract
 const uniswap = await createAtomFromSmartContract(
   { walletClient, publicClient, address },
   '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI token
-  parseEther('0.01')
-)
+  parseEther('0.01'),
+);
 
-console.log('Contract Atom ID:', uniswap.state.termId)
+console.log('Contract Atom ID:', uniswap.state.termId);
 ```
 
 ### Common Use Cases
@@ -361,13 +353,13 @@ console.log('Contract Atom ID:', uniswap.state.termId)
 // Create atoms for DeFi protocols
 const aave = await createAtomFromSmartContract(
   config,
-  '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9' // AAVE token
-)
+  '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9', // AAVE token
+);
 
 const compound = await createAtomFromSmartContract(
   config,
-  '0xc00e94Cb662C3520282E6f5717214004A7f26888' // COMP token
-)
+  '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP token
+);
 ```
 
 ---
@@ -386,8 +378,8 @@ Create an atom from an existing IPFS URI.
 function createAtomFromIpfsUri(
   config: WriteConfig,
   ipfsUri: string,
-  deposit?: bigint
-): Promise<AtomCreationResult>
+  deposit?: bigint,
+): Promise<AtomCreationResult>;
 ```
 
 #### Basic Example
@@ -397,16 +389,16 @@ import {
   createAtomFromIpfsUri,
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
-} from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+} from '@0xintuition/sdk';
+import { parseEther } from 'viem';
 
 const atom = await createAtomFromIpfsUri(
   { walletClient, publicClient, address },
   'ipfs://bafkreib7534cszxn2c6qwoviv43sqh244yfrxomjbealjdwntd6a7atq6u',
-  parseEther('0.01')
-)
+  parseEther('0.01'),
+);
 
-console.log('IPFS Atom ID:', atom.state.termId)
+console.log('IPFS Atom ID:', atom.state.termId);
 ```
 
 ### createAtomFromIpfsUpload
@@ -419,15 +411,15 @@ Upload JSON data to Pinata and create an atom with the resulting IPFS URI.
 function createAtomFromIpfsUpload(
   config: WriteConfig & { pinataApiJWT: string },
   data: object,
-  deposit?: bigint
-): Promise<AtomCreationResult>
+  deposit?: bigint,
+): Promise<AtomCreationResult>;
 ```
 
 #### Basic Example
 
 ```typescript
-import { createAtomFromIpfsUpload } from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+import { createAtomFromIpfsUpload } from '@0xintuition/sdk';
+import { parseEther } from 'viem';
 
 const atom = await createAtomFromIpfsUpload(
   {
@@ -441,11 +433,11 @@ const atom = await createAtomFromIpfsUpload(
     description: 'A blockchain project',
     url: 'https://myproject.com',
   },
-  parseEther('0.05')
-)
+  parseEther('0.05'),
+);
 
-console.log('Atom ID:', atom.state.termId)
-console.log('IPFS URI:', atom.uri) // ipfs://bafkrei...
+console.log('Atom ID:', atom.state.termId);
+console.log('IPFS URI:', atom.uri); // ipfs://bafkrei...
 ```
 
 ---
@@ -468,36 +460,39 @@ import {
   batchCreateAtomsFromEthereumAccounts,
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
-} from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+} from '@0xintuition/sdk';
+import { parseEther } from 'viem';
 
 const addresses = [
   '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
   '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb',
   '0x1234567890123456789012345678901234567890',
-]
+];
 
 const result = await batchCreateAtomsFromEthereumAccounts(
   { walletClient, publicClient, address },
   addresses,
-  parseEther('0.01') // 0.01 TRUST per atom
-)
+  parseEther('0.01'), // 0.01 TRUST per atom
+);
 
-console.log('Created', result.state.length, 'atoms')
-console.log('Atom IDs:', result.state.map(s => s.termId))
-console.log('Single transaction:', result.transactionHash)
+console.log('Created', result.state.length, 'atoms');
+console.log(
+  'Atom IDs:',
+  result.state.map((s) => s.termId),
+);
+console.log('Single transaction:', result.transactionHash);
 ```
 
 ### Gas Savings
 
 Batch creation saves significant gas compared to individual transactions:
 
-| Atoms | Individual Txs | Batch Tx | Savings |
-|-------|---------------|----------|---------|
-| 1 | ~150k gas | ~150k gas | 0% |
-| 5 | ~750k gas | ~300k gas | 60% |
-| 10 | ~1.5M gas | ~450k gas | 70% |
-| 50 | ~7.5M gas | ~1.5M gas | 80% |
+| Atoms | Individual Txs | Batch Tx  | Savings |
+| ----- | -------------- | --------- | ------- |
+| 1     | ~150k gas      | ~150k gas | 0%      |
+| 5     | ~750k gas      | ~300k gas | 60%     |
+| 10    | ~1.5M gas      | ~450k gas | 70%     |
+| 50    | ~7.5M gas      | ~1.5M gas | 80%     |
 
 ---
 
@@ -512,21 +507,21 @@ Fetch comprehensive atom details from the Intuition API.
 #### Function Signature
 
 ```typescript
-function getAtomDetails(atomId: string): Promise<AtomDetails>
+function getAtomDetails(atomId: string): Promise<AtomDetails>;
 ```
 
 #### Basic Example
 
 ```typescript
-import { getAtomDetails } from '@0xintuition/sdk'
+import { getAtomDetails } from '@0xintuition/sdk';
 
-const atomId = '0x1234567890abcdef...'
-const details = await getAtomDetails(atomId)
+const atomId = '0x1234567890abcdef...';
+const details = await getAtomDetails(atomId);
 
-console.log('Atom Label:', details.label)
-console.log('Creator:', details.creator)
-console.log('Vault Shares:', details.vault.totalShares)
-console.log('Share Price:', details.vault.currentSharePrice)
+console.log('Atom Label:', details.label);
+console.log('Creator:', details.creator);
+console.log('Vault Shares:', details.vault.totalShares);
+console.log('Share Price:', details.vault.currentSharePrice);
 ```
 
 ### calculateAtomId
@@ -536,25 +531,27 @@ Calculate the atom ID from atom data without querying the blockchain.
 #### Function Signature
 
 ```typescript
-function calculateAtomId(atomData: string): Hex
+function calculateAtomId(atomData: string): Hex;
 ```
 
 #### Basic Example
 
 ```typescript
-import { calculateAtomId } from '@0xintuition/sdk'
+import { calculateAtomId } from '@0xintuition/sdk';
 
 // Calculate ID for a string atom
-const atomId = calculateAtomId('developer')
-console.log('Atom ID:', atomId)
+const atomId = calculateAtomId('developer');
+console.log('Atom ID:', atomId);
 
 // Calculate ID for an Ethereum address
-const addressAtomId = calculateAtomId('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
-console.log('Address Atom ID:', addressAtomId)
+const addressAtomId = calculateAtomId(
+  '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+);
+console.log('Address Atom ID:', addressAtomId);
 
 // Calculate ID for IPFS URI
-const ipfsAtomId = calculateAtomId('ipfs://bafkreib...')
-console.log('IPFS Atom ID:', ipfsAtomId)
+const ipfsAtomId = calculateAtomId('ipfs://bafkreib...');
+console.log('IPFS Atom ID:', ipfsAtomId);
 ```
 
 ### Use Cases
@@ -562,22 +559,26 @@ console.log('IPFS Atom ID:', ipfsAtomId)
 #### Check if Atom Exists Before Creating
 
 ```typescript
-import { calculateAtomId, getAtomDetails, createAtomFromString } from '@0xintuition/sdk'
+import {
+  calculateAtomId,
+  getAtomDetails,
+  createAtomFromString,
+} from '@0xintuition/sdk';
 
 async function createAtomIfNotExists(data: string) {
   // Calculate ID
-  const atomId = calculateAtomId(data)
+  const atomId = calculateAtomId(data);
 
   try {
     // Check if exists
-    const existing = await getAtomDetails(atomId)
-    console.log('Atom already exists:', atomId)
-    return existing
+    const existing = await getAtomDetails(atomId);
+    console.log('Atom already exists:', atomId);
+    return existing;
   } catch (error) {
     // Doesn't exist, create it
-    console.log('Creating new atom')
-    const atom = await createAtomFromString(config, data)
-    return atom
+    console.log('Creating new atom');
+    const atom = await createAtomFromString(config, data);
+    return atom;
   }
 }
 ```
@@ -585,18 +586,16 @@ async function createAtomIfNotExists(data: string) {
 #### Batch Query Multiple Atoms
 
 ```typescript
-import { getAtomDetails } from '@0xintuition/sdk'
+import { getAtomDetails } from '@0xintuition/sdk';
 
 async function getMultipleAtoms(atomIds: string[]) {
-  const atoms = await Promise.all(
-    atomIds.map(id => getAtomDetails(id))
-  )
+  const atoms = await Promise.all(atomIds.map((id) => getAtomDetails(id)));
 
-  atoms.forEach(atom => {
-    console.log(`${atom.label}: ${atom.vault.totalShares} shares`)
-  })
+  atoms.forEach((atom) => {
+    console.log(`${atom.label}: ${atom.vault.totalShares} shares`);
+  });
 
-  return atoms
+  return atoms;
 }
 ```
 
@@ -608,26 +607,26 @@ After successfully creating an atom, the SDK returns a data object with transact
 
 ```typescript
 type AtomCreationResult = {
-  uri: string                    // The atom's data URI (IPFS or raw data)
-  transactionHash: `0x${string}` // Transaction hash on chain
+  uri: string; // The atom's data URI (IPFS or raw data)
+  transactionHash: `0x${string}`; // Transaction hash on chain
   state: {
-    creator: Address             // Address that created the atom
-    termId: Hex                  // Unique atom identifier
-    atomData: Hex                // Encoded atom data
-    atomWallet: Address          // Associated vault wallet address
-  }
-}
+    creator: Address; // Address that created the atom
+    termId: Hex; // Unique atom identifier
+    atomData: Hex; // Encoded atom data
+    atomWallet: Address; // Associated vault wallet address
+  };
+};
 ```
 
 ### Example Usage
 
 ```typescript
-const result = await createAtomFromString(config, 'developer')
+const result = await createAtomFromString(config, 'developer');
 
-console.log('Transaction:', result.transactionHash)
-console.log('Atom ID:', result.state.termId)
-console.log('Creator:', result.state.creator)
-console.log('Vault Wallet:', result.state.atomWallet)
+console.log('Transaction:', result.transactionHash);
+console.log('Atom ID:', result.state.termId);
+console.log('Creator:', result.state.creator);
+console.log('Vault Wallet:', result.state.atomWallet);
 ```
 
 ---

--- a/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
+++ b/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
@@ -59,10 +59,6 @@ async function main() {
   console.log('\n=== Pinning to IPFS ===');
   const ipfsUri = await pinThing(project);
 
-  if (!ipfsUri) {
-    throw new Error('Failed to pin to IPFS');
-  }
-
   console.log('✓ Pinned to IPFS:', ipfsUri);
 
   // 2. Create atom with Thing (auto-pins and creates atom)

--- a/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
+++ b/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
@@ -1,5 +1,5 @@
 ---
-title: "Example: Thing IPFS Pinning"
+title: 'Example: Thing IPFS Pinning'
 sidebar_label: Thing IPFS Pinning
 sidebar_position: 7
 description: Create rich entities with JSON-LD and automatic IPFS pinning
@@ -14,99 +14,96 @@ This example demonstrates creating a rich entity (Thing) with automatic IPFS pin
 
 ```typescript
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   createAtomFromThing,
   pinThing,
   getAtomDetails,
   wait,
-} from '@0xintuition/sdk'
-import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
+} from '@0xintuition/sdk';
+import { createPublicClient, createWalletClient, http, parseEther } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 async function main() {
   // Setup
-  const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+  const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+  configureSdk({
+    pinApiKey: process.env.INTUITION_PIN_API_KEY,
+  });
+
   const publicClient = createPublicClient({
     chain: intuitionTestnet,
     transport: http(),
-  })
+  });
   const walletClient = createWalletClient({
     chain: intuitionTestnet,
     transport: http(),
     account,
-  })
-  const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
+  });
+  const address = getMultiVaultAddressFromChainId(intuitionTestnet.id);
 
   // Define rich entity
   const project = {
     url: 'https://github.com/myorg/awesome-project',
     name: 'Awesome DeFi Protocol',
-    description: 'A groundbreaking decentralized finance protocol built on Intuition',
+    description:
+      'A groundbreaking decentralized finance protocol built on Intuition',
     image: 'https://myproject.com/logo.png',
-    tags: [
-      'defi',
-      'protocol',
-      'typescript',
-      'smart-contracts',
-      'intuition'
-    ],
-    twitter: 'https://twitter.com/awesomedefi',
-    github: 'github.com/myorg/awesome-project',
-  }
+  };
 
-  console.log('=== Project Metadata ===')
-  console.log(JSON.stringify(project, null, 2))
+  console.log('=== Project Metadata ===');
+  console.log(JSON.stringify(project, null, 2));
 
   // 1. Pin to IPFS (without creating atom)
-  console.log('\n=== Pinning to IPFS ===')
-  const ipfsUri = await pinThing({ thing: project })
+  console.log('\n=== Pinning to IPFS ===');
+  const ipfsUri = await pinThing(project);
 
   if (!ipfsUri) {
-    throw new Error('Failed to pin to IPFS')
+    throw new Error('Failed to pin to IPFS');
   }
 
-  console.log('✓ Pinned to IPFS:', ipfsUri)
+  console.log('✓ Pinned to IPFS:', ipfsUri);
 
   // 2. Create atom with Thing (auto-pins and creates atom)
-  console.log('\n=== Creating Atom ===')
+  console.log('\n=== Creating Atom ===');
   const atom = await createAtomFromThing(
     { walletClient, publicClient, address },
     project,
-    parseEther('0.1')
-  )
+    { depositAmount: parseEther('0.1') },
+  );
 
-  console.log('✓ Atom created!')
-  console.log('  Atom ID:', atom.state.termId)
-  console.log('  IPFS URI:', atom.uri)
-  console.log('  Transaction:', atom.transactionHash)
+  console.log('✓ Atom created!');
+  console.log('  Atom ID:', atom.state.termId);
+  console.log('  IPFS URI:', atom.uri);
+  console.log('  Transaction:', atom.transactionHash);
 
   // 3. Wait for indexing
-  console.log('\nWaiting for indexing...')
-  await wait(atom.transactionHash)
+  console.log('\nWaiting for indexing...');
+  await wait(atom.transactionHash);
 
   // 4. Query details
-  const details = await getAtomDetails(atom.state.termId)
+  const details = await getAtomDetails(atom.state.termId);
 
-  console.log('\n=== Atom Details ===')
-  console.log('Label:', details.label)
-  console.log('Creator:', details.creator)
-  console.log('Vault ID:', details.vault.id)
-  console.log('Total Shares:', details.vault.totalShares)
+  console.log('\n=== Atom Details ===');
+  console.log('Label:', details.label);
+  console.log('Creator:', details.creator);
+  console.log('Vault ID:', details.vault.id);
+  console.log('Total Shares:', details.vault.totalShares);
 
-  console.log('\nSuccess!')
+  console.log('\nSuccess!');
 }
 
 main()
   .then(() => process.exit(0))
   .catch((error) => {
-    console.error('Error:', error)
-    process.exit(1)
-  })
+    console.error('Error:', error);
+    process.exit(1);
+  });
 ```
 
 ## See Also
 
-- [createAtomFromThing](../atoms/create-from-thing.md)
+- [createAtomFromThing](../atoms-guide.md#creating-from-thing)
 - [pinThing](../integrations/pinata-ipfs.md)
 - [IPFS Integration](../integrations/pinata-ipfs.md)

--- a/docs/_data/intuition-sdk/installation-and-setup.md
+++ b/docs/_data/intuition-sdk/installation-and-setup.md
@@ -3,7 +3,22 @@ title: Installation & Setup
 sidebar_label: Installation & Setup
 sidebar_position: 0
 description: Install the Intuition SDK and configure your development environment
-keywords: [sdk, installation, npm, pnpm, bun, viem, dependencies, setup, configuration, wallet, network, testnet, mainnet]
+keywords:
+  [
+    sdk,
+    installation,
+    npm,
+    pnpm,
+    bun,
+    viem,
+    dependencies,
+    setup,
+    configuration,
+    wallet,
+    network,
+    testnet,
+    mainnet,
+  ]
 ---
 
 # Installation & Setup
@@ -76,11 +91,14 @@ Create a test file to verify everything is working:
 import {
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
-} from '@0xintuition/sdk'
+} from '@0xintuition/sdk';
 
-console.log('Network:', intuitionTestnet.name)
-console.log('Chain ID:', intuitionTestnet.id)
-console.log('MultiVault:', getMultiVaultAddressFromChainId(intuitionTestnet.id))
+console.log('Network:', intuitionTestnet.name);
+console.log('Chain ID:', intuitionTestnet.id);
+console.log(
+  'MultiVault:',
+  getMultiVaultAddressFromChainId(intuitionTestnet.id),
+);
 ```
 
 Run it with `npx tsx test-install.ts` or your preferred TypeScript runner.
@@ -91,10 +109,10 @@ Run it with `npx tsx test-install.ts` or your preferred TypeScript runner.
 
 The SDK uses [Viem](https://viem.sh) clients for blockchain interactions. You need two types:
 
-| Client Type | Purpose | Required For |
-|-------------|---------|--------------|
-| **Public Client** | Read-only operations | Querying data, checking balances |
-| **Wallet Client** | Write operations | Creating atoms, triples, deposits |
+| Client Type       | Purpose              | Required For                      |
+| ----------------- | -------------------- | --------------------------------- |
+| **Public Client** | Read-only operations | Querying data, checking balances  |
+| **Wallet Client** | Write operations     | Creating atoms, triples, deposits |
 
 ### Basic Setup
 
@@ -102,28 +120,28 @@ The SDK uses [Viem](https://viem.sh) clients for blockchain interactions. You ne
 import {
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
-} from '@0xintuition/sdk'
-import { createPublicClient, createWalletClient, http } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
+} from '@0xintuition/sdk';
+import { createPublicClient, createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 // 1. Create account from private key
-const account = privateKeyToAccount('0xYOUR_PRIVATE_KEY')
+const account = privateKeyToAccount('0xYOUR_PRIVATE_KEY');
 
 // 2. Create public client (for reading data)
 const publicClient = createPublicClient({
   chain: intuitionTestnet,
   transport: http(),
-})
+});
 
 // 3. Create wallet client (for transactions)
 const walletClient = createWalletClient({
   chain: intuitionTestnet,
   transport: http(),
   account,
-})
+});
 
 // 4. Get contract address
-const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
+const address = getMultiVaultAddressFromChainId(intuitionTestnet.id);
 ```
 
 ### Configuration Object
@@ -131,13 +149,13 @@ const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
 Most SDK functions accept a configuration object:
 
 ```typescript
-import type { WriteConfig } from '@0xintuition/sdk'
+import type { WriteConfig } from '@0xintuition/sdk';
 
 const config: WriteConfig = {
-  address,        // MultiVault contract address
-  publicClient,   // For reading blockchain data
-  walletClient,   // For sending transactions
-}
+  address, // MultiVault contract address
+  publicClient, // For reading blockchain data
+  walletClient, // For sending transactions
+};
 ```
 
 ---
@@ -148,23 +166,23 @@ The SDK supports multiple networks with built-in chain definitions.
 
 ### Supported Networks
 
-| Network | Chain ID | Type | Status |
-|---------|----------|------|--------|
-| Intuition Mainnet | 1155 | Production | ✅ Active |
-| Intuition Testnet | 13579 | Development | ✅ Active |
-| Base Mainnet | 8453 | Production | ✅ Active |
-| Base Sepolia | 84532 | Development | ✅ Active |
+| Network           | Chain ID | Type        | Status    |
+| ----------------- | -------- | ----------- | --------- |
+| Intuition Mainnet | 1155     | Production  | ✅ Active |
+| Intuition Testnet | 13579    | Development | ✅ Active |
+| Base Mainnet      | 8453     | Production  | ✅ Active |
+| Base Sepolia      | 84532    | Development | ✅ Active |
 
 ### Testnet Configuration
 
 ```typescript
-import { intuitionTestnet } from '@0xintuition/sdk'
-import { createPublicClient, http } from 'viem'
+import { intuitionTestnet } from '@0xintuition/sdk';
+import { createPublicClient, http } from 'viem';
 
 const publicClient = createPublicClient({
   chain: intuitionTestnet,
   transport: http(),
-})
+});
 
 // Network details available:
 // Chain ID: 13579
@@ -176,13 +194,13 @@ const publicClient = createPublicClient({
 ### Mainnet Configuration
 
 ```typescript
-import { intuitionMainnet } from '@0xintuition/sdk'
-import { createPublicClient, http } from 'viem'
+import { intuitionMainnet } from '@0xintuition/sdk';
+import { createPublicClient, http } from 'viem';
 
 const publicClient = createPublicClient({
   chain: intuitionMainnet,
   transport: http(),
-})
+});
 
 // Network details available:
 // Chain ID: 1155
@@ -202,14 +220,14 @@ import {
   getMultiVaultAddressFromChainId,
   getContractAddressFromChainId,
   intuitionDeployments,
-} from '@0xintuition/sdk'
+} from '@0xintuition/sdk';
 
 // Get MultiVault address (most commonly used)
-const multiVaultAddress = getMultiVaultAddressFromChainId(chainId)
+const multiVaultAddress = getMultiVaultAddressFromChainId(chainId);
 
 // Get other contract addresses
-const trustBonding = getContractAddressFromChainId('TrustBonding', chainId)
-const wrappedTrust = getContractAddressFromChainId('WrappedTrust', chainId)
+const trustBonding = getContractAddressFromChainId('TrustBonding', chainId);
+const wrappedTrust = getContractAddressFromChainId('WrappedTrust', chainId);
 ```
 
 ---
@@ -219,31 +237,29 @@ const wrappedTrust = getContractAddressFromChainId('WrappedTrust', chainId)
 ### Private Key
 
 ```typescript
-import { privateKeyToAccount } from 'viem/accounts'
+import { privateKeyToAccount } from 'viem/accounts';
 
-const account = privateKeyToAccount('0xYOUR_PRIVATE_KEY')
+const account = privateKeyToAccount('0xYOUR_PRIVATE_KEY');
 ```
 
 ### Mnemonic Phrase
 
 ```typescript
-import { mnemonicToAccount } from 'viem/accounts'
+import { mnemonicToAccount } from 'viem/accounts';
 
-const account = mnemonicToAccount(
-  'your twelve word mnemonic phrase goes here'
-)
+const account = mnemonicToAccount('your twelve word mnemonic phrase goes here');
 ```
 
 ### Browser Wallet (MetaMask, etc.)
 
 ```typescript
-import { createWalletClient, custom } from 'viem'
-import { intuitionTestnet } from '@0xintuition/sdk'
+import { createWalletClient, custom } from 'viem';
+import { intuitionTestnet } from '@0xintuition/sdk';
 
 const walletClient = createWalletClient({
   chain: intuitionTestnet,
   transport: custom(window.ethereum),
-})
+});
 ```
 
 ---
@@ -254,14 +270,19 @@ Store sensitive data in environment variables:
 
 ```bash title=".env"
 PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+INTUITION_PIN_API_KEY=your-intuition-pin-api-key
 PINATA_API_JWT=your-pinata-jwt-token
 ```
 
 ```typescript title="config.ts"
-import { privateKeyToAccount } from 'viem/accounts'
+import { configureSdk } from '@0xintuition/sdk';
+import { privateKeyToAccount } from 'viem/accounts';
 
-const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
-const pinataApiJWT = process.env.PINATA_API_JWT
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
 ```
 
 ---
@@ -295,7 +316,7 @@ For optimal TypeScript support:
 const publicClient = createPublicClient({
   chain: intuitionTestnet,
   transport: http('https://your-custom-rpc-endpoint.com'),
-})
+});
 ```
 
 ### Fallback Transports
@@ -303,7 +324,7 @@ const publicClient = createPublicClient({
 Configure backup RPC endpoints for reliability:
 
 ```typescript
-import { fallback, http } from 'viem'
+import { fallback, http } from 'viem';
 
 const publicClient = createPublicClient({
   chain: intuitionTestnet,
@@ -311,7 +332,7 @@ const publicClient = createPublicClient({
     http('https://testnet.rpc.intuition.systems/http'),
     http('https://backup-rpc.example.com'),
   ]),
-})
+});
 ```
 
 ### Batch Requests (Multicall)
@@ -325,7 +346,7 @@ const publicClient = createPublicClient({
   batch: {
     multicall: true,
   },
-})
+});
 ```
 
 ---
@@ -334,20 +355,21 @@ const publicClient = createPublicClient({
 
 ```typescript title="intuition-client.ts"
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
-} from '@0xintuition/sdk'
-import type { WriteConfig } from '@0xintuition/sdk'
-import {
-  createPublicClient,
-  createWalletClient,
-  http,
-  fallback,
-} from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
+} from '@0xintuition/sdk';
+import type { WriteConfig } from '@0xintuition/sdk';
+import { createPublicClient, createWalletClient, http, fallback } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
 // Account
-const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+
+// Intuition pinning service
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
 
 // Public client with fallback and batching
 const publicClient = createPublicClient({
@@ -359,39 +381,38 @@ const publicClient = createPublicClient({
   batch: {
     multicall: true,
   },
-})
+});
 
 // Wallet client
 const walletClient = createWalletClient({
   chain: intuitionTestnet,
   transport: http('https://testnet.rpc.intuition.systems/http'),
   account,
-})
+});
 
 // Contract address
-const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
+const address = getMultiVaultAddressFromChainId(intuitionTestnet.id);
 
 // Export configuration
 export const config: WriteConfig = {
   address,
   publicClient,
   walletClient,
-  pinataApiJWT: process.env.PINATA_API_JWT,
-}
+};
 ```
 
 ---
 
 ## Optional: Pinata for IPFS
 
-For IPFS operations (uploading metadata), you'll need a Pinata API token:
+For direct Pinata upload operations, you'll need a Pinata API token:
 
 1. Sign up at [pinata.cloud](https://pinata.cloud)
 2. Create an API key and get your JWT token
-3. Pass it in the config when using IPFS upload functions
+3. Pass it in the config when using direct Pinata upload functions
 
 ```typescript
-import { createAtomFromIpfsUpload } from '@0xintuition/sdk'
+import { createAtomFromIpfsUpload } from '@0xintuition/sdk';
 
 const atom = await createAtomFromIpfsUpload(
   {
@@ -403,8 +424,8 @@ const atom = await createAtomFromIpfsUpload(
   {
     name: 'My Project',
     description: 'A blockchain project',
-  }
-)
+  },
+);
 ```
 
 ---

--- a/docs/_data/intuition-sdk/integrations/pinata-ipfs.md
+++ b/docs/_data/intuition-sdk/integrations/pinata-ipfs.md
@@ -1,215 +1,217 @@
 ---
-title: Pinata IPFS Integration
-sidebar_label: Pinata IPFS
+title: IPFS Pinning
+sidebar_label: IPFS Pinning
 sidebar_position: 1
-description: Upload and pin content to IPFS using Pinata integration
+description: Pin metadata to IPFS using the Intuition pinning service or direct Pinata uploads
 keywords: [sdk, ipfs, pinata, upload, pin, thing, metadata]
 ---
 
-# Pinata IPFS Integration
+# IPFS Pinning
 
-Upload and pin content to IPFS using Pinata or the Intuition API.
+The SDK supports two IPFS paths:
+
+| Path                      | Use for                                                         | Credential                          |
+| ------------------------- | --------------------------------------------------------------- | ----------------------------------- |
+| Intuition pinning service | `pinThing`, `createAtomFromThing`, `batchCreateAtomsFromThings` | Intuition pin API key (`pinApiKey`) |
+| Direct Pinata upload      | `uploadJsonToPinata`, `createAtomFromIpfsUpload`                | Pinata API JWT (`pinataApiJWT`)     |
+
+`pinThing` does not require a Pinata account, but it does require an Intuition pin API key. Keep API keys in a trusted server runtime and do not expose them in public browser environment variables.
+
+## Intuition Pin API Key
+
+Configure the SDK once before calling `pinThing` or any SDK helper that auto-pins Thing metadata:
+
+```typescript
+import { configureSdk } from '@0xintuition/sdk';
+
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
+```
+
+You can also pass the key per call:
+
+```typescript
+const uri = await pinThing(thing, {
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
+```
 
 ## pinThing
 
-Pin a Thing object to IPFS via the Intuition API (no Pinata key required).
+Pin a Thing object to IPFS via the Intuition pinning service.
+
+SDK helpers accept the Thing fields directly (`name`, `description`, `image`, `url`). Raw GraphQL mutation requests use the GraphQL `thing` input wrapper.
 
 ### Function Signature
 
 ```typescript
 function pinThing(
-  variables: PinThingMutationVariables
-): Promise<string | null>
+  variables: PinThingMutationVariables,
+  options?: PinThingOptions,
+): Promise<string>;
 ```
 
 ### Basic Example
 
 ```typescript
-import { pinThing } from '@0xintuition/sdk'
+import { configureSdk, pinThing } from '@0xintuition/sdk';
+
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
 
 const uri = await pinThing({
-  thing: {
-    url: 'https://example.com',
-    name: 'Example Project',
-    description: 'A great project',
-    image: 'https://example.com/logo.png',
-    tags: ['blockchain', 'defi'],
-  }
-})
+  url: 'https://example.com',
+  name: 'Example Project',
+  description: 'A great project',
+  image: 'https://example.com/logo.png',
+});
 
-if (uri) {
-  console.log('Pinned to IPFS:', uri) // ipfs://bafkreib...
-}
+console.log('Pinned to IPFS:', uri); // ipfs://bafkreib...
 ```
 
-## uploadJsonToPinata
+### Pin Thing and Create Atom
 
-Upload JSON directly to Pinata (requires Pinata API JWT).
+Use `createAtomFromThing` when you want the SDK to pin the Thing metadata and create the atom in one flow:
 
-### Function Signature
+```typescript
+import { configureSdk, createAtomFromThing } from '@0xintuition/sdk';
+import { parseEther } from 'viem';
+
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
+
+const atom = await createAtomFromThing(
+  { walletClient, publicClient, address },
+  {
+    url: 'https://myproject.com',
+    name: 'My Project',
+    description: 'A blockchain project',
+    image: 'https://myproject.com/logo.png',
+  },
+  { depositAmount: parseEther('0.05') },
+);
+
+console.log('Atom created:', atom.state.termId);
+console.log('IPFS URI:', atom.uri);
+```
+
+## Direct Pinata Uploads
+
+Use direct Pinata uploads when you want to bring your own Pinata account. These paths do not use the Intuition pin API key.
+
+### uploadJsonToPinata
+
+Upload JSON directly to Pinata.
+
+#### Function Signature
 
 ```typescript
 function uploadJsonToPinata(
   pinataApiJWT: string,
-  data: object
-): Promise<PinataUploadResult>
+  data: object,
+): Promise<PinataUploadResult>;
 ```
 
-### Basic Example
+#### Basic Example
 
 ```typescript
-import { uploadJsonToPinata } from '@0xintuition/sdk'
+import { uploadJsonToPinata } from '@0xintuition/sdk';
 
-const result = await uploadJsonToPinata(
-  'your-pinata-jwt-token',
-  {
-    name: 'My Data',
-    description: 'Some metadata',
-    properties: {
-      key: 'value'
-    }
-  }
-)
+const result = await uploadJsonToPinata(process.env.PINATA_API_JWT!, {
+  name: 'My Data',
+  description: 'Some metadata',
+  properties: {
+    key: 'value',
+  },
+});
 
-console.log('IPFS Hash:', result.IpfsHash)
-console.log('Size:', result.PinSize, 'bytes')
-console.log('URI:', `ipfs://${result.IpfsHash}`)
+console.log('IPFS Hash:', result.IpfsHash);
+console.log('Size:', result.PinSize, 'bytes');
+console.log('URI:', `ipfs://${result.IpfsHash}`);
 ```
 
 ### Return Type
 
 ```typescript
 type PinataUploadResult = {
-  IpfsHash: string
-  PinSize: number
-  Timestamp: string
-}
+  IpfsHash: string;
+  PinSize: number;
+  Timestamp: string;
+};
 ```
 
 ## Getting a Pinata API Key
 
+Direct Pinata upload paths require a Pinata API JWT:
+
 1. Sign up at [pinata.cloud](https://pinata.cloud)
-2. Go to API Keys section
+2. Go to API Keys
 3. Create a new API key
 4. Copy the JWT token
-5. Store securely in environment variables
+5. Store it securely in environment variables
 
 ```bash title=".env"
 PINATA_API_JWT=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
-## Common Use Cases
-
-### Pin Thing and Create Atom
+## Batch Pin Multiple Items
 
 ```typescript
-import { pinThing, createAtomFromIpfsUri } from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+import { configureSdk, pinThing } from '@0xintuition/sdk';
 
-const thing = {
-  url: 'https://myproject.com',
-  name: 'My Project',
-  description: 'A blockchain project',
-  tags: ['defi', 'web3'],
-}
-
-// Pin to IPFS
-const uri = await pinThing({ thing })
-
-if (uri) {
-  // Create atom with IPFS URI
-  const atom = await createAtomFromIpfsUri(
-    config,
-    uri,
-    parseEther('0.05')
-  )
-
-  console.log('Atom created:', atom.state.termId)
-}
-```
-
-### Upload Custom Metadata
-
-```typescript
-import { uploadJsonToPinata } from '@0xintuition/sdk'
-
-const metadata = {
-  title: 'NFT #1',
-  description: 'Unique digital asset',
-  image: 'https://example.com/nft1.png',
-  attributes: [
-    { trait_type: 'Rarity', value: 'Legendary' },
-    { trait_type: 'Power', value: 100 },
-  ]
-}
-
-const result = await uploadJsonToPinata(
-  process.env.PINATA_API_JWT,
-  metadata
-)
-
-console.log('Metadata URI:', `ipfs://${result.IpfsHash}`)
-```
-
-### Batch Pin Multiple Items
-
-```typescript
-import { pinThing } from '@0xintuition/sdk'
+configureSdk({
+  pinApiKey: process.env.INTUITION_PIN_API_KEY,
+});
 
 async function batchPin(things: any[]) {
-  const uris = await Promise.all(
-    things.map(thing => pinThing({ thing }))
-  )
-
-  return uris.filter(uri => uri !== null)
+  return Promise.all(things.map((thing) => pinThing(thing)));
 }
 
-// Usage
 const projects = [
-  { name: 'Project A', url: 'https://a.com' },
-  { name: 'Project B', url: 'https://b.com' },
-]
+  {
+    name: 'Project A',
+    description: 'Project A metadata',
+    image: 'https://a.com/logo.png',
+    url: 'https://a.com',
+  },
+  {
+    name: 'Project B',
+    description: 'Project B metadata',
+    image: 'https://b.com/logo.png',
+    url: 'https://b.com',
+  },
+];
 
-const ipfsUris = await batchPin(projects)
-console.log('Pinned', ipfsUris.length, 'items to IPFS')
+const ipfsUris = await batchPin(projects);
+console.log('Pinned', ipfsUris.length, 'items to IPFS');
 ```
 
 ## Error Handling
 
 ```typescript
-import { pinThing } from '@0xintuition/sdk'
+import { pinThing } from '@0xintuition/sdk';
 
 async function safePinThing(thing: any) {
   try {
-    const uri = await pinThing({ thing })
-
-    if (!uri) {
-      throw new Error('Pinning returned null')
-    }
-
-    return { success: true, uri }
-
+    const uri = await pinThing(thing);
+    return { success: true, uri };
   } catch (error) {
-    console.error('Failed to pin:', error)
-    return { success: false, error: error.message }
+    console.error('Failed to pin:', error);
+    return { success: false, error: error.message };
   }
-}
-
-// Usage
-const result = await safePinThing({ name: 'Test', url: 'https://test.com' })
-
-if (result.success) {
-  console.log('Pinned:', result.uri)
-} else {
-  console.error('Error:', result.error)
 }
 ```
 
+Common causes include a missing `pinApiKey`, an invalid API key, missing metadata fields, or image URLs that cannot be fetched by the pinning service.
+
 ## Related Functions
 
-- [**createAtomFromThing**](../atoms/create-from-thing.md) - Create atom with auto-pinning
-- [**createAtomFromIpfsUri**](../atoms/create-from-ipfs.md) - Create from IPFS URI
-- [**createAtomFromIpfsUpload**](../atoms/create-from-ipfs.md#createatomfromipfsupload) - Upload and create
+- [**createAtomFromThing**](../atoms-guide.md#creating-from-thing) - Create atom with auto-pinning
+- [**createAtomFromIpfsUri**](../atoms-guide.md#createatomfromipfsuri) - Create from IPFS URI
+- [**createAtomFromIpfsUpload**](../atoms-guide.md#createatomfromipfsupload) - Upload directly to Pinata and create
 
 ## See Also
 

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -128,9 +128,9 @@ bun add @0xintuition/protocol@latest @0xintuition/graphql@latest
 
 :::info Version Compatibility
 This guide uses the v2 contract architecture and requires the following package versions:
-- [`@0xintuition/sdk@^2.0.0`](https://www.npmjs.com/package/@0xintuition/sdk)
+- [`@0xintuition/sdk@^3.0.0`](https://www.npmjs.com/package/@0xintuition/sdk)
 - [`@0xintuition/protocol@^2.0.0`](https://www.npmjs.com/package/@0xintuition/protocol)
-- [`@0xintuition/graphql@^2.0.0`](https://www.npmjs.com/package/@0xintuition/graphql)
+- [`@0xintuition/graphql@^3.0.0`](https://www.npmjs.com/package/@0xintuition/graphql)
 :::
 
 ### Setup A Public and Wallet Provider

--- a/scripts/graphql-schema-mainnet.json
+++ b/scripts/graphql-schema-mainnet.json
@@ -138,32 +138,6 @@
         "kind": "SCALAR"
       }
     },
-    "CachedImage": {
-      "created_at": {
-        "type": "timestamptz",
-        "kind": "SCALAR"
-      },
-      "model": {
-        "type": "String",
-        "kind": "SCALAR"
-      },
-      "original_url": {
-        "type": "String",
-        "kind": "SCALAR"
-      },
-      "safe": {
-        "type": "Boolean",
-        "kind": "SCALAR"
-      },
-      "score": {
-        "type": "jsonb",
-        "kind": "SCALAR"
-      },
-      "url": {
-        "type": "String",
-        "kind": "SCALAR"
-      }
-    },
     "ChartDataOutput": {
       "count": {
         "type": "Int",
@@ -202,12 +176,6 @@
     },
     "ChartSvgOutput": {
       "svg": {
-        "type": "String",
-        "kind": "SCALAR"
-      }
-    },
-    "PinOutput": {
-      "uri": {
         "type": "String",
         "kind": "SCALAR"
       }
@@ -422,26 +390,6 @@
         "kind": "SCALAR"
       },
       "unrealized_pnl": {
-        "type": "String",
-        "kind": "SCALAR"
-      }
-    },
-    "UploadImageFromUrlOutput": {
-      "images": {
-        "type": "CachedImage",
-        "kind": "OBJECT"
-      }
-    },
-    "UploadJsonToIpfsOutput": {
-      "hash": {
-        "type": "String",
-        "kind": "SCALAR"
-      },
-      "name": {
-        "type": "String",
-        "kind": "SCALAR"
-      },
-      "size": {
         "type": "String",
         "kind": "SCALAR"
       }
@@ -3118,32 +3066,6 @@
       "id": {
         "type": "String",
         "kind": "SCALAR"
-      }
-    },
-    "mutation_root": {
-      "pinOrganization": {
-        "type": "PinOutput",
-        "kind": "OBJECT"
-      },
-      "pinPerson": {
-        "type": "PinOutput",
-        "kind": "OBJECT"
-      },
-      "pinThing": {
-        "type": "PinOutput",
-        "kind": "OBJECT"
-      },
-      "uploadImage": {
-        "type": "UploadImageFromUrlOutput",
-        "kind": "OBJECT"
-      },
-      "uploadImageFromUrl": {
-        "type": "UploadImageFromUrlOutput",
-        "kind": "OBJECT"
-      },
-      "uploadJsonToIpfs": {
-        "type": "UploadJsonToIpfsOutput",
-        "kind": "OBJECT"
       }
     },
     "organizations": {
@@ -14305,7 +14227,6 @@
   },
   "rootTypes": {
     "query": "query_root",
-    "mutation": "mutation_root",
     "subscription": "subscription_root"
   }
 }

--- a/scripts/graphql-schema-pin.json
+++ b/scripts/graphql-schema-pin.json
@@ -1,0 +1,92 @@
+{
+  "typeMap": {
+    "CachedImage": {
+      "created_at": {
+        "type": "timestamptz",
+        "kind": "SCALAR"
+      },
+      "model": {
+        "type": "String",
+        "kind": "SCALAR"
+      },
+      "original_url": {
+        "type": "String",
+        "kind": "SCALAR"
+      },
+      "safe": {
+        "type": "Boolean",
+        "kind": "SCALAR"
+      },
+      "score": {
+        "type": "jsonb",
+        "kind": "SCALAR"
+      },
+      "url": {
+        "type": "String",
+        "kind": "SCALAR"
+      }
+    },
+    "PinOutput": {
+      "uri": {
+        "type": "String",
+        "kind": "SCALAR"
+      }
+    },
+    "UploadImageFromUrlOutput": {
+      "images": {
+        "type": "CachedImage",
+        "kind": "OBJECT"
+      }
+    },
+    "UploadJsonToIpfsOutput": {
+      "hash": {
+        "type": "String",
+        "kind": "SCALAR"
+      },
+      "name": {
+        "type": "String",
+        "kind": "SCALAR"
+      },
+      "size": {
+        "type": "String",
+        "kind": "SCALAR"
+      }
+    },
+    "mutation_root": {
+      "pinOrganization": {
+        "type": "PinOutput",
+        "kind": "OBJECT"
+      },
+      "pinPerson": {
+        "type": "PinOutput",
+        "kind": "OBJECT"
+      },
+      "pinThing": {
+        "type": "PinOutput",
+        "kind": "OBJECT"
+      },
+      "uploadImage": {
+        "type": "UploadImageFromUrlOutput",
+        "kind": "OBJECT"
+      },
+      "uploadImageFromUrl": {
+        "type": "UploadImageFromUrlOutput",
+        "kind": "OBJECT"
+      },
+      "uploadJsonToIpfs": {
+        "type": "UploadJsonToIpfsOutput",
+        "kind": "OBJECT"
+      }
+    },
+    "query_root": {
+      "no_queries_available": {
+        "type": "String",
+        "kind": "SCALAR"
+      }
+    }
+  },
+  "rootTypes": {
+    "query": "query_root",
+    "mutation": "mutation_root"
+  }
+}

--- a/scripts/validate-graphql-queries.js
+++ b/scripts/validate-graphql-queries.js
@@ -43,12 +43,25 @@ const PLAYGROUND_FILE = path.join(
 const ENDPOINTS = {
   mainnet: 'https://mainnet.intuition.sh/v1/graphql',
   testnet: 'https://testnet.intuition.sh/v1/graphql',
+  pin: 'https://pin.intuition.systems/v1/graphql',
 };
 
 const SCHEMA_FILES = {
   mainnet: path.join(SCRIPTS_DIR, 'graphql-schema-mainnet.json'),
   testnet: path.join(SCRIPTS_DIR, 'graphql-schema-testnet.json'),
+  pin: path.join(SCRIPTS_DIR, 'graphql-schema-pin.json'),
 };
+
+const READ_ENDPOINTS = ['mainnet', 'testnet'];
+const PIN_ENDPOINT = 'pin';
+const PINNING_MUTATION_FIELDS = new Set([
+  'pinOrganization',
+  'pinPerson',
+  'pinThing',
+  'uploadImage',
+  'uploadImageFromUrl',
+  'uploadJsonToIpfs',
+]);
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -58,7 +71,7 @@ function parseArgs(argv) {
   const args = {
     updateSchema: false,
     dryRun: false,
-    endpoint: null, // null = both
+    endpoint: null, // null = all routed endpoints
     files: [],
   };
 
@@ -72,7 +85,9 @@ function parseArgs(argv) {
       i++;
       if (!argv[i] || !ENDPOINTS[argv[i]]) {
         console.error(
-          `Error: --endpoint requires "mainnet" or "testnet", got "${argv[i]}"`
+          `Error: --endpoint requires ${Object.keys(ENDPOINTS)
+            .map((endpoint) => `"${endpoint}"`)
+            .join(' or ')}, got "${argv[i]}"`
         );
         process.exit(1);
       }
@@ -131,7 +146,7 @@ const INTROSPECTION_QUERY = `
  * HTTP POST with JSON body, returns parsed JSON response.
  * Uses only Node.js built-ins (https/http).
  */
-function httpPost(url, body) {
+function httpPost(url, body, headers = {}) {
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(body);
     const mod = url.startsWith('https') ? https : require('http');
@@ -146,6 +161,7 @@ function httpPost(url, body) {
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data),
+          ...headers,
         },
       },
       (res) => {
@@ -169,6 +185,15 @@ function httpPost(url, body) {
     req.write(data);
     req.end();
   });
+}
+
+function getPinApiKey() {
+  return (
+    process.env.INTUITION_PIN_API_KEY ||
+    process.env.PIN_API_KEY ||
+    process.env.PIN_APIKEY ||
+    null
+  );
 }
 
 /**
@@ -218,7 +243,16 @@ function buildTypeMap(introspectionResult) {
  */
 async function introspectEndpoint(name, url) {
   console.log(`  Introspecting ${name}: ${url}`);
-  const result = await httpPost(url, { query: INTROSPECTION_QUERY });
+  const headers = {};
+  if (name === PIN_ENDPOINT) {
+    const apiKey = getPinApiKey();
+    if (!apiKey) {
+      throw new Error('Pin endpoint introspection requires INTUITION_PIN_API_KEY');
+    }
+    headers.apikey = apiKey;
+  }
+
+  const result = await httpPost(url, { query: INTROSPECTION_QUERY }, headers);
 
   if (result.errors) {
     throw new Error(
@@ -907,6 +941,60 @@ function validateQueries(queries, schema, endpointName) {
   return allErrors;
 }
 
+function getOperationType(query) {
+  const stripped = query.replace(/^\s*(#[^\n]*\n\s*)*/g, '').trim();
+  if (stripped.startsWith('{')) {
+    return 'query';
+  }
+
+  const match = stripped.match(/^(query|mutation|subscription)\b/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function isPinningMutation(query) {
+  if (getOperationType(query) !== 'mutation') {
+    return false;
+  }
+
+  for (const fieldName of PINNING_MUTATION_FIELDS) {
+    const fieldPattern = new RegExp(`\\b${fieldName}\\b\\s*[:({]`);
+    if (fieldPattern.test(query)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getTargetEndpointsForQuery(query, endpointsToCheck) {
+  if (isPinningMutation(query)) {
+    return endpointsToCheck.includes(PIN_ENDPOINT) ? [PIN_ENDPOINT] : [];
+  }
+
+  return endpointsToCheck.filter((endpoint) =>
+    READ_ENDPOINTS.includes(endpoint)
+  );
+}
+
+function groupQueriesByEndpoint(queries, endpointsToCheck) {
+  const grouped = Object.fromEntries(
+    endpointsToCheck.map((endpoint) => [endpoint, []])
+  );
+
+  for (const query of queries) {
+    const targetEndpoints = getTargetEndpointsForQuery(
+      query.query,
+      endpointsToCheck
+    );
+
+    for (const endpoint of targetEndpoints) {
+      grouped[endpoint].push(query);
+    }
+  }
+
+  return grouped;
+}
+
 function formatError(err) {
   const location = `${err.file}:${err.line}`;
   const query = err.queryTitle ? ` [${err.queryTitle}]` : '';
@@ -918,7 +1006,7 @@ async function main() {
   const args = parseArgs(process.argv);
   const endpointsToCheck = args.endpoint
     ? [args.endpoint]
-    : ['mainnet', 'testnet'];
+    : Object.keys(ENDPOINTS);
 
   // --update-schema: introspect live endpoints and save snapshots
   if (args.updateSchema) {
@@ -926,6 +1014,18 @@ async function main() {
     const schemas = {};
 
     for (const ep of endpointsToCheck) {
+      if (ep === PIN_ENDPOINT && !getPinApiKey()) {
+        const message =
+          'Pin endpoint introspection requires INTUITION_PIN_API_KEY';
+        if (args.endpoint === PIN_ENDPOINT) {
+          console.error(`  Failed to introspect ${ep}: ${message}`);
+          process.exit(1);
+        }
+        console.warn(`  Skipping ${ep}: ${message}`);
+        schemas[ep] = loadSchema(ep);
+        continue;
+      }
+
       try {
         schemas[ep] = await introspectEndpoint(ep, ENDPOINTS[ep]);
         saveSchema(ep, schemas[ep]);
@@ -978,6 +1078,11 @@ async function main() {
     return;
   }
 
+  const queriesByEndpoint = groupQueriesByEndpoint(
+    queries,
+    endpointsToCheck
+  );
+
   // --dry-run: just list extracted queries
   if (args.dryRun) {
     console.log(`Found ${queries.length} GraphQL queries:\n`);
@@ -986,57 +1091,73 @@ async function main() {
       // Show first line of query
       const firstLine = q.query.split('\n')[0].trim();
       console.log(`    ${firstLine}`);
+      const targetEndpoints = getTargetEndpointsForQuery(
+        q.query,
+        endpointsToCheck
+      );
+      console.log(
+        `    targets: ${targetEndpoints.join(', ') || 'none'}`
+      );
       console.log();
     }
     return;
   }
 
   // Validate
-  console.log(
-    `Validating ${queries.length} queries against ${endpointsToCheck.join(' + ')} schemas...\n`
+  const routeSummary = endpointsToCheck
+    .map(
+      (endpoint) =>
+        `${endpoint} (${queriesByEndpoint[endpoint]?.length || 0})`
+    )
+    .join(' + ');
+  const routedValidationCount = endpointsToCheck.reduce(
+    (count, endpoint) => count + (queriesByEndpoint[endpoint]?.length || 0),
+    0
   );
 
-  let mainnetErrors = [];
-  let testnetErrors = [];
+  console.log(
+    `Validating ${queries.length} extracted queries (${routedValidationCount} routed validations) against schemas: ${routeSummary}...\n`
+  );
+
+  const errorsByEndpoint = {};
 
   for (const ep of endpointsToCheck) {
-    const errors = validateQueries(queries, schemas[ep], ep);
-    if (ep === 'mainnet') mainnetErrors = errors;
-    else testnetErrors = errors;
+    const endpointQueries = queriesByEndpoint[ep] || [];
+    errorsByEndpoint[ep] = validateQueries(endpointQueries, schemas[ep], ep);
   }
 
   // Report
-  const hasMainnetErrors = mainnetErrors.length > 0;
-  const hasTestnetErrors = testnetErrors.length > 0;
+  const fatalEndpoints = new Set(['mainnet', PIN_ENDPOINT]);
+  let hasFatalErrors = false;
+  let hasAnyErrors = false;
 
-  if (hasMainnetErrors) {
+  for (const ep of endpointsToCheck) {
+    const errors = errorsByEndpoint[ep] || [];
+    if (errors.length === 0) {
+      continue;
+    }
+
+    hasAnyErrors = true;
+    const isFatal = fatalEndpoints.has(ep);
+    hasFatalErrors = hasFatalErrors || isFatal;
+
     console.log(
-      `❌ ${mainnetErrors.length} mainnet error(s):\n`
+      `${isFatal ? '❌' : '⚠'} ${errors.length} ${ep}${
+        isFatal ? '' : '-only warning'
+      } error(s):\n`
     );
-    for (const err of mainnetErrors) {
+    for (const err of errors) {
       console.log(formatError(err));
     }
     console.log();
   }
 
-  if (hasTestnetErrors) {
-    console.log(
-      `⚠ ${testnetErrors.length} testnet-only warning(s):\n`
-    );
-    for (const err of testnetErrors) {
-      console.log(formatError(err));
-    }
-    console.log();
+  if (!hasAnyErrors) {
+    console.log('✓ All routed queries valid against their target schemas.');
   }
 
-  if (!hasMainnetErrors && !hasTestnetErrors) {
-    console.log(
-      `✓ All ${queries.length} queries valid against ${endpointsToCheck.join(' + ')} schemas.`
-    );
-  }
-
-  // Exit code: mainnet errors = failure, testnet-only = success with warnings
-  if (hasMainnetErrors) {
+  // Exit code: mainnet and pin endpoint errors fail; testnet-only errors warn.
+  if (hasFatalErrors) {
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Document the public gated pinning endpoint, required `apikey` header, and `PIN_API_URL` usage for raw GraphQL pinning/upload mutations.
- Update SDK examples for `configureSdk({ pinApiKey })`, `pinThing`, `createAtomFromThing`, and direct Pinata upload separation.
- Align quick-start compatibility with `@0xintuition/sdk` and `@0xintuition/graphql` v3.0.0, and remove stale `createMultivaultClient` / falsey `pinThing` examples.
- Clarify that `pinPerson` and `pinOrganization` are raw GraphQL mutations, not first-class SDK helpers.
- Route GraphQL docs validation so reads/subscriptions validate against mainnet/testnet schemas, while pinning/upload mutations validate against the gated pin schema snapshot.

## Release note
`@0xintuition/sdk`, `@0xintuition/graphql`, and `intuition-cli` v3.0.0 are published to npm. These docs are ready to merge.

## Validation
- `npm run validate-links`
- `npm run validate-queries`
- `node scripts/validate-graphql-queries.js --endpoint mainnet`
- `node scripts/validate-graphql-queries.js --endpoint testnet`
- `node scripts/validate-graphql-queries.js --endpoint pin`
- `INTUITION_PIN_API_KEY=... node scripts/validate-graphql-queries.js --update-schema`
- `env -u INTUITION_PIN_API_KEY -u PIN_API_KEY -u PIN_APIKEY node scripts/validate-graphql-queries.js --update-schema`
- `npm run build` (passes; existing Docusaurus broken-link/static-generation warnings remain outside this change)
