### PR TITLE
docs: remove semantic search references

### DIFF
--- a/docs/_data/getting-started/integrations.md
+++ b/docs/_data/getting-started/integrations.md
@@ -21,7 +21,6 @@ Use Intuition's knowledge graph with AI systems and agents to create persistent,
 - **AI agents with persistent memory** - Store and retrieve agent knowledge on-chain
 - **LLM context enhancement** - Provide verified context to language models
 - **Knowledge graph reasoning** - Enable semantic reasoning over structured data
-- **Semantic search for AI** - Query knowledge graphs for relevant information
 - **AI-assisted app development** - Give coding agents canonical protocol context before they modify Intuition reads or writes
 
 ## Coming Soon

--- a/docs/_data/graphql-api/best-practices/database-functions.md
+++ b/docs/_data/graphql-api/best-practices/database-functions.md
@@ -47,7 +47,7 @@ query GetFollowingEfficiently($address: String!) {
 
 - `following`: Get accounts a user follows
 - `positions_from_following`: Social feed of positions
-- `search_term`: Semantic search
+- `search_term`: Text search
 - `signals_from_following`: Activity from followed accounts
 
 ## Benefits

--- a/docs/_data/graphql-api/getting-started/introduction.md
+++ b/docs/_data/graphql-api/getting-started/introduction.md
@@ -95,7 +95,7 @@ Subscribe to real-time updates using cursor-based streaming for live data feeds.
 
 ### Database Functions
 
-Leverage backend functions for complex queries like social graph traversal, semantic search, and position filtering.
+Leverage backend functions for complex queries like social graph traversal, text search, and position filtering.
 
 ## Use Cases
 

--- a/docs/_data/graphql-api/queries/advanced/database-functions.md
+++ b/docs/_data/graphql-api/queries/advanced/database-functions.md
@@ -53,10 +53,10 @@ query GetPositionsFromFollowing($address: String!, $limit: Int!) {
 
 ### search_term
 
-Semantic search:
+Text search:
 
 ```graphql
-query SemanticSearch($query: String!, $limit: Int!) {
+query SearchTerms($query: String!, $limit: Int!) {
   search_term(args: { query: $query }, limit: $limit) {
     atom {
       term_id

--- a/docs/_data/graphql-api/queries/atoms/search.md
+++ b/docs/_data/graphql-api/queries/atoms/search.md
@@ -2,15 +2,15 @@
 title: Atom Search
 sidebar_label: Search
 sidebar_position: 5
-description: Full-text and semantic search for atoms
-keywords: [graphql, atom, search, full-text, semantic, ilike]
+description: Full-text and pattern matching search for atoms
+keywords: [graphql, atom, search, full-text, ilike]
 ---
 
 import GraphQLPlaygroundCustom from '@site/src/components/GraphQLPlaygroundCustom';
 
 # Atom Search
 
-Search atoms using pattern matching and semantic search capabilities.
+Search atoms using pattern matching and full-text query patterns.
 
 ## Query Structure
 
@@ -31,21 +31,6 @@ query SearchAtoms($search: String!, $limit: Int!) {
     label
     image
     type
-  }
-}
-```
-
-### Semantic Search
-
-```graphql
-query SemanticSearch($query: String!, $limit: Int) {
-  search_term(args: { query: $query }, limit: $limit) {
-    atom {
-      term_id
-      label
-      type
-      image
-    }
   }
 }
 ```
@@ -75,24 +60,6 @@ export const searchQueries = [
 }`,
     variables: {
       search: '%ethereum%',
-      limit: 20
-    }
-  },
-  {
-    id: 'semantic-search',
-    title: 'Semantic Search',
-    query: `query SemanticSearch($query: String!, $limit: Int!) {
-  search_term(args: { query: $query }, limit: $limit) {
-    atom {
-      term_id
-      label
-      type
-      image
-    }
-  }
-}`,
-    variables: {
-      query: 'blockchain technology',
       limit: 20
     }
   }
@@ -193,7 +160,6 @@ const query = `
 
 - **Use wildcards sparingly**: `%term%` is slower than `term%`
 - **Limit results**: Always include limit
-- **Consider semantic search**: For natural language queries
 
 ## Related Patterns
 

--- a/docs/_data/intuition-network/index.md
+++ b/docs/_data/intuition-network/index.md
@@ -86,7 +86,7 @@ The Rust-based indexing subnet provides:
 - **Fast queries** - Optimized database for knowledge graph traversal
 - **GraphQL API** - Flexible query language for complex graph operations
 - **Real-time updates** - Live data synchronization
-- **Semantic search** - Full-text search across atoms and triples
+- **Search APIs** - Query atoms, triples, and indexed graph data
 
 Learn more: [GraphQL API](/docs/graphql-api/overview)
 

--- a/docs/_data/intuition-sdk/quick-start.md
+++ b/docs/_data/intuition-sdk/quick-start.md
@@ -305,7 +305,6 @@ Now that you've created your first atom and triple, explore:
 
 ### Search & Discovery
 - [**Global Search**](../search/global-search.md) - Search across all entities
-- [**Semantic Search**](../search/advanced-queries.md) - Find similar content
 
 ## Common Issues
 

--- a/docs/_data/intuition-sdk/search-guide.md
+++ b/docs/_data/intuition-sdk/search-guide.md
@@ -7,7 +7,7 @@ description: Search atoms, triples, and perform advanced queries
 
 # Search and Discovery
 
-Discover atoms, triples, accounts, and collections using powerful search capabilities including full-text search, semantic search, and batch entity lookups.
+Discover atoms, triples, accounts, and collections using search, filters, and batch entity lookups.
 
 ## Table of Contents
 
@@ -312,37 +312,7 @@ triples.forEach(triple => {
 
 ## Advanced Queries
 
-Advanced search capabilities including semantic search and batch entity lookups.
-
-### semanticSearch
-
-Search using vector embeddings for semantically similar content.
-
-#### Function Signature
-
-```typescript
-function semanticSearch(
-  query: string,
-  options?: { limit?: number }
-): Promise<SemanticSearchResults | null>
-```
-
-#### Basic Example
-
-```typescript
-import { semanticSearch } from '@0xintuition/sdk'
-
-const results = await semanticSearch('decentralized knowledge graph', {
-  limit: 10,
-})
-
-if (results) {
-  console.log('Semantically similar atoms:', results.length)
-  results.forEach(result => {
-    console.log(`- ${result.label} (similarity: ${result.score})`)
-  })
-}
-```
+Advanced search helpers include batch entity lookup functions.
 
 ### findAtomIds
 

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -307,21 +307,6 @@ const results = await globalSearch('ethereum', {
 console.log('Search results:', results)
 ```
 
-### Semantic Search
-
-Use AI-powered semantic search to find relevant atoms:
-
-```typescript
-import { semanticSearch } from '@0xintuition/sdk'
-
-const results = await semanticSearch(
-  'decentralized identity protocols',
-  { limit: 5 }
-)
-
-console.log('Semantic search results:', results)
-```
-
 ### Read On-Chain Atom Data
 
 Read atom data directly from the smart contract:

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -2337,7 +2337,6 @@ Use Intuition's knowledge graph with AI systems and agents to create persistent,
 - **AI agents with persistent memory** - Store and retrieve agent knowledge on-chain
 - **LLM context enhancement** - Provide verified context to language models
 - **Knowledge graph reasoning** - Enable semantic reasoning over structured data
-- **Semantic search for AI** - Query knowledge graphs for relevant information
 - **AI-assisted app development** - Give coding agents canonical protocol context before they modify Intuition reads or writes
 
 ## Coming Soon
@@ -3117,7 +3116,7 @@ query GetFollowingEfficiently($address: String!) {
 
 - `following`: Get accounts a user follows
 - `positions_from_following`: Social feed of positions
-- `search_term`: Semantic search
+- `search_term`: Text search
 - `signals_from_following`: Activity from followed accounts
 
 ## Benefits
@@ -4953,7 +4952,7 @@ Subscribe to real-time updates using cursor-based streaming for live data feeds.
 
 ### Database Functions
 
-Leverage backend functions for complex queries like social graph traversal, semantic search, and position filtering.
+Leverage backend functions for complex queries like social graph traversal, text search, and position filtering.
 
 ## Use Cases
 
@@ -8172,10 +8171,10 @@ query GetPositionsFromFollowing($address: String!, $limit: Int!) {
 
 ### search_term
 
-Semantic search:
+Text search:
 
 ```graphql
-query SemanticSearch($query: String!, $limit: Int!) {
+query SearchTerms($query: String!, $limit: Int!) {
   search_term(args: { query: $query }, limit: $limit) {
     atom {
       term_id
@@ -8908,14 +8907,14 @@ const query = `
 
 ---
 title: "Atom Search"
-description: "Full-text and semantic search for atoms"
+description: "Full-text and pattern matching search for atoms"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/search"
 ---
 
 # Atom Search
 
-Search atoms using pattern matching and semantic search capabilities.
+Search atoms using pattern matching and full-text query patterns.
 
 ## Query Structure
 
@@ -8936,21 +8935,6 @@ query SearchAtoms($search: String!, $limit: Int!) {
     label
     image
     type
-  }
-}
-```
-
-### Semantic Search
-
-```graphql
-query SemanticSearch($query: String!, $limit: Int) {
-  search_term(args: { query: $query }, limit: $limit) {
-    atom {
-      term_id
-      label
-      type
-      image
-    }
   }
 }
 ```
@@ -8978,23 +8962,6 @@ query SemanticSearch($query: String!, $limit: Int) {
 }`,
     variables: {
       search: '%ethereum%',
-      limit: 20
-
-  },
-
-    id: 'semantic-search',
-    title: 'Semantic Search',
-    query: `query SemanticSearch($query: String!, $limit: Int!) {
-  search_term(args: { query: $query }, limit: $limit) {
-    atom {
-      term_id
-      label
-      type
-      image
-
-}`,
-    variables: {
-      query: 'blockchain technology',
       limit: 20
 
 ];
@@ -9092,7 +9059,6 @@ const query = `
 
 - **Use wildcards sparingly**: `%term%` is slower than `term%`
 - **Limit results**: Always include limit
-- **Consider semantic search**: For natural language queries
 
 ## Related Patterns
 
@@ -20442,7 +20408,7 @@ The Rust-based indexing subnet provides:
 - **Fast queries** - Optimized database for knowledge graph traversal
 - **GraphQL API** - Flexible query language for complex graph operations
 - **Real-time updates** - Live data synchronization
-- **Semantic search** - Full-text search across atoms and triples
+- **Search APIs** - Query atoms, triples, and indexed graph data
 
 Learn more: [GraphQL API](/docs/graphql-api/overview)
 
@@ -25265,7 +25231,6 @@ Now that you've created your first atom and triple, explore:
 
 ### Search & Discovery
 - [**Global Search**](../search/global-search.md) - Search across all entities
-- [**Semantic Search**](../search/advanced-queries.md) - Find similar content
 
 ## Common Issues
 
@@ -25309,7 +25274,7 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/search-guide"
 
 # Search and Discovery
 
-Discover atoms, triples, accounts, and collections using powerful search capabilities including full-text search, semantic search, and batch entity lookups.
+Discover atoms, triples, accounts, and collections using search, filters, and batch entity lookups.
 
 ## Table of Contents
 
@@ -25614,37 +25579,7 @@ triples.forEach(triple => {
 
 ## Advanced Queries
 
-Advanced search capabilities including semantic search and batch entity lookups.
-
-### semanticSearch
-
-Search using vector embeddings for semantically similar content.
-
-#### Function Signature
-
-```typescript
-function semanticSearch(
-  query: string,
-  options?: { limit?: number }
-): Promise<SemanticSearchResults | null>
-```
-
-#### Basic Example
-
-```typescript
-import { semanticSearch } from '@0xintuition/sdk'
-
-const results = await semanticSearch('decentralized knowledge graph', {
-  limit: 10,
-})
-
-if (results) {
-  console.log('Semantically similar atoms:', results.length)
-  results.forEach(result => {
-    console.log(`- ${result.label} (similarity: ${result.score})`)
-  })
-}
-```
+Advanced search helpers include batch entity lookup functions.
 
 ### findAtomIds
 
@@ -34333,21 +34268,6 @@ const results = await globalSearch('ethereum', {
 })
 
 console.log('Search results:', results)
-```
-
-### Semantic Search
-
-Use AI-powered semantic search to find relevant atoms:
-
-```typescript
-import { semanticSearch } from '@0xintuition/sdk'
-
-const results = await semanticSearch(
-  'decentralized identity protocols',
-  { limit: 5 }
-)
-
-console.log('Semantic search results:', results)
 ```
 
 ### Read On-Chain Atom Data

--- a/static/llms-medium.txt
+++ b/static/llms-medium.txt
@@ -411,7 +411,7 @@ Use backend functions for complex queries instead of client-side filtering.
 
 - `following`: Get accounts a user follows
 - `positions_from_following`: Social feed of positions
-- `search_term`: Semantic search
+- `search_term`: Text search
 - `signals_from_following`: Activity from followed accounts
 
 ## Benefits
@@ -1856,7 +1856,7 @@ Get positions from followed accounts:
 
 ### search_term
 
-Semantic search:
+Text search:
 
 ### search_positions_on_subject
 
@@ -1992,20 +1992,18 @@ Query multiple atoms with filtering, sorting, and pagination to find specific en
 
 ---
 title: "Atom Search"
-description: "Full-text and semantic search for atoms"
+description: "Full-text and pattern matching search for atoms"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/search"
 ---
 
 # Atom Search
 
-Search atoms using pattern matching and semantic search capabilities.
+Search atoms using pattern matching and full-text query patterns.
 
 ## Query Structure
 
 ### Pattern Matching Search
-
-### Semantic Search
 
 ## Interactive Examples
 
@@ -2032,16 +2030,23 @@ Search atoms using pattern matching and semantic search capabilities.
       search: '%ethereum%',
       limit: 20
 
-  },
+];
 
-    id: 'semantic-search',
-    title: 'Semantic Search',
-    query: `query SemanticSearch($query: String!, $limit: Int!) {
-  search_term(args: { query: $query }, limit: $limit) {
-    atom {
-      term_id
-      label
-      type
+## Search Patterns
+
+### Case-Insensitive Search
+
+### Multi-Field Search
+
+### Filter Search by Type
+
+## Use Cases
+
+### Autocomplete
+
+### Global Search
+
+## Performance Considerations
 
 [... see full docs for complete content]
 
@@ -5048,7 +5053,7 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/search-guide"
 
 # Search and Discovery
 
-Discover atoms, triples, accounts, and collections using powerful search capabilities including full-text search, semantic search, and batch entity lookups.
+Discover atoms, triples, accounts, and collections using search, filters, and batch entity lookups.
 
 ## Table of Contents
 
@@ -5077,6 +5082,10 @@ Search across all entity types (atoms, accounts, triples, collections) with a si
 ### Basic Example
 
 ### Advanced Example
+
+Search with custom limits:
+
+### Common Use Cases
 
 [... see full docs for complete content]
 


### PR DESCRIPTION
## Summary
- Remove public docs references to unsupported semantic search and `semanticSearch` SDK examples.
- Reword existing GraphQL search docs as text/pattern search where the documented queries remain valid.
- Regenerate `llms-full.txt` and `llms-medium.txt` from the updated docs source.

## Validation
- `rg -n -i "semantic\\s*search|semanticsearch|semantic-search|vector embeddings|semantically similar|AI-powered.*search" docs/_data src README.md static/llms-full.txt static/llms-medium.txt` returns no matches
- `npm run validate-links`
- `npm run validate-queries`
- `npm run generate-llms`
- `git diff --check`
- `npm run build` (passes; existing unrelated Docusaurus warnings remain)
