### PR TITLE
docs: add pinning auth examples

### DIFF
--- a/docs/_data/graphql-api/mutations/pin-organization.md
+++ b/docs/_data/graphql-api/mutations/pin-organization.md
@@ -18,6 +18,19 @@ Use the public gated pinning endpoint and send your Intuition pin API key in an 
 https://pin.intuition.systems/v1/graphql
 ```
 
+Create an authenticated client before sending the mutation:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
+
 `pinOrganization` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinOrganization` helper.
 
 ## Mutation Structure

--- a/docs/_data/graphql-api/mutations/pin-person.md
+++ b/docs/_data/graphql-api/mutations/pin-person.md
@@ -18,6 +18,19 @@ Use the public gated pinning endpoint and send your Intuition pin API key in an 
 https://pin.intuition.systems/v1/graphql
 ```
 
+Create an authenticated client before sending the mutation:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
+
 `pinPerson` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinPerson` helper.
 
 ## Mutation Structure

--- a/docs/_data/graphql-api/mutations/pin-thing.md
+++ b/docs/_data/graphql-api/mutations/pin-thing.md
@@ -20,6 +20,19 @@ https://pin.intuition.systems/v1/graphql
 
 Keep the key in a trusted server runtime. Do not pass it in the URL or expose it in public browser environment variables.
 
+Create an authenticated client before sending the mutation:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
+
 ## Mutation Structure
 
 ```graphql

--- a/docs/_data/graphql-api/writes.mdx
+++ b/docs/_data/graphql-api/writes.mdx
@@ -16,6 +16,52 @@ The Intuition GraphQL API provides mutations for **off-chain operations** like u
 Pinning mutations are served from the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, not the read endpoint. Send your Intuition pin API key in an `apikey` request header from a trusted server runtime.
 :::
 
+## Authenticated Pinning Client
+
+With `graphql-request`, create a client with the `apikey` header:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const pinClient = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
+
+Without a GraphQL client, send the same header with `fetch`:
+
+```typescript
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const response = await fetch(PIN_API_URL, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+  body: JSON.stringify({
+    query: `
+      mutation PinThing($thing: PinThingInput!) {
+        pinThing(thing: $thing) {
+          uri
+        }
+      }
+    `,
+    variables: {
+      thing: {
+        name: 'My Project',
+        description: 'Description of my project',
+        image: 'ipfs://...',
+        url: 'https://example.com',
+      },
+    },
+  }),
+});
+```
+
 :::info GraphQL vs Smart Contracts
 **GraphQL mutations** handle:
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -6358,6 +6358,19 @@ Use the public gated pinning endpoint and send your Intuition pin API key in an 
 https://pin.intuition.systems/v1/graphql
 ```
 
+Create an authenticated client before sending the mutation:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
+
 `pinOrganization` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinOrganization` helper.
 
 ## Mutation Structure
@@ -6410,6 +6423,19 @@ Use the public gated pinning endpoint and send your Intuition pin API key in an 
 
 ```text
 https://pin.intuition.systems/v1/graphql
+```
+
+Create an authenticated client before sending the mutation:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
 ```
 
 `pinPerson` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinPerson` helper.
@@ -6468,6 +6494,19 @@ https://pin.intuition.systems/v1/graphql
 ```
 
 Keep the key in a trusted server runtime. Do not pass it in the URL or expose it in public browser environment variables.
+
+Create an authenticated client before sending the mutation:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const client = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
 
 ## Mutation Structure
 
@@ -16599,6 +16638,52 @@ source: "https://docs.intuition.systems/docs/graphql-api/writes"
 The Intuition GraphQL API provides mutations for **off-chain operations** like uploading metadata to IPFS. For **on-chain operations** like creating atoms, triples, and positions, you must use the [Intuition SDK](/docs/intuition-sdk/installation-and-setup) or interact directly with the smart contracts.
 
 Pinning mutations are served from the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, not the read endpoint. Send your Intuition pin API key in an `apikey` request header from a trusted server runtime.
+
+## Authenticated Pinning Client
+
+With `graphql-request`, create a client with the `apikey` header:
+
+```typescript
+import { GraphQLClient } from 'graphql-request';
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const pinClient = new GraphQLClient(PIN_API_URL, {
+  headers: {
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+});
+```
+
+Without a GraphQL client, send the same header with `fetch`:
+
+```typescript
+import { PIN_API_URL } from '@0xintuition/graphql';
+
+const response = await fetch(PIN_API_URL, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    apikey: process.env.INTUITION_PIN_API_KEY!,
+  },
+  body: JSON.stringify({
+    query: `
+      mutation PinThing($thing: PinThingInput!) {
+        pinThing(thing: $thing) {
+          uri
+        }
+      }
+    `,
+    variables: {
+      thing: {
+        name: 'My Project',
+        description: 'Description of my project',
+        image: 'ipfs://...',
+        url: 'https://example.com',
+      },
+    },
+  }),
+});
+```
 
 **GraphQL mutations** handle:
 

--- a/static/llms-medium.txt
+++ b/static/llms-medium.txt
@@ -1443,6 +1443,8 @@ Pin an Organization entity to IPFS for use in atom creation.
 
 Use the public gated pinning endpoint and send your Intuition pin API key in an `apikey` header:
 
+Create an authenticated client before sending the mutation:
+
 `pinOrganization` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinOrganization` helper.
 
 ## Mutation Structure
@@ -1472,6 +1474,8 @@ Pin a Person entity to IPFS for use in atom creation.
 ## Endpoint and Auth
 
 Use the public gated pinning endpoint and send your Intuition pin API key in an `apikey` header:
+
+Create an authenticated client before sending the mutation:
 
 `pinPerson` is available as a raw GraphQL mutation. The SDK currently exposes a `pinThing` helper, but not a first-class `pinPerson` helper.
 
@@ -1505,6 +1509,8 @@ Use the public gated pinning endpoint and send your Intuition pin API key in an 
 
 Keep the key in a trusted server runtime. Do not pass it in the URL or expose it in public browser environment variables.
 
+Create an authenticated client before sending the mutation:
+
 ## Mutation Structure
 
 ## Variables
@@ -1516,9 +1522,6 @@ Keep the key in a trusted server runtime. Do not pass it in the URL or expose it
 1. **Pin metadata** using `pinThing` mutation
 2. **Get IPFS URI** from response
 3. **Create atom on-chain** using the URI
-4. **Query the atom** via GraphQL API
-
-## Best Practices
 
 [... see full docs for complete content]
 
@@ -3736,15 +3739,13 @@ The Intuition GraphQL API provides mutations for **off-chain operations** like u
 
 Pinning mutations are served from the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, not the read endpoint. Send your Intuition pin API key in an `apikey` request header from a trusted server runtime.
 
+## Authenticated Pinning Client
+
+With `graphql-request`, create a client with the `apikey` header:
+
+Without a GraphQL client, send the same header with `fetch`:
+
 **GraphQL mutations** handle:
-
-- Uploading metadata to IPFS (pinThing, pinPerson, pinOrganization)
-
-**Smart contract operations** handle:
-
-- Creating atoms
-- Creating triples
-- Taking positions (depositing/redeeming)
 
 [... see full docs for complete content]
 


### PR DESCRIPTION
## Summary
- Add copy-paste `apikey` header setup examples to the raw `pinThing`, `pinPerson`, and `pinOrganization` mutation docs.
- Add both `graphql-request` and raw `fetch` authenticated pinning examples to the GraphQL Writes overview.
- Regenerate `llms-full.txt` and `llms-medium.txt` from the updated docs source.

## Validation
- `npm run generate-llms`
- `npm run validate-links`
- `npm run validate-queries`
- `git diff --check`
- `npm run build` (passes; existing unrelated Docusaurus warnings remain)
