### PR TITLE
fix: clean llms generated docs

### DIFF
--- a/docs/_data/experimental-applications/data-populator.md
+++ b/docs/_data/experimental-applications/data-populator.md
@@ -515,7 +515,7 @@ The Data Populator is part of the Intuition ecosystem and follows the same devel
 
 For support with the Data Populator:
 
-- Check the [Intuition documentation](/guides) for detailed guides
+- Check the [Intuition documentation](/docs) for detailed guides
 - Visit the [GitHub repository](https://github.com/0xIntuition) for technical details
 - Join the [community discussions](https://discord.gg/RgBenkX4mx) for user support
 - Review the [API documentation](/docs/getting-started/developer-stack) for integration help
@@ -619,4 +619,4 @@ For support with the Data Populator:
 
 </div>
 
-</div> 
+</div>

--- a/docs/_data/graphql-api/use-cases/overview.mdx
+++ b/docs/_data/graphql-api/use-cases/overview.mdx
@@ -16,7 +16,7 @@ Select a use case above to see detailed step-by-step implementation guides.
 
 <div className="uniform-card-grid">
   <a
-    href="/finding-top-dapps-on-coinbase"
+    href="/docs/tutorials/queries/finding-top-dapps-on-coinbase"
     className="clickable-card uniform-card vision-card items-center justify-center text-center"
   >
     <span className="mb-4 relative flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-primary/10 to-primary/5">
@@ -31,7 +31,7 @@ Select a use case above to see detailed step-by-step implementation guides.
   </a>
 
   <a
-    href="/discovering-most-trusted-accounts"
+    href="/docs/tutorials/queries/discovering-most-trusted-accounts"
     className="clickable-card uniform-card vision-card items-center justify-center text-center"
   >
     <span className="mb-4 relative flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-primary/10 to-primary/5">
@@ -46,7 +46,7 @@ Select a use case above to see detailed step-by-step implementation guides.
   </a>
 
   <a
-    href="/building-user-activity-feeds"
+    href="/docs/tutorials/queries/building-user-activity-feeds"
     className="clickable-card uniform-card vision-card items-center justify-center text-center"
   >
     <span className="mb-4 relative flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-primary/10 to-primary/5">
@@ -61,7 +61,7 @@ Select a use case above to see detailed step-by-step implementation guides.
   </a>
 
   <a
-    href="/finding-related-claims"
+    href="/docs/tutorials/queries/finding-related-claims"
     className="clickable-card uniform-card vision-card items-center justify-center text-center"
   >
     <span className="mb-4 relative flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-primary/10 to-primary/5">

--- a/docs/_data/intuition-concepts/primitives/Atoms/best-practices.md
+++ b/docs/_data/intuition-concepts/primitives/Atoms/best-practices.md
@@ -340,6 +340,6 @@ Before creating an Atom, verify:
 
 ## Next Steps
 
-- [Triple Fundamentals](../triples/fundamentals) - Learn how to connect Atoms into meaningful relationships
-- [Signal Fundamentals](../signals/fundamentals) - Understand how to build trust in your Atoms
+- [Triple Fundamentals](../Triples/fundamentals) - Learn how to connect Atoms into meaningful relationships
+- [Signal Fundamentals](../Signals/fundamentals) - Understand how to build trust in your Atoms
 - [Atom Structuring](./structuring) - Review advanced structuring techniques

--- a/docs/_data/intuition-concepts/primitives/Atoms/fundamentals.md
+++ b/docs/_data/intuition-concepts/primitives/Atoms/fundamentals.md
@@ -279,5 +279,5 @@ Now that you understand Atom fundamentals, explore:
 
 - [Atom Structuring](./structuring) - Learn advanced techniques for structuring Atoms effectively
 - [Atom Best Practices](./best-practices) - Discover patterns and guidelines for creating high-quality Atoms
-- [Triple Fundamentals](../triples/fundamentals) - Learn how Atoms combine to form relationships
-- [Signal Fundamentals](../signals/fundamentals) - Understand how users interact with Atoms through signaling
+- [Triple Fundamentals](../Triples/fundamentals) - Learn how Atoms combine to form relationships
+- [Signal Fundamentals](../Signals/fundamentals) - Understand how users interact with Atoms through signaling

--- a/docs/_data/intuition-concepts/primitives/Atoms/structuring.md
+++ b/docs/_data/intuition-concepts/primitives/Atoms/structuring.md
@@ -237,5 +237,5 @@ Ensure your atoms follow these validation rules:
 ## Next Steps
 
 - [Atom Best Practices](./best-practices) - Detailed guidelines for effective Atom design
-- [Triple Fundamentals](../triples/fundamentals) - Learn how to connect Atoms into relationships
-- [Signal Fundamentals](../signals/fundamentals) - Understand how to measure Atom usage and relevance
+- [Triple Fundamentals](../Triples/fundamentals) - Learn how to connect Atoms into relationships
+- [Signal Fundamentals](../Signals/fundamentals) - Understand how to measure Atom usage and relevance

--- a/docs/_data/intuition-concepts/primitives/Signals/fundamentals.md
+++ b/docs/_data/intuition-concepts/primitives/Signals/fundamentals.md
@@ -112,5 +112,5 @@ Creating an Atom or Triple is distinctly different from taking a position on the
 
 - [Capturing Signal](./capturing) - Learn advanced techniques for signal capture
 - [Signal Rewards](./rewards) - Understand the economic incentives and reward distribution
-- [Atom Fundamentals](../atoms/fundamentals) - Review Atom basics
-- [Triple Fundamentals](../triples/fundamentals) - Review Triple basics
+- [Atom Fundamentals](../Atoms/fundamentals) - Review Atom basics
+- [Triple Fundamentals](../Triples/fundamentals) - Review Triple basics

--- a/docs/_data/intuition-concepts/primitives/Signals/rewards.md
+++ b/docs/_data/intuition-concepts/primitives/Signals/rewards.md
@@ -131,5 +131,5 @@ This creates an economy where:
 ## Next Steps
 
 - [Economics Overview](../../economics/bonding-curves) - Deep dive into bonding curve mechanics
-- [Fees & Rewards](../../economics/fees-rewards) - Detailed fee structure
+- [Fees & Rewards](../../economics/fees-and-rewards) - Detailed fee structure
 - [Signal Fundamentals](./fundamentals) - Review signal basics

--- a/docs/_data/intuition-concepts/primitives/Triples/fundamentals.md
+++ b/docs/_data/intuition-concepts/primitives/Triples/fundamentals.md
@@ -133,4 +133,4 @@ With Atoms as the words in our global dictionary and Triples as the sentences we
 
 - [Triple Structuring](./structuring) - Learn advanced techniques for creating effective Triples
 - [Nested Triples](./nested-triples) - Understand how to build complex, layered claims
-- [Signal Fundamentals](../signals/fundamentals) - Discover how the community validates Triples
+- [Signal Fundamentals](../Signals/fundamentals) - Discover how the community validates Triples

--- a/docs/_data/intuition-concepts/primitives/Triples/nested-triples.md
+++ b/docs/_data/intuition-concepts/primitives/Triples/nested-triples.md
@@ -69,5 +69,5 @@ Each ID carries with it not just data, but the entire graph of relationships, ev
 
 ## Next Steps
 
-- [Signal Fundamentals](../signals/fundamentals) - Learn how the community validates nested claims
+- [Signal Fundamentals](../Signals/fundamentals) - Learn how the community validates nested claims
 - [Triple Structuring](./structuring) - Review best practices for Triple design

--- a/docs/_data/intuition-concepts/primitives/Triples/structuring.md
+++ b/docs/_data/intuition-concepts/primitives/Triples/structuring.md
@@ -122,4 +122,4 @@ const result = await createTripleStatement(
 ## Next Steps
 
 - [Nested Triples](./nested-triples) - Learn how to create meta-claims and context
-- [Signal Fundamentals](../signals/fundamentals) - Understand how to validate Triples
+- [Signal Fundamentals](../Signals/fundamentals) - Understand how to validate Triples

--- a/docs/_data/intuition-concepts/trust-mechanisms.md
+++ b/docs/_data/intuition-concepts/trust-mechanisms.md
@@ -163,6 +163,6 @@ Create personalized trust lenses:
 
 ## Next Steps
 
-- [Signal Fundamentals](../primitives/signals/fundamentals) - How trust is expressed
-- [Architecture Overview](../architecture/system-design) - System design for trust
-- [Economics](../economics/bonding-curves) - Economic trust incentives
+- [Signal Fundamentals](/docs/intuition-concepts/primitives/Signals/fundamentals) - How trust is expressed
+- [Architecture Overview](/docs/intuition-concepts/architecture) - System design for trust
+- [Economics](/docs/intuition-concepts/economics/bonding-curves) - Economic trust incentives

--- a/docs/_data/intuition-sdk/examples/batch-ethereum-accounts.md
+++ b/docs/_data/intuition-sdk/examples/batch-ethereum-accounts.md
@@ -81,5 +81,5 @@ main()
 
 ## See Also
 
-- [batchCreateAtomsFromEthereumAccounts](../atoms/batch-creation.md)
-- [Batch Creation Guide](../atoms/batch-creation.md)
+- [batchCreateAtomsFromEthereumAccounts](/docs/intuition-sdk/atoms-guide)
+- [Batch Creation Guide](/docs/intuition-sdk/atoms-guide)

--- a/docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md
+++ b/docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md
@@ -133,5 +133,5 @@ npx tsx bulk-sync-example.ts --execute
 
 ## See Also
 
-- [sync Function (Experimental)](/Users/simonas/dev/0xIntuition/intuition-ts/packages/sdk/README.md#sync)
-- [Batch Creation](../atoms/batch-creation.md)
+- sync Function (Experimental)
+- [Batch Creation](/docs/intuition-sdk/atoms-guide)

--- a/docs/_data/intuition-sdk/examples/create-atom-from-string.md
+++ b/docs/_data/intuition-sdk/examples/create-atom-from-string.md
@@ -140,6 +140,6 @@ Success!
 
 ## See Also
 
-- [createAtomFromString](../atoms/create-from-string.md)
-- [getAtomDetails](../atoms/querying.md)
-- [Quick Start Guide](../getting-started/quick-start.md)
+- [createAtomFromString](/docs/intuition-sdk/atoms-guide)
+- [getAtomDetails](/docs/intuition-sdk/atoms-guide)
+- [Quick Start Guide](/docs/intuition-sdk/quick-start)

--- a/docs/_data/intuition-sdk/examples/create-triple-statement.md
+++ b/docs/_data/intuition-sdk/examples/create-triple-statement.md
@@ -108,5 +108,5 @@ main()
 
 ## See Also
 
-- [createTripleStatement](../triples/create-triple.md)
+- [createTripleStatement](/docs/intuition-sdk/triples-guide)
 - [Create Atom Example](./create-atom-from-string.md)

--- a/docs/_data/intuition-sdk/examples/deposit-into-vault.md
+++ b/docs/_data/intuition-sdk/examples/deposit-into-vault.md
@@ -112,6 +112,6 @@ main()
 
 ## See Also
 
-- [deposit](../vaults/deposits.md)
-- [Vault Queries](../vaults/queries.md)
-- [Vault Previews](../vaults/previews.md)
+- [deposit](/docs/intuition-sdk/vaults-guide)
+- [Vault Queries](/docs/intuition-sdk/vaults-guide)
+- [Vault Previews](/docs/intuition-sdk/vaults-guide)

--- a/docs/_data/intuition-sdk/examples/find-existing-entities.md
+++ b/docs/_data/intuition-sdk/examples/find-existing-entities.md
@@ -146,7 +146,7 @@ main()
 
 ## See Also
 
-- [findAtomIds](../search/advanced-queries.md#findatomids)
-- [findTripleIds](../search/advanced-queries.md#findtripleids)
-- [calculateAtomId](../atoms/querying.md#calculateatomid)
-- [calculateTripleId](../triples/querying.md#calculatetripleid)
+- [findAtomIds](/docs/intuition-sdk/search-guide)
+- [findTripleIds](/docs/intuition-sdk/search-guide)
+- [calculateAtomId](/docs/intuition-sdk/atoms-guide)
+- [calculateTripleId](/docs/intuition-sdk/triples-guide)

--- a/docs/_data/intuition-sdk/examples/global-search.md
+++ b/docs/_data/intuition-sdk/examples/global-search.md
@@ -81,5 +81,5 @@ main()
 
 ## See Also
 
-- [globalSearch](../search/global-search.md)
-- [getAtomDetails](../atoms/querying.md)
+- [globalSearch](/docs/intuition-sdk/search-guide)
+- [getAtomDetails](/docs/intuition-sdk/atoms-guide)

--- a/docs/_data/intuition-sdk/integrations/react.md
+++ b/docs/_data/intuition-sdk/integrations/react.md
@@ -297,7 +297,7 @@ export function AtomManager() {
 
 - [TanStack Query Integration](./tanstack-query.md)
 - [Wagmi Documentation](https://wagmi.sh)
-- [SDK Quick Start](../getting-started/quick-start.md)
+- [SDK Quick Start](/docs/intuition-sdk/quick-start)
 
 ## See Also
 

--- a/docs/_data/intuition-sdk/integrations/tanstack-query.md
+++ b/docs/_data/intuition-sdk/integrations/tanstack-query.md
@@ -327,4 +327,4 @@ function AtomWithTriples({ atomId }: { atomId: string }) {
 ## See Also
 
 - [Wagmi Hooks](https://wagmi.sh)
-- [SDK Query Functions](../search/global-search.md)
+- [SDK Query Functions](/docs/intuition-sdk/search-guide)

--- a/docs/_data/intuition-sdk/quick-start.md
+++ b/docs/_data/intuition-sdk/quick-start.md
@@ -38,7 +38,7 @@ In this quick start guide, you'll:
 
 ## Prerequisites
 
-- [Installed the SDK](./installation.md)
+- [Installed the SDK](/docs/intuition-sdk/installation-and-setup)
 - Have a wallet with testnet TRUST tokens ([get testnet tokens](https://testnet.faucet.intuition.systems))
 - Your wallet private key
 
@@ -291,20 +291,20 @@ Each atom and triple has a vault for deposits:
 Now that you've created your first atom and triple, explore:
 
 ### Atom Operations
-- [**Create from Thing**](../atoms/create-from-thing.md) - Create rich entities with metadata
-- [**Create from Ethereum Account**](../atoms/create-from-ethereum-account.md) - Create identity atoms
-- [**Batch Creation**](../atoms/batch-creation.md) - Create multiple atoms efficiently
+- [**Create from Thing**](/docs/intuition-sdk/atoms-guide) - Create rich entities with metadata
+- [**Create from Ethereum Account**](/docs/intuition-sdk/atoms-guide) - Create identity atoms
+- [**Batch Creation**](/docs/intuition-sdk/atoms-guide) - Create multiple atoms efficiently
 
 ### Triple Operations
-- [**Querying Triples**](../triples/querying.md) - Fetch triple details
-- [**Counter Triples**](../triples/counter-triples.md) - Work with opposing positions
+- [**Querying Triples**](/docs/intuition-sdk/triples-guide) - Fetch triple details
+- [**Counter Triples**](/docs/intuition-sdk/triples-guide) - Work with opposing positions
 
 ### Vault Operations
-- [**Deposits**](../vaults/deposits.md) - Deposit into vaults
-- [**Redemptions**](../vaults/redemptions.md) - Redeem shares
+- [**Deposits**](/docs/intuition-sdk/vaults-guide) - Deposit into vaults
+- [**Redemptions**](/docs/intuition-sdk/vaults-guide) - Redeem shares
 
 ### Search & Discovery
-- [**Global Search**](../search/global-search.md) - Search across all entities
+- [**Global Search**](/docs/intuition-sdk/search-guide) - Search across all entities
 
 ## Common Issues
 
@@ -335,6 +335,6 @@ console.log('Chain ID:', intuitionTestnet.id)
 
 ## See Also
 
-- [Core Concepts](../../../core-concepts/primitives/overview.md) - Understand atoms and triples
-- [SDK Examples](../examples/create-atom-from-string.md) - More detailed examples
-- [GraphQL Queries](../../graphql-api/queries/atoms/single-atom.md) - Query protocol data
+- [Core Concepts](/docs/intuition-concepts/primitives) - Understand atoms and triples
+- [SDK Examples](/docs/intuition-sdk/examples/create-atom-from-string) - More detailed examples
+- [GraphQL Queries](/docs/graphql-api/queries/atoms/single-atom) - Query protocol data

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -5,7 +5,7 @@
  * Generate llms-full.txt and llms-medium.txt from all docs/_data/ markdown files.
  *
  * Produces structured text files with cleaned content, correct canonical
- * Docusaurus URLs (frontmatter-aware), and per-section metadata.
+ * Docusaurus URLs (frontmatter-aware), and metadata where appropriate.
  *
  * Usage:
  *   node scripts/generate-llms-full.js              # generate both output files
@@ -53,6 +53,128 @@ function normalizeDocPath(docPath) {
     normalized = normalized.slice(0, -1);
   }
   return normalized;
+}
+
+function absolutizeUrl(href, pageUrl = BASE_URL) {
+  const trimmed = String(href || '').trim();
+  if (!trimmed) return href;
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    return new URL(trimmed, pageUrl || BASE_URL).toString();
+  } catch {
+    return href;
+  }
+}
+
+function splitLinkTarget(href) {
+  const match = String(href || '').match(/^([^?#]*)([?#][\s\S]*)?$/);
+  return {
+    pathPart: match ? match[1] : String(href || ''),
+    suffix: match?.[2] || '',
+  };
+}
+
+function normalizeRoutePath(routePath) {
+  let normalized = normalizeDocPath(routePath);
+  normalized = normalized.replace(/\.(md|mdx)$/i, '');
+  return normalized;
+}
+
+function resolveDocRoutePath(routePath, routeMaps) {
+  const normalized = normalizeRoutePath(routePath);
+  if (routeMaps.validRoutes.has(normalized)) {
+    return normalized;
+  }
+
+  const lowerMatch = routeMaps.routeByLowerCase.get(normalized.toLowerCase());
+  if (lowerMatch) {
+    return lowerMatch;
+  }
+
+  return null;
+}
+
+function resolveSourceRelativeDocRoute(hrefPath, sourceFile, routeMaps) {
+  if (!sourceFile || !hrefPath) return null;
+
+  const targetPath = path.resolve(path.dirname(sourceFile), hrefPath);
+  const rel = path.relative(DOCS_DIR, targetPath);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return null;
+  }
+
+  const relWithoutExt = rel
+    .replace(/\.(md|mdx)$/i, '')
+    .split(path.sep)
+    .join('/');
+
+  const route = routeMaps.routeBySourcePath.get(relWithoutExt);
+  if (route) {
+    return route;
+  }
+
+  return routeMaps.routeByLowerSourcePath.get(relWithoutExt.toLowerCase()) || null;
+}
+
+function resolveContentUrl(href, { pageUrl = BASE_URL, sourceFile = '', routeMaps = null } = {}) {
+  const trimmed = String(href || '').trim();
+  if (!trimmed) return href;
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const { pathPart, suffix } = splitLinkTarget(trimmed);
+
+  if (trimmed.startsWith('#')) {
+    return `${pageUrl}${trimmed}`;
+  }
+
+  if (pathPart.startsWith('/docs') && routeMaps) {
+    const route = resolveDocRoutePath(pathPart, routeMaps);
+    return route ? `${BASE_URL}${route}${suffix}` : null;
+  }
+
+  if (/^\.{1,2}\//.test(pathPart) && routeMaps) {
+    const route = resolveSourceRelativeDocRoute(pathPart, sourceFile, routeMaps);
+    if (route) {
+      return `${BASE_URL}${route}${suffix}`;
+    }
+
+    if (!path.extname(pathPart) || /\.(md|mdx)$/i.test(pathPart)) {
+      return null;
+    }
+  }
+
+  return absolutizeUrl(trimmed, pageUrl);
+}
+
+function getHtmlAttribute(attrs, name) {
+  const quoted = attrs.match(new RegExp(`\\b${name}\\s*=\\s*["']([^"']+)["']`, 'i'));
+  if (quoted) return quoted[1];
+
+  const braced = attrs.match(new RegExp(`\\b${name}\\s*=\\s*\\{["']([^"']+)["']\\}`, 'i'));
+  if (braced) return braced[1];
+
+  return '';
+}
+
+function textFromHtml(value) {
+  return String(value || '')
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\{[^}]*\}/g, '')
+    .replace(/(^|\s)#{1,6}\s+/g, '$1')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function parseFrontMatter(content) {
@@ -115,13 +237,29 @@ function resolveDocRoute({ dirPath, basename, frontMatter }) {
 // ---------------------------------------------------------------------------
 
 function extractTitle(frontMatter, body, filePath) {
-  if (frontMatter.title) {
-    return frontMatter.title;
+  const h1Match = body.match(/^#\s+(.+)$/m);
+  const bodyTitle = h1Match ? h1Match[1].trim() : '';
+  const frontMatterTitle = frontMatter.title ? String(frontMatter.title).trim() : '';
+
+  if (frontMatterTitle && bodyTitle) {
+    const normalizedFrontMatter = normalizeTitleText(frontMatterTitle);
+    const normalizedBody = normalizeTitleText(bodyTitle);
+
+    if (normalizedFrontMatter.includes(normalizedBody)) {
+      return frontMatterTitle;
+    }
+    if (normalizedBody.includes(normalizedFrontMatter)) {
+      return bodyTitle;
+    }
+    return frontMatterTitle;
   }
 
-  const h1Match = body.match(/^#\s+(.+)$/m);
+  if (frontMatterTitle) {
+    return frontMatterTitle;
+  }
+
   if (h1Match) {
-    return h1Match[1].trim();
+    return bodyTitle;
   }
 
   const basename = path.basename(filePath, path.extname(filePath));
@@ -130,6 +268,13 @@ function extractTitle(frontMatter, body, filePath) {
     return titleCase(parentDir);
   }
   return titleCase(basename);
+}
+
+function normalizeTitleText(str) {
+  return String(str || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
 }
 
 function extractDescription(frontMatter, body) {
@@ -213,12 +358,65 @@ function getLastUpdatedMap() {
 // Content cleaning — multi-pass JSX/MDX stripping
 // ---------------------------------------------------------------------------
 
-function cleanContent(body, title, { stripCodeBlocks = false } = {}) {
+function qualifyGenericReferenceHeadings(content, pageTitle) {
+  const genericHeadings = new Set([
+    'Parameters',
+    'Returns',
+    'Example',
+    'Query Structure',
+  ]);
+  const headingStack = new Map();
+  if (pageTitle) {
+    headingStack.set(1, pageTitle);
+  }
+
+  return content
+    .split('\n')
+    .map((line) => {
+      const match = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+      if (!match) return line;
+
+      const level = match[1].length;
+      const heading = match[2].trim();
+
+      for (const existingLevel of [...headingStack.keys()]) {
+        if (existingLevel >= level) {
+          headingStack.delete(existingLevel);
+        }
+      }
+
+      if (!genericHeadings.has(heading)) {
+        headingStack.set(level, heading);
+        return line;
+      }
+
+      let parent = '';
+      for (let parentLevel = level - 1; parentLevel >= 1; parentLevel--) {
+        const candidate = headingStack.get(parentLevel);
+        if (candidate && !genericHeadings.has(candidate)) {
+          parent = candidate;
+          break;
+        }
+      }
+
+      const qualified = parent ? `${parent} - ${heading}` : heading;
+      headingStack.set(level, qualified);
+      return `${match[1]} ${qualified}`;
+    })
+    .join('\n');
+}
+
+function cleanContent(
+  body,
+  title,
+  { stripCodeBlocks = false, pageUrl = BASE_URL, sourceFile = '', routeMaps = null } = {}
+) {
   let content = body;
+  const linkContext = { pageUrl, sourceFile, routeMaps };
 
   // Pass 0: Handle fenced code blocks
   const codeBlocks = [];
-  content = content.replace(/^(```[\s\S]*?^```)/gm, (match) => {
+  content = content.replace(/^([ \t]*```[\s\S]*?^[ \t]*```)/gm, (match) => {
     if (stripCodeBlocks) {
       return ''; // Remove entirely for medium output
     }
@@ -236,13 +434,70 @@ function cleanContent(body, title, { stripCodeBlocks = false } = {}) {
   // Pass 3: Remove HTML comments
   content = content.replace(/<!--[\s\S]*?-->/g, '');
 
-  // Pass 4: Remove self-closing JSX components: <Component ... />
+  // Pass 4: Remove markdown horizontal rules from exported body content.
+  content = content.replace(/^[ \t]*---[ \t]*$/gm, '');
+
+  // Pass 5: Convert simple HTML/MDX elements to markdown where the text matters.
+  content = content.replace(
+    /^[ \t]*<h([1-6])\b[^>]*>\s*\r?\n([^\n]+?)\r?\n[ \t]*<\/h\1>[ \t]*$/gim,
+    (_, level, text) => {
+      const heading = textFromHtml(text);
+      return heading ? `${'#'.repeat(Number(level))} ${heading}` : '';
+    }
+  );
+  content = content.replace(
+    /^[ \t]*<h([1-6])\b[^>]*>(.*?)<\/h\1>[ \t]*$/gim,
+    (_, level, text) => {
+      const heading = textFromHtml(text);
+      return heading ? `${'#'.repeat(Number(level))} ${heading}` : '';
+    }
+  );
+  content = content.replace(
+    /^[ \t]*<img\b([^>]*)\/?>[ \t]*$/gim,
+    (_, attrs) => {
+      const src = getHtmlAttribute(attrs, 'src');
+      if (!src) return '';
+      const alt = textFromHtml(getHtmlAttribute(attrs, 'alt'));
+      const resolved = resolveContentUrl(src, linkContext);
+      return resolved ? `![${alt}](${resolved})` : alt;
+    }
+  );
+  content = content.replace(
+    /<a\b([^>]*)>([\s\S]*?)<\/a>/gim,
+    (_, attrs, text) => {
+      const href = getHtmlAttribute(attrs, 'href');
+      const label = textFromHtml(text);
+      if (!href) return label;
+      const resolved = resolveContentUrl(href, linkContext);
+      if (!resolved) return label;
+      return label ? `[${label}](${resolved})` : '';
+    }
+  );
+  content = content.replace(/<br\s*\/?>/gi, '\n');
+
+  // Pass 6: Drop decorative SVG markup before generic tag stripping.
+  content = content.replace(/^[ \t]*<svg\b[\s\S]*?<\/svg>[ \t]*$/gim, '');
+  content = content.replace(/^[ \t]*<(?:svg|path)\b[^>]*\/?>[ \t]*$/gim, '');
+
+  // Pass 7: Absolutize markdown links and images outside code fences.
+  content = content.replace(
+    /(!?)\[([^\]\n]*)\]\(((?:\/(?!\/)|\.{1,2}\/|#)[^)\s]*)\)/g,
+    (match, imagePrefix, label, href) => {
+      const resolved = resolveContentUrl(href, linkContext);
+      if (!resolved) {
+        return imagePrefix ? label : label;
+      }
+      return `${imagePrefix}[${label}](${resolved})`;
+    }
+  );
+
+  // Pass 8: Remove self-closing JSX components: <Component ... />
   content = content.replace(
     /^[ \t]*<[A-Z][A-Za-z]*\b[^>]*\/>\s*$/gm,
     ''
   );
 
-  // Pass 5: Remove multi-line JSX blocks (opening + children + closing)
+  // Pass 9: Remove multi-line JSX blocks (opening + children + closing)
   for (let i = 0; i < 5; i++) {
     const before = content;
     content = content.replace(
@@ -252,45 +507,38 @@ function cleanContent(body, title, { stripCodeBlocks = false } = {}) {
     if (content === before) break;
   }
 
-  // Pass 6: Remove inline style objects: style={{ ... }}
+  // Pass 10: Remove inline style objects: style={{ ... }}
   content = content.replace(/style=\{\{[\s\S]*?\}\}/g, '');
 
-  // Pass 7: Remove JSX event handlers and React-specific attributes
+  // Pass 11: Remove JSX event handlers and React-specific attributes
   content = content.replace(/\s+(onClick|onChange|onSubmit|onError|onLoad|className|htmlFor|tabIndex|aria-\w+)=\{[^}]*\}/g, '');
   content = content.replace(/\s+(onClick|onChange|onSubmit|onError|onLoad|className|htmlFor)="[^"]*"/g, '');
 
-  // Pass 8: Remove lines that are clearly JSX/React artifacts
+  // Pass 12: Remove lines that are clearly JSX/React artifacts
   content = content.replace(
-    /^[ \t]*(className=|<div|<\/div>|<span|<\/span>|<button|<\/button>|<p[ >]|<\/p>|<br\s*\/?>|<img\b|<a\s|<\/a>|<ul|<\/ul>|<li|<\/li>|<table|<\/table>|<thead|<\/thead>|<tbody|<\/tbody>|<tr|<\/tr>|<th|<\/th>|<td|<\/td>).*$/gm,
+    /^[ \t]*(className=|<div|<\/div>|<span|<\/span>|<button|<\/button>|<input\b|<\/input>|<p[ >]|<\/p>|<a\s|<\/a>|<ul|<\/ul>|<li|<\/li>|<table|<\/table>|<thead|<\/thead>|<tbody|<\/tbody>|<tr|<\/tr>|<th|<\/th>|<td|<\/td>).*$/gm,
     ''
   );
 
-  // Pass 9: Remove Docusaurus/MDX admonition wrappers (keep content)
+  // Pass 13: Remove Docusaurus/MDX admonition wrappers (keep content)
   content = content.replace(/^:::.*$/gm, '');
 
-  // Pass 10: Remove remaining inline HTML tags but keep text content
-  content = content.replace(/<\/?(?:div|span|p|br|img|a|ul|ol|li|table|thead|tbody|tr|th|td|strong|em|b|i|code|pre|blockquote|section|article|header|footer|nav|main|aside|details|summary|figure|figcaption|sup|sub|mark|small|del|ins|abbr|cite|q|dfn|kbd|samp|var|time|ruby|rt|rp|bdi|bdo|wbr|hr)\b[^>]*\/?>/gi, '');
+  // Pass 14: Remove remaining inline HTML tags but keep text content.
+  content = content.replace(/<\/?(?:div|span|p|br|img|a|ul|ol|li|table|thead|tbody|tr|th|td|strong|em|b|i|code|pre|blockquote|section|article|header|footer|nav|main|aside|details|summary|figure|figcaption|sup|sub|mark|small|del|ins|abbr|cite|q|dfn|kbd|samp|var|time|ruby|rt|rp|bdi|bdo|wbr|hr|h[1-6])\b[^>]*\/?>/gi, '');
 
-  // Pass 11: Remove empty JSX fragments and closings
+  // Pass 15: Remove empty JSX fragments and closings
   content = content.replace(/^[ \t]*[<>{}()]+[ \t]*$/gm, '');
 
-  // Pass 12: Remove lines with only Docusaurus CSS variables
+  // Pass 16: Remove lines with only Docusaurus CSS variables
   content = content.replace(/^.*var\(--ifm[^)]*\).*$/gm, '');
 
-  // Pass 12.5: Strip markdown links that point to local filesystem paths.
+  // Pass 17: Strip markdown links that point to local filesystem paths.
   content = content.replace(
     /\[([^\]]+)\]\((\/Users\/[^)\s]+|[A-Za-z]:[\\/][^)]+|file:\/\/[^)\s]+)\)/g,
     '$1'
   );
 
-  // Pass 13: Restore preserved code blocks
-  if (!stripCodeBlocks) {
-    content = content.replace(/__CODE_BLOCK_(\d+)__/g, (_, idx) => {
-      return codeBlocks[parseInt(idx, 10)];
-    });
-  }
-
-  // Pass 14: Collapse excessive blank lines (3+ → 2)
+  // Pass 18: Collapse excessive blank lines (3+ -> 2)
   content = content.replace(/\n{3,}/g, '\n\n');
 
   // Trim leading/trailing whitespace
@@ -300,10 +548,31 @@ function cleanContent(body, title, { stripCodeBlocks = false } = {}) {
   if (title) {
     const h1Pattern = /^#\s+(.+)\n*/;
     const h1Match = content.match(h1Pattern);
-    if (h1Match && h1Match[1].trim() === title.trim()) {
+    if (
+      h1Match &&
+      (
+        normalizeTitleText(h1Match[1]).includes(normalizeTitleText(title)) ||
+        normalizeTitleText(title).includes(normalizeTitleText(h1Match[1]))
+      )
+    ) {
       content = content.slice(h1Match[0].length).trim();
     }
   }
+
+  // Preserve a single page-level H1 emitted by the formatter; demote any
+  // remaining body H1s so heading-based chunkers don't treat them as page starts.
+  content = content.replace(/^#\s+/gm, '## ');
+
+  content = qualifyGenericReferenceHeadings(content, title);
+
+  // Pass 19: Restore preserved code blocks
+  if (!stripCodeBlocks) {
+    content = content.replace(/__CODE_BLOCK_(\d+)__/g, (_, idx) => {
+      return codeBlocks[parseInt(idx, 10)];
+    });
+  }
+
+  content = content.replace(/\n{3,}/g, '\n\n').trim();
 
   return content;
 }
@@ -311,6 +580,49 @@ function cleanContent(body, title, { stripCodeBlocks = false } = {}) {
 // ---------------------------------------------------------------------------
 // Section parsing — shared across output formats
 // ---------------------------------------------------------------------------
+
+function buildDocRouteMaps(docFiles) {
+  const routeByFile = new Map();
+  const routeBySourcePath = new Map();
+  const routeByLowerSourcePath = new Map();
+  const routeByLowerCase = new Map();
+  const validRoutes = new Set(['/docs']);
+
+  for (const file of docFiles) {
+    const rel = path.relative(DOCS_DIR, file);
+    const basename = path.basename(rel);
+    const ext = path.extname(rel).toLowerCase();
+    if (ext !== '.md' && ext !== '.mdx') continue;
+    if (basename.startsWith('_')) continue;
+
+    const withoutExt = rel.replace(/\.(md|mdx)$/i, '');
+    const parts = withoutExt.split(path.sep);
+    const dirPath = parts.slice(0, -1).join('/');
+    const baseNameNoExt = parts[parts.length - 1];
+    const content = fs.readFileSync(file, 'utf-8');
+    const { attributes: frontMatter } = parseFrontMatter(content);
+    const route = resolveDocRoute({
+      dirPath,
+      basename: baseNameNoExt,
+      frontMatter,
+    });
+    const sourcePath = withoutExt.split(path.sep).join('/');
+
+    routeByFile.set(file, route);
+    routeBySourcePath.set(sourcePath, route);
+    routeByLowerSourcePath.set(sourcePath.toLowerCase(), route);
+    routeByLowerCase.set(route.toLowerCase(), route);
+    validRoutes.add(route);
+  }
+
+  return {
+    routeByFile,
+    routeBySourcePath,
+    routeByLowerSourcePath,
+    routeByLowerCase,
+    validRoutes,
+  };
+}
 
 function parseSections() {
   const lastUpdatedMap = getLastUpdatedMap();
@@ -327,6 +639,7 @@ function parseSections() {
     })
     .sort();
 
+  const routeMaps = buildDocRouteMaps(docFiles);
   const sections = [];
 
   for (const file of docFiles) {
@@ -339,7 +652,7 @@ function parseSections() {
     const dirPath = parts.slice(0, -1).join('/');
     const baseNameNoExt = parts[parts.length - 1];
 
-    const route = resolveDocRoute({
+    const route = routeMaps.routeByFile.get(file) || resolveDocRoute({
       dirPath,
       basename: baseNameNoExt,
       frontMatter,
@@ -354,10 +667,19 @@ function parseSections() {
     const lastUpdated = lastUpdatedMap.get(gitKey) || '';
 
     // Clean content (full version — preserves code blocks)
-    const cleanedFull = cleanContent(body, title);
+    const cleanedFull = cleanContent(body, title, {
+      pageUrl: url,
+      sourceFile: file,
+      routeMaps,
+    });
 
     // Clean content (medium version — strips code blocks)
-    const cleanedMedium = cleanContent(body, title, { stripCodeBlocks: true });
+    const cleanedMedium = cleanContent(body, title, {
+      stripCodeBlocks: true,
+      pageUrl: url,
+      sourceFile: file,
+      routeMaps,
+    });
 
     // Skip files with very little content
     const nonEmptyLines = cleanedFull
@@ -414,22 +736,21 @@ Intuition is a permissionless protocol for creating verifiable, tokenized attest
 
 ## Routing Guide
 
-- SDK docs: /docs/intuition-sdk/…
-- GraphQL API: /docs/graphql-api/…
-- Smart Contracts: /docs/intuition-smart-contracts/…
-- Protocol package: /docs/protocol/…
-- Tutorials: /docs/tutorials/…
-- Core concepts: /docs/intuition-concepts/…
+- SDK docs: ${BASE_URL}/docs/intuition-sdk/
+- GraphQL API: ${BASE_URL}/docs/graphql-api/
+- Smart Contracts: ${BASE_URL}/docs/intuition-smart-contracts/
+- Protocol package: ${BASE_URL}/docs/protocol/
+- Tutorials: ${BASE_URL}/docs/tutorials/
+- Core concepts: ${BASE_URL}/docs/intuition-concepts/
 
 For a curated index of the most important pages, see: ${BASE_URL}/llms.txt
 
-Because this file is large, agents should prefer ${BASE_URL}/llms.txt first, then fetch specific pages or chunk this file by \`Source:\` sections.
+Because this file is large, agents should prefer ${BASE_URL}/llms.txt first, then fetch specific pages or chunk this file by page sections. Each page section starts with a single H1 followed by a \`Source:\` line.
 `;
 
   const body = sections
     .map((s) => {
-      const meta = formatMetadataBlock(s);
-      return `${meta}\n\n# ${s.title}\n\n${s.contentFull}`;
+      return `# ${s.title}\n\nSource: ${s.url}\n\n${s.contentFull}`;
     })
     .join('\n\n');
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -12,25 +12,20 @@ Intuition is a permissionless protocol for creating verifiable, tokenized attest
 
 ## Routing Guide
 
-- SDK docs: /docs/intuition-sdk/…
-- GraphQL API: /docs/graphql-api/…
-- Smart Contracts: /docs/intuition-smart-contracts/…
-- Protocol package: /docs/protocol/…
-- Tutorials: /docs/tutorials/…
-- Core concepts: /docs/intuition-concepts/…
+- SDK docs: https://docs.intuition.systems/docs/intuition-sdk/
+- GraphQL API: https://docs.intuition.systems/docs/graphql-api/
+- Smart Contracts: https://docs.intuition.systems/docs/intuition-smart-contracts/
+- Protocol package: https://docs.intuition.systems/docs/protocol/
+- Tutorials: https://docs.intuition.systems/docs/tutorials/
+- Core concepts: https://docs.intuition.systems/docs/intuition-concepts/
 
 For a curated index of the most important pages, see: https://docs.intuition.systems/llms.txt
 
-Because this file is large, agents should prefer https://docs.intuition.systems/llms.txt first, then fetch specific pages or chunk this file by `Source:` sections.
-
----
-title: "Contribution Guidelines"
-description: "Guidelines for contributing to Intuition projects across all repositories including intuition-ts, intuition-rs, intuition-mcp-server, and intuition-contracts-v2"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/contribution-guidelines"
----
+Because this file is large, agents should prefer https://docs.intuition.systems/llms.txt first, then fetch specific pages or chunk this file by page sections. Each page section starts with a single H1 followed by a `Source:` line.
 
 # Contribution Guidelines
+
+Source: https://docs.intuition.systems/docs/contribution-guidelines
 
 Thanks for your interest in contributing to 0xIntuition! We're excited to have you join our community of builders working on the trust protocol for the internet.
 
@@ -171,16 +166,9 @@ We welcome contributions of all kinds:
 
 Thank you for contributing to the future of decentralized trust! 🚀
 
----
-title: "Data Populator (Deprecated)"
-description: "Documentation for the Intuition Data Populator application"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/experimental-applications/data-populator"
----
-
 # Data Populator (Deprecated)
 
-# Data Populator
+Source: https://docs.intuition.systems/docs/experimental-applications/data-populator
 
 The **Intuition Data Populator** is a specialized tool designed to help users and developers efficiently populate the Intuition knowledge graph with high-quality, structured data. This application streamlines the process of creating atoms, triples, and establishing meaningful relationships within the decentralized knowledge network.
 
@@ -478,10 +466,10 @@ The Data Populator is part of the Intuition ecosystem and follows the same devel
 
 For support with the Data Populator:
 
-- Check the [Intuition documentation](/guides) for detailed guides
+- Check the [Intuition documentation](https://docs.intuition.systems/docs) for detailed guides
 - Visit the [GitHub repository](https://github.com/0xIntuition) for technical details
 - Join the [community discussions](https://discord.gg/RgBenkX4mx) for user support
-- Review the [API documentation](/docs/getting-started/developer-stack) for integration help
+- Review the [API documentation](https://docs.intuition.systems/docs/getting-started/developer-stack) for integration help
 
 ## Getting Started
 
@@ -493,22 +481,17 @@ For support with the Data Populator:
 
 ## Related Resources
 
-**[Portal](/docs/portal)** - Main interface for interacting with the knowledge graph
+**[Portal](https://docs.intuition.systems/docs/portal)** - Main interface for interacting with the knowledge graph
 
-**[Explorer](/docs/intuition-network)** - Network exploration and transaction monitoring
+**[Explorer](https://docs.intuition.systems/docs/intuition-network)** - Network exploration and transaction monitoring
 
-**[Developer Tools](/docs/getting-started/developer-stack)** - Programmatic access and integration
+**[Developer Tools](https://docs.intuition.systems/docs/getting-started/developer-stack)** - Programmatic access and integration
 
-**[API Documentation](/docs/graphql-api/overview)** - Technical integration guides
-
----
-title: "Farcaster Frames"
-description: "Documentation for the Intuition Farcaster Frames integration"
-last_updated: "2026-02-11T09:19:02-05:00"
-source: "https://docs.intuition.systems/docs/experimental-applications/farcaster-frames"
----
+**[API Documentation](https://docs.intuition.systems/docs/graphql-api/overview)** - Technical integration guides
 
 # Farcaster Frames
+
+Source: https://docs.intuition.systems/docs/experimental-applications/farcaster-frames
 
 The **Intuition Farcaster Frames** integration brings the power of Intuition's knowledge graph directly into the Farcaster social network. This integration enables users to create, verify, and interact with Intuition atoms and triples through interactive frames embedded in Farcaster posts, creating a seamless bridge between social media and decentralized knowledge.
 
@@ -789,7 +772,7 @@ const claimFrame = {
 ### Documentation
 
 - [Farcaster Frames Documentation](https://docs.farcaster.xyz/developers/frames)
-- [Intuition API Documentation](/docs/graphql-api/overview)
+- [Intuition API Documentation](https://docs.intuition.systems/docs/graphql-api/overview)
 - [Frame SDK Documentation](https://github.com/0xIntuition/intuition-frame)
 
 ### Tools and SDKs
@@ -808,23 +791,16 @@ const claimFrame = {
 
 ## Related Resources
 
-- [Portal](/docs/portal) - Main web interface for Intuition
-- [MetaMask Snap](/docs/experimental-applications/metamask-snap) - MetaMask integration
-- [Browser Extension](/docs/experimental-applications/metamask-snap) - Chrome extension
-- [Developer Tools](/docs/getting-started/developer-stack) - Programmatic access
-- [API Documentation](/docs/graphql-api/overview) - Technical guides
+- [Portal](https://docs.intuition.systems/docs/portal) - Main web interface for Intuition
+- [MetaMask Snap](https://docs.intuition.systems/docs/experimental-applications/metamask-snap) - MetaMask integration
+- [Browser Extension](https://docs.intuition.systems/docs/experimental-applications/metamask-snap) - Chrome extension
+- [Developer Tools](https://docs.intuition.systems/docs/getting-started/developer-stack) - Programmatic access
+- [API Documentation](https://docs.intuition.systems/docs/graphql-api/overview) - Technical guides
 - [Community](https://discord.gg/0xintuition) - Join the Intuition community
 
----
-title: "MCP Server"
-description: "Documentation for the Intuition MCP Server"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/experimental-applications/mcp-server"
----
-
-# MCP Server
-
 # Intuition MCP Server
+
+Source: https://docs.intuition.systems/docs/experimental-applications/mcp-server
 
 The Intuition MCP Server is an HTTP stream server designed to interact with the Intuition knowledge graph, enabling AI models and applications to query and manage data through powerful tools built on the Model Context Protocol.
 
@@ -842,19 +818,11 @@ This server supports both modern Streamable HTTP and legacy Server-Sent Events (
 
 ## GitHub Repository
 
-  <h3 >
-    Intuition MCP Server
-  </h3>
+### Intuition MCP Server
 
     Open-source Model Context Protocol server for knowledge graph interactions
 
-    target="_blank"
-    rel="noopener noreferrer"
-    
-    onMouseOver={(e) => e.currentTarget.style.transform = 'scale(1.05)'}
-    onMouseOut={(e) => e.currentTarget.style.transform = 'scale(1)'}
-
-    View on GitHub →
+  [e.currentTarget.style.transform = 'scale(1.05)'} onMouseOut= > View on GitHub →](https://github.com/0xIntuition/intuition-mcp-server)
 
 ## Getting Started
 
@@ -1044,14 +1012,9 @@ Please ensure your code follows the project's coding standards and includes test
 
 The Intuition MCP Server is open-source software licensed under the MIT License. See the [LICENSE](https://github.com/0xIntuition/intuition-mcp-server/blob/main/LICENSE) file for details.
 
----
-title: "MetaMask Snap"
-description: "Documentation for the Intuition MetaMask Snap"
-last_updated: "2026-02-11T09:19:02-05:00"
-source: "https://docs.intuition.systems/docs/experimental-applications/metamask-snap"
----
-
 # MetaMask Snap
+
+Source: https://docs.intuition.systems/docs/experimental-applications/metamask-snap
 
 The **Intuition MetaMask Snap** extends MetaMask's functionality to seamlessly integrate with the Intuition knowledge graph. This Snap enables users to interact with Intuition's decentralized identity and reputation system directly through their MetaMask wallet, providing a familiar and secure interface for managing atoms, triples, and staking operations.
 
@@ -1255,20 +1218,15 @@ The MetaMask Snap is open source and welcomes contributions:
 
 ## Related Resources
 
-- [Portal](/docs/portal) - Main web interface for Intuition
-- [Browser Extension](/docs/experimental-applications/metamask-snap) - Chrome extension for web browsing
-- [Developer Tools](/docs/getting-started/developer-stack) - Programmatic access and integration
-- [API Documentation](/docs/graphql-api/overview) - Technical integration guides
+- [Portal](https://docs.intuition.systems/docs/portal) - Main web interface for Intuition
+- [Browser Extension](https://docs.intuition.systems/docs/experimental-applications/metamask-snap) - Chrome extension for web browsing
+- [Developer Tools](https://docs.intuition.systems/docs/getting-started/developer-stack) - Programmatic access and integration
+- [API Documentation](https://docs.intuition.systems/docs/graphql-api/overview) - Technical integration guides
 - [Community](https://discord.gg/0xintuition) - Join the Intuition community
 
----
-title: "AI Skills"
-description: "Install Intuition agent skills for Claude Code, Codex, and compatible AI coding agents"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/ai-skills"
----
-
 # AI Skills
+
+Source: https://docs.intuition.systems/docs/getting-started/ai-skills
 
 The Intuition Agent Skills repository gives AI coding agents canonical protocol context. Use it when you want an agent to produce correct Intuition reads, writes, calldata, or unsigned transaction parameters.
 
@@ -1329,30 +1287,23 @@ Treat `main` as a moving branch. For production agent workflows, pin installs to
 
 Use AI skills when an agent is writing or modifying code that interacts with the protocol.
 
-Use the [MCP Server](/docs/experimental-applications/mcp-server) when an AI application needs tools for querying atoms, accounts, social graph data, or lists at runtime.
+Use the [MCP Server](https://docs.intuition.systems/docs/experimental-applications/mcp-server) when an AI application needs tools for querying atoms, accounts, social graph data, or lists at runtime.
 
 The two can be used together: skills help the coding agent implement correctly while MCP gives the finished AI application live graph tools.
 
 ## Pair With Templates
 
-The official [templates](/docs/getting-started/templates) already include agent-readable READMEs and `.agents/INSTRUCTIONS.md` files. Install the Intuition skill before asking an agent to extend those templates with new protocol operations.
-
----
-title: "Architecture"
-description: "Technical architecture of Intuition's three-layer system - Network, Protocol, and Subnet"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/getting-started/architecture"
----
-
-# Architecture
+The official [templates](https://docs.intuition.systems/docs/getting-started/templates) already include agent-readable READMEs and `.agents/INSTRUCTIONS.md` files. Install the Intuition skill before asking an agent to extend those templates with new protocol operations.
 
 # Technical Architecture
+
+Source: https://docs.intuition.systems/docs/getting-started/architecture
 
 Intuition's architecture consists of three tightly integrated layers that work together to create a high-performance, decentralized knowledge graph. This document provides a technical deep-dive into each layer and how they interconnect.
 
 ## Architecture Overview
 
-![Intuition System Overview](/img/intuition-intro.png)
+![Intuition System Overview](https://docs.intuition.systems/img/intuition-intro.png)
 
 Intuition's architecture is designed for **speed**, **scale**, and **interoperability**. By separating concerns across three specialized layers, we achieve optimal performance while maintaining decentralization and cross-chain compatibility.
 
@@ -1944,22 +1895,17 @@ const data = await graphqlClient.request(`
 
 Ready to start building? Explore these resources:
 
-**[Smart Contracts](/docs/intuition-smart-contracts)** - Deep dive into Protocol contracts
+**[Smart Contracts](https://docs.intuition.systems/docs/intuition-smart-contracts)** - Deep dive into Protocol contracts
 
-**[GraphQL API](/docs/graphql-api/overview)** - Learn the query interface
+**[GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)** - Learn the query interface
 
-**[SDK Guide](/docs/intuition-sdk/quick-start)** - Start building applications
+**[SDK Guide](https://docs.intuition.systems/docs/intuition-sdk/quick-start)** - Start building applications
 
-**[Deployments](/docs/intuition-smart-contracts/deployments)** - Contract addresses
-
----
-title: "Choose Your Path"
-description: "Find the best way to get started with Intuition based on your goals"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/choose-your-path"
----
+**[Deployments](https://docs.intuition.systems/docs/intuition-smart-contracts/deployments)** - Contract addresses
 
 # Choose Your Path
+
+Source: https://docs.intuition.systems/docs/getting-started/choose-your-path
 
 Not sure where to start? Pick the path that matches your goal.
 
@@ -1972,7 +1918,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Best for: Web apps, dashboards, social platforms
 - Abstracts complexity
 - React integration ready
-- **Start here:** [SDK Quick Start](/docs/intuition-sdk/quick-start)
+- **Start here:** [SDK Quick Start](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ### Query Data Only (No Writes)
 
@@ -1981,7 +1927,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Best for: Analytics, dashboards, data visualization
 - No wallet needed for reads
 - Powerful filtering and aggregation
-- **Start here:** [GraphQL Setup](/docs/graphql-api/getting-started/client-setup)
+- **Start here:** [GraphQL Setup](https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup)
 
 ### Build Smart Contract Integration
 
@@ -1990,7 +1936,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Best for: Other smart contracts, custom logic, gas optimization
 - Direct contract calls
 - Full control
-- **Start here:** [Protocol Configuration](/docs/protocol/getting-started/configuration)
+- **Start here:** [Protocol Configuration](https://docs.intuition.systems/docs/protocol/getting-started/configuration)
 
 ### Understand the System First
 
@@ -1999,7 +1945,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Atoms, Triples, Signals
 - Economics and incentives
 - Architecture
-- **Start here:** [Primitives Overview](/docs/intuition-concepts/primitives)
+- **Start here:** [Primitives Overview](https://docs.intuition.systems/docs/intuition-concepts/primitives)
 
 ### Learn Through a Guided Course
 
@@ -2007,7 +1953,7 @@ Not sure where to start? Pick the path that matches your goal.
 
 - Best for: Structured onboarding, AI-assisted learning, capstone practice
 - Covers atoms, triples, signals, reads, writes, and app building
-- **Start here:** [Learn Intuition](/docs/getting-started/learn-intuition)
+- **Start here:** [Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition)
 
 ### Start from a Working App
 
@@ -2015,7 +1961,7 @@ Not sure where to start? Pick the path that matches your goal.
 
 - Best for: Faster app starts, direct protocol exploration, production-style examples
 - Includes agent-readable project context
-- **Start here:** [Templates](/docs/getting-started/templates)
+- **Start here:** [Templates](https://docs.intuition.systems/docs/getting-started/templates)
 
 ### Build with an AI Agent
 
@@ -2023,7 +1969,7 @@ Not sure where to start? Pick the path that matches your goal.
 
 - Best for: Claude Code, Codex, Cursor, and compatible agents
 - Produces canonical protocol context and unsigned transaction parameters
-- **Start here:** [AI Skills](/docs/getting-started/ai-skills)
+- **Start here:** [AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills)
 
 ### See Complete Examples
 
@@ -2032,7 +1978,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Reputation system
 - Curated lists
 - Social attestations
-- **Start here:** [Tutorials](/docs/tutorials/overview)
+- **Start here:** [Tutorials](https://docs.intuition.systems/docs/tutorials/overview)
 
 ## Decision Tree
 
@@ -2068,6 +2014,8 @@ graph TD
 - Abstracts complexity
 - React integration ready
 
+[Start with SDK Quick Start →](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
+
 ### Query Data Only (No Writes)
 
 **Use GraphQL API** - Read-only queries for the knowledge graph.
@@ -2075,6 +2023,8 @@ graph TD
 - Best for: Analytics, dashboards, data visualization
 - No wallet needed for reads
 - Powerful filtering and aggregation
+
+[Start with GraphQL Setup →](https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup)
 
 ### Build Smart Contract Integration
 
@@ -2084,6 +2034,8 @@ graph TD
 - Direct contract calls
 - Full control
 
+[Start with Protocol Configuration →](https://docs.intuition.systems/docs/protocol/getting-started/configuration)
+
 ### Understand the System First
 
 **Read Concepts** - Learn how Intuition works.
@@ -2091,6 +2043,8 @@ graph TD
 - Atoms, Triples, Signals
 - Economics and incentives
 - Architecture
+
+[Start with Primitives Overview →](https://docs.intuition.systems/docs/intuition-concepts/primitives)
 
 ### Learn Through a Guided Course
 
@@ -2100,6 +2054,8 @@ graph TD
 - Covers the protocol primitives and implementation path together
 - Pairs well with the official templates
 
+[Start Learn Intuition →](https://docs.intuition.systems/docs/getting-started/learn-intuition)
+
 ### Start from a Working App
 
 **Use Templates** - Official starter apps with protocol calls already wired.
@@ -2107,6 +2063,8 @@ graph TD
 - Best for: Frontend developers, agent-assisted builds, app prototypes
 - Basic template for direct protocol forms
 - Advanced template for GraphQL reads, protocol writes, and SIWE auth
+
+[Open Templates →](https://docs.intuition.systems/docs/getting-started/templates)
 
 ### Build with an AI Agent
 
@@ -2116,6 +2074,8 @@ graph TD
 - Helps with ABIs, bytes32 IDs, batch-only creation, value calculations, and unsigned transaction parameters
 - Pair with the templates when asking an agent to extend protocol behavior
 
+[Install AI Skills →](https://docs.intuition.systems/docs/getting-started/ai-skills)
+
 ### See Complete Examples
 
 **Follow Tutorials** - Build real applications step-by-step.
@@ -2123,6 +2083,8 @@ graph TD
 - Reputation system
 - Curated lists
 - Social attestations
+
+[Start with Tutorials →](https://docs.intuition.systems/docs/tutorials/overview)
 
 ## Comparison Table
 
@@ -2145,20 +2107,15 @@ Join our [Discord](https://discord.gg/RgBenkX4mx) and ask the community!
 Once you've chosen your path:
 
 1. Follow the quick start guide for your chosen tool
-2. Read through the [Core Concepts](/docs/intuition-concepts/primitives)
-3. Run [Learn Intuition](/docs/getting-started/learn-intuition) if you want guided onboarding
-4. Fork a [Template](/docs/getting-started/templates) when you are ready to build
-5. Install [AI Skills](/docs/getting-started/ai-skills) before asking an agent to write protocol code
-6. Join the [Community](/docs/resources/community-and-support)
-
----
-title: "Developer Resources"
-description: "Official learning materials, templates, and AI-agent resources for building with Intuition"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/developer-resources"
----
+2. Read through the [Core Concepts](https://docs.intuition.systems/docs/intuition-concepts/primitives)
+3. Run [Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition) if you want guided onboarding
+4. Fork a [Template](https://docs.intuition.systems/docs/getting-started/templates) when you are ready to build
+5. Install [AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills) before asking an agent to write protocol code
+6. Join the [Community](https://docs.intuition.systems/docs/resources/community-and-support)
 
 # Developer Resources
+
+Source: https://docs.intuition.systems/docs/getting-started/developer-resources
 
 Use these official resources when you want to learn the protocol, start from a working application, or hand Intuition-specific context to an AI coding agent.
 
@@ -2166,10 +2123,10 @@ Use these official resources when you want to learn the protocol, start from a w
 
 | Resource | Use When | Link |
 | --- | --- | --- |
-| Learn Intuition | You want a guided course through atoms, triples, signals, reads, writes, and app building. | [Learn Intuition](/docs/getting-started/learn-intuition) |
-| Templates | You want to fork a working Intuition app instead of starting from a blank repository. | [Templates](/docs/getting-started/templates) |
-| AI Skills | You want Claude Code, Codex, or another agent to produce correct Intuition protocol operations. | [AI Skills](/docs/getting-started/ai-skills) |
-| MCP Server | You want an AI app to query Intuition through Model Context Protocol tools. | [MCP Server](/docs/experimental-applications/mcp-server) |
+| Learn Intuition | You want a guided course through atoms, triples, signals, reads, writes, and app building. | [Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition) |
+| Templates | You want to fork a working Intuition app instead of starting from a blank repository. | [Templates](https://docs.intuition.systems/docs/getting-started/templates) |
+| AI Skills | You want Claude Code, Codex, or another agent to produce correct Intuition protocol operations. | [AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills) |
+| MCP Server | You want an AI app to query Intuition through Model Context Protocol tools. | [MCP Server](https://docs.intuition.systems/docs/experimental-applications/mcp-server) |
 
 ## Official Repositories
 
@@ -2183,11 +2140,11 @@ Use these official resources when you want to learn the protocol, start from a w
 
 ## Suggested Path
 
-1. Read [Choose Your Path](/docs/getting-started/choose-your-path) to pick the right building surface.
-2. Run [Learn Intuition](/docs/getting-started/learn-intuition) if you want guided protocol context.
-3. Fork the [basic or advanced template](/docs/getting-started/templates) that matches your application.
-4. Install the [AI skills](/docs/getting-started/ai-skills) before asking an agent to write Intuition protocol code.
-5. Use the [MCP Server](/docs/experimental-applications/mcp-server) when your AI application needs live graph tools.
+1. Read [Choose Your Path](https://docs.intuition.systems/docs/getting-started/choose-your-path) to pick the right building surface.
+2. Run [Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition) if you want guided protocol context.
+3. Fork the [basic or advanced template](https://docs.intuition.systems/docs/getting-started/templates) that matches your application.
+4. Install the [AI skills](https://docs.intuition.systems/docs/getting-started/ai-skills) before asking an agent to write Intuition protocol code.
+5. Use the [MCP Server](https://docs.intuition.systems/docs/experimental-applications/mcp-server) when your AI application needs live graph tools.
 
 ## Agent-Ready Development
 
@@ -2197,18 +2154,13 @@ The course, templates, and skills are designed to work together:
 - The templates include agent-facing instructions for Claude Code, Codex, Cursor, and compatible tools.
 - The AI skills fill in Intuition-specific details that general LLMs usually miss, including ABIs, bytes32 IDs, batch-only creation flows, bonding curve mechanics, and unsigned transaction parameter generation.
 
-For protocol concepts before implementation, start with [Primitives](/docs/intuition-concepts/primitives). For reads and queries, use the [GraphQL API](/docs/graphql-api/overview). For onchain writes, use the [SDK](/docs/intuition-sdk/quick-start) or [Protocol](/docs/protocol/getting-started/overview) docs.
-
----
-title: "Developer Stack"
-description: "Choose the right tool or resource for building with Intuition"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/developer-stack"
----
+For protocol concepts before implementation, start with [Primitives](https://docs.intuition.systems/docs/intuition-concepts/primitives). For reads and queries, use the [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview). For onchain writes, use the [SDK](https://docs.intuition.systems/docs/intuition-sdk/quick-start) or [Protocol](https://docs.intuition.systems/docs/protocol/getting-started/overview) docs.
 
 # Developer Stack
 
-# Developer Tools
+Source: https://docs.intuition.systems/docs/getting-started/developer-stack
+
+## Developer Tools
 
 Choose the right tool for your use case.
 
@@ -2225,7 +2177,7 @@ Interactive course that teaches atoms, triples, signals, protocol reads, protoco
 - You are onboarding yourself or an AI-assisted workflow.
 - You want a course that ends with a template-based capstone.
 
-**[Learn Intuition](/docs/getting-started/learn-intuition)**
+**[Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition)**
 
 ### Templates
 
@@ -2236,7 +2188,7 @@ Official starter apps for direct protocol exploration and production-style appli
 - You need wallet, protocol, GraphQL, or SIWE patterns already wired.
 - You want agent-readable project context included from the start.
 
-**[Templates](/docs/getting-started/templates)**
+**[Templates](https://docs.intuition.systems/docs/getting-started/templates)**
 
 ### AI Skills
 
@@ -2247,7 +2199,7 @@ Agent-facing protocol context for Claude Code, Codex, and compatible AI coding a
 - You need canonical ABIs, addresses, value calculations, and unsigned transaction parameters.
 - You want to reduce LLM mistakes around bytes32 IDs, batch-only creation, and bonding curves.
 
-**[AI Skills](/docs/getting-started/ai-skills)**
+**[AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills)**
 
 ## Core Building Surfaces
 
@@ -2261,7 +2213,7 @@ High-level TypeScript SDK with React integration.
 - Need React hooks
 - Prefer abstraction over low-level control
 
-**[→ SDK Overview](/docs/intuition-sdk/quick-start)**
+**[→ SDK Overview](https://docs.intuition.systems/docs/intuition-sdk/quick-start)**
 
 ### Protocol Package
 
@@ -2273,7 +2225,7 @@ Low-level contract interactions for advanced use cases.
 - Optimizing gas costs
 - Building on Solidity
 
-**[→ Protocol Overview](/docs/protocol/getting-started/overview)**
+**[→ Protocol Overview](https://docs.intuition.systems/docs/protocol/getting-started/overview)**
 
 ### GraphQL API
 
@@ -2285,7 +2237,7 @@ Query the knowledge graph with GraphQL.
 - Data visualization
 - No wallet needed for reads
 
-**[→ GraphQL Overview](/docs/graphql-api/overview)**
+**[→ GraphQL Overview](https://docs.intuition.systems/docs/graphql-api/overview)**
 
 ### Smart Contracts
 
@@ -2297,7 +2249,7 @@ Direct contract interactions and ABIs.
 - Verifying on-chain data
 - Auditing contracts
 
-**[→ Contracts Overview](/docs/intuition-smart-contracts)**
+**[→ Contracts Overview](https://docs.intuition.systems/docs/intuition-smart-contracts)**
 
 ## Comparison
 
@@ -2312,16 +2264,11 @@ Direct contract interactions and ABIs.
 
 ## Still Unsure?
 
-See [Choose Your Path](/docs/getting-started/choose-your-path) for a decision tree, or use the [Developer Resources](/docs/getting-started/developer-resources) index for courses, templates, and AI-agent resources.
-
----
-title: "Integrations"
-description: "Integrate Intuition with various platforms and tools"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/integrations"
----
+See [Choose Your Path](https://docs.intuition.systems/docs/getting-started/choose-your-path) for a decision tree, or use the [Developer Resources](https://docs.intuition.systems/docs/getting-started/developer-resources) index for courses, templates, and AI-agent resources.
 
 # Integrations
+
+Source: https://docs.intuition.systems/docs/getting-started/integrations
 
 Intuition integrates with various platforms and tools to extend its capabilities beyond the core knowledge graph protocol.
 
@@ -2329,9 +2276,9 @@ Intuition integrates with various platforms and tools to extend its capabilities
 
 Use Intuition's knowledge graph with AI systems and agents to create persistent, verifiable memory and context.
 
-- **[AI Skills](/docs/getting-started/ai-skills)** - Agent-facing protocol context for Claude Code, Codex, and compatible AI coding agents.
-- **[MCP Server](/docs/experimental-applications/mcp-server)** - Model Context Protocol tools for querying atoms, accounts, lists, and graph data.
-- **[Templates](/docs/getting-started/templates)** - Agent-ready starter apps with file maps, protocol paths, and `.agents/INSTRUCTIONS.md` guidance.
+- **[AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills)** - Agent-facing protocol context for Claude Code, Codex, and compatible AI coding agents.
+- **[MCP Server](https://docs.intuition.systems/docs/experimental-applications/mcp-server)** - Model Context Protocol tools for querying atoms, accounts, lists, and graph data.
+- **[Templates](https://docs.intuition.systems/docs/getting-started/templates)** - Agent-ready starter apps with file maps, protocol paths, and `.agents/INSTRUCTIONS.md` guidance.
 
 **Use cases:**
 - **AI agents with persistent memory** - Store and retrieve agent knowledge on-chain
@@ -2379,9 +2326,9 @@ Bring attestations to DeFi and DAOs:
 
 Enhanced developer experience:
 
-- **[Learn Intuition](/docs/getting-started/learn-intuition)** - Interactive course for protocol onboarding inside Claude Code
-- **[AI Skills](/docs/getting-started/ai-skills)** - Canonical agent skills for protocol operations
-- **[Templates](/docs/getting-started/templates)** - Official starter apps for direct protocol exploration and production-style builds
+- **[Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition)** - Interactive course for protocol onboarding inside Claude Code
+- **[AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills)** - Canonical agent skills for protocol operations
+- **[Templates](https://docs.intuition.systems/docs/getting-started/templates)** - Official starter apps for direct protocol exploration and production-style builds
 - **Hardhat Plugin** - Deploy and test Intuition contracts
 - **Foundry Integration** - Testing framework support
 - **Ethers.js Plugin** - Simplified SDK integration
@@ -2407,19 +2354,19 @@ Have an integration idea? We'd love to hear from you!
 
 Intuition's open architecture makes it easy to build custom integrations:
 
-1. **[SDK Overview](/docs/intuition-sdk/quick-start)** - Start with the TypeScript SDK
-2. **[Protocol Overview](/docs/protocol/getting-started/overview)** - Direct smart contract integration
-3. **[GraphQL API](/docs/graphql-api/overview)** - Query the knowledge graph
-4. **[Templates](/docs/getting-started/templates)** - Fork a working Intuition app
-5. **[AI Skills](/docs/getting-started/ai-skills)** - Equip your coding agent with canonical protocol context
+1. **[SDK Overview](https://docs.intuition.systems/docs/intuition-sdk/quick-start)** - Start with the TypeScript SDK
+2. **[Protocol Overview](https://docs.intuition.systems/docs/protocol/getting-started/overview)** - Direct smart contract integration
+3. **[GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)** - Query the knowledge graph
+4. **[Templates](https://docs.intuition.systems/docs/getting-started/templates)** - Fork a working Intuition app
+5. **[AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills)** - Equip your coding agent with canonical protocol context
 
 ## Examples
 
 See these integration patterns:
 
-- **[Atoms Guide](/docs/intuition-sdk/atoms-guide)** - Working with atoms
-- **[Triples Guide](/docs/intuition-sdk/triples-guide)** - Creating attestations
-- **[Vaults Guide](/docs/intuition-sdk/vaults-guide)** - Vault operations
+- **[Atoms Guide](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)** - Working with atoms
+- **[Triples Guide](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)** - Creating attestations
+- **[Vaults Guide](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)** - Vault operations
 
 ## Stay Updated
 
@@ -2429,14 +2376,9 @@ Follow our progress on upcoming integrations:
 - **[Blog](https://intuition.systems/blog)** - Deep dives and tutorials
 - **[Newsletter](https://intuition.systems/newsletter)** - Monthly updates
 
----
-title: "Learn Intuition"
-description: "Run the interactive Learn Intuition course inside Claude Code"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/learn-intuition"
----
-
 # Learn Intuition
+
+Source: https://docs.intuition.systems/docs/getting-started/learn-intuition
 
 Learn Intuition is an interactive course that teaches the Intuition protocol inside Claude Code. It is meant for builders who want guided context before writing production code or asking an AI agent to extend an Intuition app. We'll be extending to support Codex in the future, but this first iteration is focused on running the experience within Claude Code.
 
@@ -2486,23 +2428,18 @@ Use Learn Intuition when you want to:
 - Have a guided, AI-assisted interactive learning experience.
 - Learn the read path and write path together.
 - Practice with an AI coding agent in a controlled environment.
-- Prepare to fork the [basic or advanced template](/docs/getting-started/templates).
+- Prepare to fork the [basic or advanced template](https://docs.intuition.systems/docs/getting-started/templates).
 
 ## Next Steps
 
-- [Templates](/docs/getting-started/templates) - fork a working app after the course.
-- [AI Skills](/docs/getting-started/ai-skills) - install agent skills before asking an agent to write protocol operations.
-- [SDK Quick Start](/docs/intuition-sdk/quick-start) - build directly with the TypeScript SDK.
-- [GraphQL Overview](/docs/graphql-api/overview) - query the knowledge graph.
-
----
-title: "Overview"
-description: "Learn about Intuition's core concepts, architecture, and economic model"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/getting-started/overview"
----
+- [Templates](https://docs.intuition.systems/docs/getting-started/templates) - fork a working app after the course.
+- [AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills) - install agent skills before asking an agent to write protocol operations.
+- [SDK Quick Start](https://docs.intuition.systems/docs/intuition-sdk/quick-start) - build directly with the TypeScript SDK.
+- [GraphQL Overview](https://docs.intuition.systems/docs/graphql-api/overview) - query the knowledge graph.
 
 # Overview
+
+Source: https://docs.intuition.systems/docs/getting-started/overview
 
 ## Intuition at a Glance
 
@@ -2514,27 +2451,23 @@ Instead of information living as unstructured, siloed, minimally-attributable da
 
 The result is a Semantic Web of Trust, powered the world's first token-curated knowledge graph — a network where information isn't just stored, but structured, incentivized, and made usable for developers and AI systems alike — all while maintaining verifiable provenance and attribution.
 
----
-
 ## The Three Pillars of Intuition
 
-<h3 >1. Intuition Network</h3>
+### 1. Intuition Network
 
 A custom Layer 3 blockchain settling to Base, built on Arbitrum Orbit with AnyTrust DA for scale and low-cost interactions — about 10,000 cheaper and 100x faster than most of the competition.
 
-<h3 >2. Intuition Protocol</h3>
+### 2. Intuition Protocol
 
 The rules and logic for how knowledge is represented and monetized.
 
 The Protocol is the grammar of programmable attestations — a universal language for expressing who said what, about what, at what time, and with what conviction.
 
-<h3 >3. Rust Subnet</h3>
+### 3. Rust Subnet
 
 A high-performance indexing and query layer built for developers.
 
 The Subnet turns raw attestations into actionable intelligence, powering AI agents, decentralized apps, and enterprise systems.
-
----
 
 ## Core Primitives
 
@@ -2567,15 +2500,11 @@ Tokenized stakes that weight attestations with economic confidence. Signals show
 - Creates economic incentives for accuracy
 - Provides the "weights" in the knowledge graph
 
-**[→ Deep dive into Primitives](/docs/intuition-concepts/primitives)**
-
----
+**[→ Deep dive into Primitives](https://docs.intuition.systems/docs/intuition-concepts/primitives)**
 
 ## How It Fits Together
 
 Together, they form the rails of a programmable knowledge economy where:
-
----
 
 ## Why This Matters for Developers
 
@@ -2583,46 +2512,31 @@ Building on Intuition means you don't have to reinvent trust, identity, or data 
 
 Attestations and identifiers give you:
 
-<h4 >
-💾 Memory
-</h4>
+#### 💾 Memory
 
 Agents and apps don't start from zero; they inherit context.
 
-<h4 >
-🔐 Trust
-</h4>
+#### 🔐 Trust
 
 Every claim is signed, staked, and auditable.
 
-<h4 >
-🎯 Alignment
-</h4>
+#### 🎯 Alignment
 
 Incentives built into the data layer itself.
 
-<h4 >
-🌐 Portability
-</h4>
+#### 🌐 Portability
 
 Your users' context and reputation follow them across apps.
 
-<h4 >
-🔌 Interoperability
-</h4>
+#### 🔌 Interoperability
 
 Shared identifiers and standards mean your app plugs into a larger ecosystem by default.
 
 Intuition provides the foundation. You build the apps, agents, and experiences that bring it to life.
 
----
-title: "Templates"
-description: "Fork official Intuition starter templates for protocol exploration and production-style apps"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs/getting-started/templates"
----
-
 # Templates
+
+Source: https://docs.intuition.systems/docs/getting-started/templates
 
 Our official templates give you working Intuition applications with protocol calls, wallet integration, and agent-readable project context already in place.
 
@@ -2686,25 +2600,20 @@ After a fresh clone, run the template's agentsync command if the symlinks need t
 bun run agents:apply
 ```
 
-Before asking an agent to change protocol behavior, we suggest installing the [AI skills](/docs/getting-started/ai-skills) so it has the canonical Intuition contract context.
+Before asking an agent to change protocol behavior, we suggest installing the [AI skills](https://docs.intuition.systems/docs/getting-started/ai-skills) so it has the canonical Intuition contract context.
 
 ## Next Steps
 
-- [Learn Intuition](/docs/getting-started/learn-intuition) - run the course before using a template.
-- [SDK Quick Start](/docs/intuition-sdk/quick-start) - understand the SDK surface.
-- [Protocol Overview](/docs/protocol/getting-started/overview) - inspect lower-level contract integration docs.
-- [GraphQL Client Setup](/docs/graphql-api/getting-started/client-setup) - add read queries to your app.
-
----
-title: "Use Cases"
-description: "Discover how to build amazing applications with Intuition's decentralized knowledge graph - from list curation to verification and fraud protection"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/getting-started/use-cases"
----
+- [Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition) - run the course before using a template.
+- [SDK Quick Start](https://docs.intuition.systems/docs/intuition-sdk/quick-start) - understand the SDK surface.
+- [Protocol Overview](https://docs.intuition.systems/docs/protocol/getting-started/overview) - inspect lower-level contract integration docs.
+- [GraphQL Client Setup](https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup) - add read queries to your app.
 
 # Use Cases
 
-![Use Cases](/img/use-cases.png)
+Source: https://docs.intuition.systems/docs/getting-started/use-cases
+
+![Use Cases](https://docs.intuition.systems/img/use-cases.png)
 
 This article outlines use cases that take advantage of Intuition's unique knowledge graph and claim infrastructure. There are many more ways to use Intuition (and we would love to see what you come up with!), but here are some ideas to get you started.
 
@@ -2807,14 +2716,9 @@ Intuition can help people signal what they believe will happen next or be advant
 - Know Your Futurist: Elevate trusted voices whose foresight consistently aligns with events and who posses domain knowledge, emphasizing their expertise within the community.
 - Provable Track Records: Assess past predictions in the form of claims from thought leaders in Intuition, including any financial stake they placed on the prediction, to determine their likelihood of correctly predicting future events.
 
----
-title: "Why Intuition?"
-description: "Understanding the trust crisis Intuition addresses and our mission to rebuild the internet's trust architecture"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/getting-started/why-intuition"
----
-
 # Why Intuition?
+
+Source: https://docs.intuition.systems/docs/getting-started/why-intuition
 
 > **Every interaction online is an attestation.**
 > A review or a purchase on Amazon, a comment on Reddit, the watching of a show on Netflix, a retweet, a LinkedIn endorsement, a 'follow', a bookmark, the ordering of an Uber, even a "like" — all are forms of attestations: claims made by things about things.
@@ -2905,57 +2809,53 @@ Where the Semantic Web asked the world to voluntarily agree on standards, Intuit
 
 If you're building applications that need identity, reputation, trust, or structured data — Intuition isn't optional. It's infrastructure.
 
-    <h4 >Data Layer Included</h4>
+#### Data Layer Included
 
       Inherit identity, reputation, and trust systems. No rebuilding from scratch.
 
-    <h4 >Network Effects</h4>
+#### Network Effects
 
       Every attestation joins a liquid ecosystem. Your users' data compounds globally.
 
-    <h4 >Economic Rails</h4>
+#### Economic Rails
 
       Bonding curves, staking, and rewards built in. Monetization without infrastructure.
 
-    <h4 >AI-Ready</h4>
+#### AI-Ready
 
       Verifiable context for AI agents. Training data with provenance.
 
-    <h4 >Great DX</h4>
+#### Great DX
 
       TypeScript SDK, GraphQL API, comprehensive docs. Ship fast.
 
-    <h4 >Avoid Silos</h4>
+#### Avoid Silos
 
       Don't rebuild isolated systems. Plug into shared infrastructure.
-
----
 
 ## For Users
 
 Your data has value. Your opinions matter. Your reputation should be yours.
 
-    <h4 >Own Your Data</h4>
+#### Own Your Data
 
       Your attestations belong to you, not platforms. Take them anywhere.
 
-    <h4 >Earn Value</h4>
+#### Earn Value
 
       Get rewarded when your contributions prove useful to others.
 
-    <h4 >Trust What You See</h4>
+#### Trust What You See
 
       Know who said what, with what stake behind it.
 
-    <h4 >One Identity</h4>
+#### One Identity
 
       Portable reputation across all apps and chains.
 
-    <h4 >Shape Knowledge</h4>
+#### Shape Knowledge
 
       Contribute to humanity's shared knowledge graph.
-
----
 
 ## How It Works: Skin in the Game
 
@@ -3025,14 +2925,9 @@ Whether you're a developer, researcher, or community builder, your contributions
 
 **Together, we can rebuild the web around truth, attribution, and trust.**
 
----
-title: "Choose Appropriate Operators"
-description: "Use the right comparison operator for the job"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/comparison-operators"
----
-
 # Choose Appropriate Operators
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/comparison-operators
 
 Use the right comparison operator for better performance.
 
@@ -3068,14 +2963,9 @@ query GetAccount($address: String!) {
 - **_gt/_lt**: Comparisons
 - **Primary key lookup**: Most efficient (when possible)
 
----
-title: "Use Database Functions"
-description: "Leverage backend functions for complex queries"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/database-functions"
----
-
 # Use Database Functions
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/database-functions
 
 Use backend functions for complex queries instead of client-side filtering.
 
@@ -3125,14 +3015,9 @@ query GetFollowingEfficiently($address: String!) {
 2. **Less data transfer**: Filtered server-side
 3. **More maintainable**: Logic in one place
 
----
-title: "Error Handling"
-description: "Handle GraphQL errors gracefully"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/error-handling"
----
-
 # Error Handling
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/error-handling
 
 Handle GraphQL errors gracefully in your application.
 
@@ -3184,14 +3069,9 @@ try {
 3. **Show user-friendly messages**: Don't expose internal errors
 4. **Implement retry logic**: For network failures
 
----
-title: "Efficient Filtering"
-description: "Use indexed fields and appropriate operators"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/filtering"
----
-
 # Efficient Filtering
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/filtering
 
 Filter early and use indexed fields for better performance.
 
@@ -3227,14 +3107,9 @@ These fields have database indexes:
 - Use `_in` for multiple values
 - Combine filters with `_and` for specificity
 
----
-title: "Use Fragments"
-description: "Reuse field selections with GraphQL fragments"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/fragments"
----
-
 # Use Fragments
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/fragments
 
 Reuse field selections across queries with GraphQL fragments.
 
@@ -3292,14 +3167,9 @@ query GetTriple($id: String!) {
 3. **Consistent data**: Same fields across queries
 4. **Better readability**: Named, semantic units
 
----
-title: "Pagination Best Practices"
-description: "Efficient pagination with limit and offset"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/pagination"
----
-
 # Pagination Best Practices
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/pagination
 
 Always use limit and offset for efficient pagination with consistent ordering.
 
@@ -3330,14 +3200,9 @@ query GetAtomsPage($limit: Int!, $offset: Int!) {
 3. **Use reasonable limits** (10-100 items per page)
 4. **Calculate offset** as `(page - 1) * limit`
 
----
-title: "Query Performance"
-description: "Optimize GraphQL query performance"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/performance"
----
-
 # Query Performance
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/performance
 
 Optimize your GraphQL queries for better performance.
 
@@ -3472,14 +3337,9 @@ query GetFollowing($address: String!) {
 - Track cache hit rates
 - Watch for N+1 query patterns
 
----
-title: "Use Pre-Computed Statistics"
-description: "Leverage time-series tables for analytics"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/pre-computed-stats"
----
-
 # Use Pre-Computed Statistics
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/pre-computed-stats
 
 Leverage time-series aggregation tables for efficient analytics.
 
@@ -3535,14 +3395,9 @@ query GetDailyPriceStats($termId: String!, $curveId: numeric!) {
 3. **Smaller payloads**: Aggregated vs raw data
 4. **Better UX**: Faster dashboard loading
 
----
-title: "Request Only Needed Fields"
-description: "Avoid over-fetching by requesting only required fields"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/request-only-needed"
----
-
 # Request Only Needed Fields
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/request-only-needed
 
 Avoid over-fetching by requesting only the fields you actually need.
 
@@ -3602,14 +3457,9 @@ query GetAtoms {
 - Use fragments for commonly requested field sets
 - Profile queries to identify over-fetching
 
----
-title: "Subscriptions vs Polling"
-description: "When to use subscriptions vs polling"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/subscriptions-vs-polling"
----
-
 # Subscriptions vs Polling
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/subscriptions-vs-polling
 
 Choose the right approach for your data update needs.
 
@@ -3657,14 +3507,9 @@ query GetStats {
 - **Subscription batch_size**: 10-50 items
 - **Handle reconnections**: Store last cursor for resumability
 
----
-title: "Use Variables"
-description: "Always use variables for dynamic values"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/best-practices/variables"
----
-
 # Use Variables
+
+Source: https://docs.intuition.systems/docs/graphql-api/best-practices/variables
 
 Always use variables for dynamic values instead of hardcoding.
 
@@ -3706,14 +3551,9 @@ query GetAtomsByType($type: atom_type!) {
 3. **Security**: Prevents injection attacks
 4. **Caching**: Better query plan caching
 
----
-title: "Custom Queries"
-description: "Common GraphQL query examples and patterns for the Intuition API"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/custom-queries"
----
-
 # Custom Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/custom-queries
 
 This page provides practical examples of common GraphQL queries for the Intuition API.
 
@@ -3907,16 +3747,9 @@ function useCustomAtomQuery(termId: string) {
 }
 ```
 
----
-title: "Activity Feed"
-description: "Build real-time activity feed"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/activity-feed"
----
-
-# Activity Feed
-
 # Example: Activity Feed
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/activity-feed
 
 Build an activity feed showing recent protocol activity.
 
@@ -3952,16 +3785,9 @@ Build an activity feed showing recent protocol activity.
 
 ];
 
----
-title: "Atom with Vault"
-description: "Fetch atom details with vault statistics"
-last_updated: "2026-06-22T14:26:07-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/atom-with-vault"
----
-
-# Atom with Vault
-
 # Example: Atom with Vault
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/atom-with-vault
 
 Fetch atom metadata along with vault statistics.
 
@@ -4031,16 +3857,9 @@ const data = await client.request(query, {
 })
 ```
 
----
-title: "Complex Filtering"
-description: "Multi-criteria search and filtering"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/complex-filtering"
----
-
-# Complex Filtering
-
 # Example: Complex Filtering
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/complex-filtering
 
 Implement multi-criteria search across entities.
 
@@ -4093,14 +3912,9 @@ Implement multi-criteria search across entities.
 
 ];
 
----
-title: "Multi-Language Examples"
-description: "GraphQL API usage in Python, Go, and Rust"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/multi-language"
----
-
 # Multi-Language Examples
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/multi-language
 
 Use the Intuition GraphQL API across different programming languages.
 
@@ -4195,16 +4009,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
----
-title: "Price History"
-description: "Analyze price trends over time"
-last_updated: "2026-06-22T14:26:07-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/price-history"
----
-
-# Price History
-
 # Example: Price History
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/price-history
 
 Analyze share price trends using time-series data.
 
@@ -4235,16 +4042,9 @@ Analyze share price trends using time-series data.
 
 ];
 
----
-title: "Social Graph"
-description: "Build social feed from followed accounts"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/social-graph"
----
-
-# Social Graph
-
 # Example: Social Graph
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/social-graph
 
 Build a social activity feed from followed accounts.
 
@@ -4282,16 +4082,9 @@ Build a social activity feed from followed accounts.
 
 ];
 
----
-title: "Real-Time Subscriptions"
-description: "Implement real-time updates with subscriptions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/subscriptions"
----
-
-# Real-Time Subscriptions
-
 # Example: Real-Time Subscriptions
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/subscriptions
 
 Implement real-time position monitoring with subscriptions.
 
@@ -4362,16 +4155,9 @@ client.subscribe(
 )
 ```
 
----
-title: "Trending Atoms"
-description: "Find top atoms by market cap and activity"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/trending-atoms"
----
-
-# Trending Atoms
-
 # Example: Trending Atoms
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/trending-atoms
 
 Find top atoms ranked by vault market cap.
 
@@ -4403,16 +4189,9 @@ Find top atoms ranked by vault market cap.
 
 ];
 
----
-title: "Triples Pagination"
-description: "Paginate through triples with total count"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/triples-pagination"
----
-
-# Triples Pagination
-
 # Example: Triples Pagination
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/triples-pagination
 
 Paginate through triples with total count for UI.
 
@@ -4443,16 +4222,9 @@ Paginate through triples with total count for UI.
 
 ];
 
----
-title: "User Positions"
-description: "Fetch all positions for a user with aggregates"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/examples/user-positions"
----
-
-# User Positions
-
 # Example: User Positions
+
+Source: https://docs.intuition.systems/docs/graphql-api/examples/user-positions
 
 Fetch user positions with aggregate statistics.
 
@@ -4487,14 +4259,9 @@ Fetch user positions with aggregate statistics.
 
 ];
 
----
-title: "Client Setup"
-description: "Set up GraphQL clients in JavaScript, Python, Go, and Rust"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup"
----
-
 # Client Setup
+
+Source: https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup
 
 The Intuition GraphQL API works with any GraphQL client in any language. This guide provides setup examples for popular clients across different languages.
 
@@ -4850,20 +4617,13 @@ try {
 
 ## Next Steps
 
-- [Schema Reference](/docs/graphql-api/getting-started/schema-reference) - Learn about schema features
-- [Query Patterns](/docs/graphql-api/queries/atoms/single-atom) - Explore common queries
-- [Best Practices](/docs/graphql-api/best-practices/request-only-needed) - Optimize your queries
-
----
-title: "Introduction"
-description: "Introduction to the Intuition GraphQL API and its capabilities"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/getting-started/introduction"
----
-
-# Introduction
+- [Schema Reference](https://docs.intuition.systems/docs/graphql-api/getting-started/schema-reference) - Learn about schema features
+- [Query Patterns](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) - Explore common queries
+- [Best Practices](https://docs.intuition.systems/docs/graphql-api/best-practices/request-only-needed) - Optimize your queries
 
 # GraphQL API Introduction
+
+Source: https://docs.intuition.systems/docs/graphql-api/getting-started/introduction
 
 The Intuition GraphQL API provides comprehensive access to the Intuition knowledge graph, including atoms (entities), triples (relationships), vaults (asset pools), and user positions. The API is powered by Hasura and offers rich querying capabilities with filtering, sorting, pagination, and aggregations.
 
@@ -4967,9 +4727,9 @@ The GraphQL API enables a wide range of applications:
 
 ## Next Steps
 
-- [Client Setup](/docs/graphql-api/getting-started/client-setup) - Configure a GraphQL client in your preferred language
-- [Schema Reference](/docs/graphql-api/getting-started/schema-reference) - Learn about schema features and introspection
-- [Query Patterns](/docs/graphql-api/queries/atoms/single-atom) - Explore common query patterns
+- [Client Setup](https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup) - Configure a GraphQL client in your preferred language
+- [Schema Reference](https://docs.intuition.systems/docs/graphql-api/getting-started/schema-reference) - Learn about schema features and introspection
+- [Query Patterns](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) - Explore common query patterns
 
 ## Resources
 
@@ -4977,14 +4737,9 @@ The GraphQL API enables a wide range of applications:
 - **Hasura GraphQL Docs**: https://hasura.io/docs/latest/queries/postgres/index/
 - **Intuition Protocol Docs**: https://docs.intuition.systems
 
----
-title: "Schema Reference"
-description: "GraphQL schema features including filtering, sorting, pagination, and aggregations"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/getting-started/schema-reference"
----
-
 # Schema Reference
+
+Source: https://docs.intuition.systems/docs/graphql-api/getting-started/schema-reference
 
 The Intuition GraphQL API is powered by Hasura, providing a rich set of features for querying and manipulating data.
 
@@ -5395,12 +5150,12 @@ The Intuition GraphQL API exposes 142 root query fields. Every table/view suppor
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `atoms` | `term_id` | Fundamental units of knowledge | [Queries](/docs/graphql-api/queries/atoms/single-atom) |
-| `triples` | `term_id` | Subject-predicate-object relationships | [Queries](/docs/graphql-api/queries/triples/single-triple) |
-| `accounts` | `id` | User accounts and wallets | [Queries](/docs/graphql-api/queries/accounts/overview) |
+| `atoms` | `term_id` | Fundamental units of knowledge | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) |
+| `triples` | `term_id` | Subject-predicate-object relationships | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/triples/single-triple) |
+| `accounts` | `id` | User accounts and wallets | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/accounts/overview) |
 | `terms` | `id` | Shared term data for atoms and triples (holds `total_assets`, `total_market_cap`, `type`) | |
-| `vaults` | `term_id`, `curve_id` | Bonding curve vaults for staking | [Queries](/docs/graphql-api/queries/vaults/vault-details) |
-| `positions` | `id` | User stakes in vaults | [Queries](/docs/graphql-api/queries/vaults/user-positions) |
+| `vaults` | `term_id`, `curve_id` | Bonding curve vaults for staking | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details) |
+| `positions` | `id` | User stakes in vaults | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) |
 
 ### Atom Value Types
 
@@ -5418,45 +5173,45 @@ The Intuition GraphQL API exposes 142 root query fields. Every table/view suppor
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `signals` | — | Enriched deposit/redemption events | [Queries](/docs/graphql-api/queries/signals/overview) |
-| `events` | `id` | Raw blockchain events | [Queries](/docs/graphql-api/queries/events/overview) |
-| `deposits` | `id` | Deposit transactions | [Queries](/docs/graphql-api/queries/vaults/deposits-redemptions) |
-| `redemptions` | `id` | Redemption transactions | [Queries](/docs/graphql-api/queries/vaults/deposits-redemptions) |
+| `signals` | — | Enriched deposit/redemption events | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/signals/overview) |
+| `events` | `id` | Raw blockchain events | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/events/overview) |
+| `deposits` | `id` | Deposit transactions | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/deposits-redemptions) |
+| `redemptions` | `id` | Redemption transactions | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/deposits-redemptions) |
 
 ### Position Tracking Views
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `positions_with_value` | — | Positions enriched with PnL, redeemable value | [Queries](/docs/graphql-api/queries/vaults/positions-with-value) |
-| `position_changes` | `id` | Individual position change events | [Queries](/docs/graphql-api/queries/vaults/position-changes) |
-| `position_change_daily` | — | Daily aggregated position changes | [Queries](/docs/graphql-api/queries/vaults/position-changes) |
-| `position_change_hourly` | — | Hourly aggregated position changes | [Queries](/docs/graphql-api/queries/vaults/position-changes) |
+| `positions_with_value` | — | Positions enriched with PnL, redeemable value | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/positions-with-value) |
+| `position_changes` | `id` | Individual position change events | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes) |
+| `position_change_daily` | — | Daily aggregated position changes | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes) |
+| `position_change_hourly` | — | Hourly aggregated position changes | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes) |
 
 ### Graph Structure Views
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `subject_predicates` | `subject_id`, `predicate_id` | Subject-predicate pair aggregates | [Queries](/docs/graphql-api/queries/triples/subject-predicates) |
-| `predicate_objects` | `predicate_id`, `object_id` | Predicate-object pair aggregates | [Queries](/docs/graphql-api/queries/advanced/predicate-objects) |
-| `triple_term` | `term_id` | Triple-term aggregate stats | [Queries](/docs/graphql-api/queries/triples/triple-terms) |
-| `triple_vault` | `term_id`, `curve_id` | Triple vault-level data | [Queries](/docs/graphql-api/queries/triples/triple-vaults) |
+| `subject_predicates` | `subject_id`, `predicate_id` | Subject-predicate pair aggregates | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/triples/subject-predicates) |
+| `predicate_objects` | `predicate_id`, `object_id` | Predicate-object pair aggregates | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/advanced/predicate-objects) |
+| `triple_term` | `term_id` | Triple-term aggregate stats | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-terms) |
+| `triple_vault` | `term_id`, `curve_id` | Triple vault-level data | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-vaults) |
 
 ### Statistics & Fees
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `stats` | `id` | Protocol-wide statistics | [Queries](/docs/graphql-api/queries/stats/protocol-stats) |
+| `stats` | `id` | Protocol-wide statistics | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) |
 | `statHours` | `id` | Hourly protocol stats snapshots | |
-| `fee_transfers` | `id` | Protocol fee transfer events | [Queries](/docs/graphql-api/queries/stats/fee-transfers) |
-| `protocol_fee_accruals` | `id` | Fee accruals by epoch | [Queries](/docs/graphql-api/queries/stats/fee-accruals) |
+| `fee_transfers` | `id` | Protocol fee transfer events | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers) |
+| `protocol_fee_accruals` | `id` | Fee accruals by epoch | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accruals) |
 
 ### PnL & Leaderboard
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `pnl_leaderboard_entry` | — | Leaderboard rows (34 fields) | [Queries](/docs/graphql-api/queries/leaderboard/pnl-leaderboard) |
-| `pnl_leaderboard_stats` | — | Aggregate leaderboard stats | [Queries](/docs/graphql-api/queries/leaderboard/leaderboard-stats) |
-| `account_pnl_rank` | — | Individual account rank/percentile | [Queries](/docs/graphql-api/queries/leaderboard/account-rank) |
+| `pnl_leaderboard_entry` | — | Leaderboard rows (34 fields) | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) |
+| `pnl_leaderboard_stats` | — | Aggregate leaderboard stats | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats) |
+| `account_pnl_rank` | — | Individual account rank/percentile | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) |
 
 ### Time-Series (Continuous Aggregates)
 
@@ -5464,16 +5219,16 @@ Pre-computed at hourly, daily, weekly, and monthly granularities.
 
 | Base Entity | Intervals | Description | Docs |
 |-------------|-----------|-------------|------|
-| `share_price_change_stats_*` | hourly, daily, weekly, monthly | Share price OHLC-style stats | [Queries](/docs/graphql-api/queries/advanced/time-series) |
-| `signal_stats_*` | hourly, daily, weekly, monthly | Signal count and volume | [Queries](/docs/graphql-api/queries/advanced/time-series) |
-| `term_total_state_change_stats_*` | hourly, daily, weekly, monthly | Term market cap changes | [Queries](/docs/graphql-api/queries/advanced/time-series) |
-| `term_total_state_changes` | — | Raw state change events | [Queries](/docs/graphql-api/queries/advanced/time-series) |
+| `share_price_change_stats_*` | hourly, daily, weekly, monthly | Share price OHLC-style stats | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series) |
+| `signal_stats_*` | hourly, daily, weekly, monthly | Signal count and volume | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series) |
+| `term_total_state_change_stats_*` | hourly, daily, weekly, monthly | Term market cap changes | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series) |
+| `term_total_state_changes` | — | Raw state change events | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series) |
 
 ### Price & Share Data
 
 | Entity | Primary Key | Description | Docs |
 |--------|-------------|-------------|------|
-| `share_price_changes` | — | Vault share price history | [Queries](/docs/graphql-api/queries/vaults/share-price-changes) |
+| `share_price_changes` | — | Vault share price history | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/vaults/share-price-changes) |
 | `chainlink_prices` | `id` | Chainlink oracle price data | |
 
 ### Social
@@ -5495,19 +5250,19 @@ These functions take an `args` parameter with function-specific inputs and retur
 
 | Function | Args | Returns | Description | Docs |
 |----------|------|---------|-------------|------|
-| `search_term` | `search: String` | `atoms[]` | Full-text search for atoms | [Queries](/docs/graphql-api/queries/search/search-term) |
-| `search_term_from_following` | `address: String`, `search: String` | `atoms[]` | Search within followed accounts | [Queries](/docs/graphql-api/queries/search/search-from-following) |
+| `search_term` | `search: String` | `atoms[]` | Full-text search for atoms | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) |
+| `search_term_from_following` | `address: String`, `search: String` | `atoms[]` | Search within followed accounts | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following) |
 | `search_term_tsvector` | `search: String` | `atoms[]` | Full-text search (tsvector variant) | |
-| `search_positions_on_subject` | `addresses: _text`, `search_fields: jsonb` | `positions[]` | Find positions on a subject | [Queries](/docs/graphql-api/queries/search/search-positions) |
-| `following` | `address: String` | `accounts[]` | Accounts followed by address | [Queries](/docs/graphql-api/queries/accounts/following) |
-| `signals_from_following` | `address: String` | `signals[]` | Signals from followed accounts | [Queries](/docs/graphql-api/queries/signals/signals-from-following) |
-| `positions_from_following` | `address: String` | `positions[]` | Positions from followed accounts | [Queries](/docs/graphql-api/queries/accounts/positions-from-following) |
-| `get_pnl_leaderboard` | `p_limit`, `p_offset`, `p_sort_by`, ... | `pnl_leaderboard_entry[]` | PnL leaderboard | [Queries](/docs/graphql-api/queries/leaderboard/pnl-leaderboard) |
-| `get_pnl_leaderboard_period` | `p_start_date`, `p_end_date`, ... | `pnl_leaderboard_entry[]` | Period-scoped leaderboard | [Queries](/docs/graphql-api/queries/leaderboard/pnl-leaderboard) |
-| `get_pnl_leaderboard_stats` | `p_term_id`, `p_time_filter` | `pnl_leaderboard_stats[]` | Leaderboard aggregate stats | [Queries](/docs/graphql-api/queries/leaderboard/leaderboard-stats) |
-| `get_vault_leaderboard` | `p_term_id`, `p_curve_id`, ... | `pnl_leaderboard_entry[]` | Vault leaderboard | [Queries](/docs/graphql-api/queries/leaderboard/vault-leaderboard) |
-| `get_vault_leaderboard_period` | `p_start_date`, `p_end_date`, ... | `pnl_leaderboard_entry[]` | Period-scoped vault leaderboard | [Queries](/docs/graphql-api/queries/leaderboard/vault-leaderboard) |
-| `get_account_pnl_rank` | `p_account_id`, `p_sort_by`, ... | `account_pnl_rank[]` | Account rank + percentile | [Queries](/docs/graphql-api/queries/leaderboard/account-rank) |
+| `search_positions_on_subject` | `addresses: _text`, `search_fields: jsonb` | `positions[]` | Find positions on a subject | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions) |
+| `following` | `address: String` | `accounts[]` | Accounts followed by address | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) |
+| `signals_from_following` | `address: String` | `signals[]` | Signals from followed accounts | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) |
+| `positions_from_following` | `address: String` | `positions[]` | Positions from followed accounts | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following) |
+| `get_pnl_leaderboard` | `p_limit`, `p_offset`, `p_sort_by`, ... | `pnl_leaderboard_entry[]` | PnL leaderboard | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) |
+| `get_pnl_leaderboard_period` | `p_start_date`, `p_end_date`, ... | `pnl_leaderboard_entry[]` | Period-scoped leaderboard | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) |
+| `get_pnl_leaderboard_stats` | `p_term_id`, `p_time_filter` | `pnl_leaderboard_stats[]` | Leaderboard aggregate stats | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats) |
+| `get_vault_leaderboard` | `p_term_id`, `p_curve_id`, ... | `pnl_leaderboard_entry[]` | Vault leaderboard | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard) |
+| `get_vault_leaderboard_period` | `p_start_date`, `p_end_date`, ... | `pnl_leaderboard_entry[]` | Period-scoped vault leaderboard | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard) |
+| `get_account_pnl_rank` | `p_account_id`, `p_sort_by`, ... | `account_pnl_rank[]` | Account rank + percentile | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) |
 
 ### Custom Operations (Hasura Actions)
 
@@ -5515,41 +5270,36 @@ These are backed by external services (chart-api, IPFS gateway). They use camelC
 
 | Operation | Type | Description | Docs |
 |-----------|------|-------------|------|
-| `getAccountPnlCurrent` | Query | Current account PnL snapshot | [Queries](/docs/graphql-api/queries/pnl/account-pnl-current) |
-| `getAccountPnlChart` | Query | Account PnL over time | [Queries](/docs/graphql-api/queries/pnl/account-pnl-chart) |
-| `getAccountPnlRealized` | Query | Realized PnL breakdown | [Queries](/docs/graphql-api/queries/pnl/account-pnl-realized) |
-| `getPositionPnlChart` | Query | Position-level PnL chart | [Queries](/docs/graphql-api/queries/pnl/position-pnl-chart) |
-| `getChartJson` | Query | Chart data as JSON | [Queries](/docs/graphql-api/queries/charts/chart-json) |
-| `getChartRawJson` | Query | Raw chart data as JSON | [Queries](/docs/graphql-api/queries/charts/chart-raw-json) |
-| `getChartSvg` | Query | Chart rendered as SVG | [Queries](/docs/graphql-api/queries/charts/chart-svg) |
-| `getChartRawSvg` | Query | Minimal raw SVG chart | [Queries](/docs/graphql-api/queries/charts/chart-raw-svg) |
-| `pinThing` | Mutation | Pin Thing metadata to IPFS | [Mutations](/docs/graphql-api/mutations/pin-thing) |
-| `pinPerson` | Mutation | Pin Person metadata to IPFS | [Mutations](/docs/graphql-api/mutations/pin-person) |
-| `pinOrganization` | Mutation | Pin Organization metadata to IPFS | [Mutations](/docs/graphql-api/mutations/pin-organization) |
-| `uploadImage` | Mutation | Upload image (base64) | [Mutations](/docs/graphql-api/mutations/images/upload-image) |
-| `uploadImageFromUrl` | Mutation | Upload image from URL | [Mutations](/docs/graphql-api/mutations/images/upload-image-from-url) |
-| `uploadJsonToIpfs` | Mutation | Upload JSON to IPFS | [Mutations](/docs/graphql-api/mutations/images/upload-json-to-ipfs) |
+| `getAccountPnlCurrent` | Query | Current account PnL snapshot | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) |
+| `getAccountPnlChart` | Query | Account PnL over time | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) |
+| `getAccountPnlRealized` | Query | Realized PnL breakdown | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) |
+| `getPositionPnlChart` | Query | Position-level PnL chart | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pnl-chart) |
+| `getChartJson` | Query | Chart data as JSON | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) |
+| `getChartRawJson` | Query | Raw chart data as JSON | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-json) |
+| `getChartSvg` | Query | Chart rendered as SVG | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) |
+| `getChartRawSvg` | Query | Minimal raw SVG chart | [Queries](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-svg) |
+| `pinThing` | Mutation | Pin Thing metadata to IPFS | [Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing) |
+| `pinPerson` | Mutation | Pin Person metadata to IPFS | [Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/pin-person) |
+| `pinOrganization` | Mutation | Pin Organization metadata to IPFS | [Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/pin-organization) |
+| `uploadImage` | Mutation | Upload image (base64) | [Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image) |
+| `uploadImageFromUrl` | Mutation | Upload image from URL | [Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) |
+| `uploadJsonToIpfs` | Mutation | Upload JSON to IPFS | [Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs) |
 
 ## Next Steps
 
-- [Query Atoms](/docs/graphql-api/queries/atoms/single-atom) - Learn atom query patterns
-- [Query Triples](/docs/graphql-api/queries/triples/single-triple) - Learn triple query patterns
-- [Query Signals](/docs/graphql-api/queries/signals/overview) - Learn signal query patterns
-- [Query Accounts](/docs/graphql-api/queries/accounts/overview) - Learn account query patterns
-- [PnL Queries](/docs/graphql-api/queries/pnl/overview) - Track profit and loss
-- [Leaderboard](/docs/graphql-api/queries/leaderboard/overview) - PnL and vault leaderboards
-- [Charts](/docs/graphql-api/queries/charts/overview) - Chart data and SVG rendering
-- [Time-Series](/docs/graphql-api/queries/advanced/time-series) - Pre-computed analytics
-- [Best Practices](/docs/graphql-api/best-practices/request-only-needed) - Optimize your queries
-
----
-title: "GraphQL Generator"
-description: "Comprehensive guide to the Intuition GraphQL Generator"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/graphql-generator"
----
+- [Query Atoms](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) - Learn atom query patterns
+- [Query Triples](https://docs.intuition.systems/docs/graphql-api/queries/triples/single-triple) - Learn triple query patterns
+- [Query Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/overview) - Learn signal query patterns
+- [Query Accounts](https://docs.intuition.systems/docs/graphql-api/queries/accounts/overview) - Learn account query patterns
+- [PnL Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview) - Track profit and loss
+- [Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/overview) - PnL and vault leaderboards
+- [Charts](https://docs.intuition.systems/docs/graphql-api/queries/charts/overview) - Chart data and SVG rendering
+- [Time-Series](https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series) - Pre-computed analytics
+- [Best Practices](https://docs.intuition.systems/docs/graphql-api/best-practices/request-only-needed) - Optimize your queries
 
 # GraphQL Generator
+
+Source: https://docs.intuition.systems/docs/graphql-api/graphql-generator
 
 The Intuition GraphQL package can be used as a GraphQL generator for your custom queries. It provides a type-safe interface for interacting with the Intuition API. It functions as the core data fetching layer, supplying generated types and React Query hooks for easy integration with the semantic knowledge graph.
 
@@ -5655,16 +5405,11 @@ The GraphQL API provides the foundation for building powerful applications on In
 - [React Query Documentation](https://tanstack.com/query)
 - [Intuition GraphQL Package Source](https://github.com/0xIntuition/intuition-ts/tree/main/packages/graphql)
 
----
-title: "Migration Guide"
-description: "Migrating GraphQL from v1.5 to v2.0"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/migration-guide"
----
-
 # Migration Guide
 
-# Migrating GraphQL from v1.5 to v2.0
+Source: https://docs.intuition.systems/docs/graphql-api/migration-guide
+
+## Migrating GraphQL from v1.5 to v2.0
 
 ## Overview
 
@@ -5781,14 +5526,9 @@ query GetAtom($termId: String!) {
 }
 ```
 
----
-title: "Image & IPFS Operations"
-description: "Upload images and JSON data to IPFS"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/images/overview"
----
-
 # Image & IPFS Operations
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/images/overview
 
 The Intuition GraphQL API provides mutations for uploading images and JSON data to IPFS (InterPlanetary File System). Image uploads return cached image URLs, while JSON uploads return IPFS hashes that can be used in atom creation.
 
@@ -5798,9 +5538,9 @@ Image and JSON upload mutations use the public gated pinning endpoint, `https://
 
 | Operation                                       | Description                           |
 | ----------------------------------------------- | ------------------------------------- |
-| [`uploadImage`](./upload-image)                 | Upload a base64-encoded image to IPFS |
-| [`uploadImageFromUrl`](./upload-image-from-url) | Upload an image from a URL to IPFS    |
-| [`uploadJsonToIpfs`](./upload-json-to-ipfs)     | Upload JSON metadata to IPFS          |
+| [`uploadImage`](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image)                 | Upload a base64-encoded image to IPFS |
+| [`uploadImageFromUrl`](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) | Upload an image from a URL to IPFS    |
+| [`uploadJsonToIpfs`](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs)     | Upload JSON metadata to IPFS          |
 
 ## Use Cases
 
@@ -5915,19 +5655,14 @@ The exact response shape depends on the mutation. JSON uploads return the raw ha
 
 ## Related Documentation
 
-- [Upload Image](./upload-image) - Base64 image upload
-- [Upload Image from URL](./upload-image-from-url) - URL-based upload
-- [Upload JSON to IPFS](./upload-json-to-ipfs) - JSON metadata upload
-- [Pin Mutations](/docs/graphql-api/mutations/pin-thing) - Pin entities to IPFS
-
----
-title: "Upload Image from URL"
-description: "Upload an image from a URL"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url"
----
+- [Upload Image](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image) - Base64 image upload
+- [Upload Image from URL](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) - URL-based upload
+- [Upload JSON to IPFS](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs) - JSON metadata upload
+- [Pin Mutations](https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing) - Pin entities to IPFS
 
 # Upload Image from URL
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url
 
 Upload an image by providing its URL. The server fetches, caches, and moderates the image. Returns a `CachedImage` with the hosted URL and safety score.
 
@@ -6047,18 +5782,13 @@ async function importExternalImage(imageUrl: string) {
 
 ## Related
 
-- [Upload Image](./upload-image) - Upload base64 image
-- [Upload JSON to IPFS](./upload-json-to-ipfs) - Upload metadata
-- [Pin Person](/docs/graphql-api/mutations/pin-person) - Create Person with image
-
----
-title: "Upload Image"
-description: "Upload a base64-encoded image via the API"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image"
----
+- [Upload Image](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image) - Upload base64 image
+- [Upload JSON to IPFS](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs) - Upload metadata
+- [Pin Person](https://docs.intuition.systems/docs/graphql-api/mutations/pin-person) - Create Person with image
 
 # Upload Image
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image
 
 Upload a base64-encoded image. The image is cached and a moderation check is performed. Returns a `CachedImage` with the hosted URL and safety score.
 
@@ -6183,18 +5913,13 @@ async function uploadFileInput(file: File) {
 
 ## Related
 
-- [Upload Image from URL](./upload-image-from-url) - Upload from URL
-- [Upload JSON to IPFS](./upload-json-to-ipfs) - Upload metadata
-- [Pin Thing](/docs/graphql-api/mutations/pin-thing) - Create Thing with image
-
----
-title: "Upload JSON to IPFS"
-description: "Upload JSON metadata to IPFS"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs"
----
+- [Upload Image from URL](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) - Upload from URL
+- [Upload JSON to IPFS](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs) - Upload metadata
+- [Pin Thing](https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing) - Create Thing with image
 
 # Upload JSON to IPFS
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs
 
 Upload JSON metadata to IPFS for use in atom creation. Returns the IPFS hash, name, and size.
 
@@ -6331,22 +6056,15 @@ async function prepareAtomMetadata(thing: {
 
 ## Related
 
-- [Upload Image](./upload-image) - Upload images
-- [Upload Image from URL](./upload-image-from-url) - Import external images
-- [Pin Thing](/docs/graphql-api/mutations/pin-thing) - Pin Thing metadata
-- [Pin Person](/docs/graphql-api/mutations/pin-person) - Pin Person metadata
-- [Pin Organization](/docs/graphql-api/mutations/pin-organization) - Pin Organization metadata
-
----
-title: "Pin Organization"
-description: "Pin Organization metadata to IPFS"
-last_updated: "2026-06-25T17:24:12-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/pin-organization"
----
-
-# Pin Organization
+- [Upload Image](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image) - Upload images
+- [Upload Image from URL](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) - Import external images
+- [Pin Thing](https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing) - Pin Thing metadata
+- [Pin Person](https://docs.intuition.systems/docs/graphql-api/mutations/pin-person) - Pin Person metadata
+- [Pin Organization](https://docs.intuition.systems/docs/graphql-api/mutations/pin-organization) - Pin Organization metadata
 
 # Pin Organization Mutation
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/pin-organization
 
 Pin an Organization entity to IPFS for use in atom creation.
 
@@ -6404,16 +6122,9 @@ mutation PinOrganization($organization: PinOrganizationInput!) {
 3. **Provide website URL** for reference
 4. **Include contact email** if available
 
----
-title: "Pin Person"
-description: "Pin Person metadata to IPFS"
-last_updated: "2026-06-25T17:24:12-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/pin-person"
----
-
-# Pin Person
-
 # Pin Person Mutation
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/pin-person
 
 Pin a Person entity to IPFS for use in atom creation.
 
@@ -6472,16 +6183,9 @@ mutation PinPerson($person: PinPersonInput!) {
 3. **Provide description** for context
 4. **Use person-specific fields** for rich metadata
 
----
-title: "Pin Thing"
-description: "Pin Thing metadata to IPFS"
-last_updated: "2026-06-25T17:24:12-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing"
----
-
-# Pin Thing
-
 # Pin Thing Mutation
+
+Source: https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing
 
 Pin a "Thing" object (general entity) to IPFS for use in atom creation.
 
@@ -6557,14 +6261,9 @@ mutation PinThing($thing: PinThingInput!) {
 3. **Store IPFS URI** for future reference
 4. **Wait for indexing** before querying the atom
 
----
-title: "GraphQL NPM Package"
-description: "Comprehensive guide to use the Intuition GraphQL NPM package"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/npm-package"
----
-
 # GraphQL NPM Package
+
+Source: https://docs.intuition.systems/docs/graphql-api/npm-package
 
 The Intuition GraphQL package provides a type-safe interface for interacting with the Intuition API. It functions as the core data fetching layer, supplying generated types and React Query hooks for easy integration with the semantic knowledge graph.
 
@@ -6711,23 +6410,23 @@ The following groups correspond to the query documents in the `src/queries` subd
 
 ### Accounts
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useAccountByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useAccountsQuery
 
 ### Atoms
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useAtomByIdQuery
 
         useGetAtomQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useAtomsQuery
 
@@ -6735,61 +6434,61 @@ The following groups correspond to the query documents in the `src/queries` subd
 
 ### Claims
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useClaimByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useClaimsQuery
 
 ### Events
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useEventByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useEventsQuery
 
 ### Follows
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useFollowByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useFollowsQuery
 
 ### Lists
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useListByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useListsQuery
 
 ### Points
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         usePointByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         usePointsQuery
 
 ### Positions
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         usePositionByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         usePositionsQuery
 
@@ -6797,11 +6496,11 @@ The following groups correspond to the query documents in the `src/queries` subd
 
 ### Signals
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useSignalByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useSignalsQuery
 
@@ -6809,41 +6508,41 @@ The following groups correspond to the query documents in the `src/queries` subd
 
 ### Stats
 
-    <h4>Get</h4>
+#### Get
 
         useGetStatsQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useStatsQuery
 
 ### Tags
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useTagByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useTagsQuery
 
 ### Triples
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useTripleByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useTriplesQuery
 
 ### Vaults
 
-    <h4>Get by ID</h4>
+#### Get by ID
 
         useVaultByIdQuery
 
-    <h4>Search &amp; Filter</h4>
+#### Search & Filter
 
         useVaultsQuery
 
@@ -6858,46 +6557,27 @@ The GraphQL package source code is available on GitHub: [`intuition-ts/packages/
 - [GraphQL Code Generator](https://the-guild.dev/graphql/codegen)
 - [React Query Documentation](https://tanstack.com/query)
 
----
-title: "Overview"
-description: "Introduction to the Intuition GraphQL API and its main features"
-last_updated: "2026-02-11T14:23:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/overview"
----
-
-# Overview
-
 # GraphQL API Overview
+
+Source: https://docs.intuition.systems/docs/graphql-api/overview
 
 Intuition provides GraphQL APIs for querying its knowledge graph in a convenient and versatile way. 
 
 **Available endpoints**
 
-    <h3>
-      Intuition mainnet
-    </h3>
+### Intuition mainnet
 
       ```text
       https://mainnet.intuition.sh/v1/graphql
       ```
+      [Try on GraphQL Explorer](https://studio.apollographql.com/sandbox/explorer?endpoint=https://mainnet.intuition.sh/v1/graphql)
 
-        target="_blank"
-        rel="noreferrer"
-
-        Try on GraphQL Explorer
-
-    <h3>
-      Intuition testnet
-    </h3>
+### Intuition testnet
 
       ```text
       https://testnet.intuition.sh/v1/graphql
       ```
-
-        target="_blank"
-        rel="noreferrer"
-
-        Try on GraphQL Explorer
+      [Try on GraphQL Explorer](https://studio.apollographql.com/sandbox/explorer?endpoint=https://testnet.intuition.sh/v1/graphql)
 
 Alternatively, you can import these URLs from the GraphQL package:
 
@@ -6909,59 +6589,38 @@ If this is your first time using GraphQL, you can learn more at [graphql.org](ht
 
 There are a few ways to get started with this GraphQL API, depending on the level of abstraction and customization you require : 
 
-    <h3>
-      SDK
-    </h3>
+  [SDK Integrate with Intuition smart contracts using our TypeScript SDK.](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
 
-      Integrate with Intuition smart contracts using our TypeScript SDK.
-
-    <h3>
-      Custom Queries
-    </h3>
-
-      Create bespoke GraphQL queries for your specific use case.
+  [Custom Queries Create bespoke GraphQL queries for your specific use case.](https://docs.intuition.systems/docs/graphql-api/custom-queries)
 
 ### GraphQL Package
 
-    <h3>
-      Install it with NPM
-    </h3>
+  [Install it with NPM Install and use the NPM package with ready-made React Query hooks.](https://docs.intuition.systems/docs/graphql-api/npm-package)
 
-      Install and use the NPM package with ready-made React Query hooks.
-
-    <h3>
-      Use it as a GraphQL Generator
-    </h3>
-
-      Use the GraphQL package to generate your own queries and mutations.
+  [Use it as a GraphQL Generator Use the GraphQL package to generate your own queries and mutations.](https://docs.intuition.systems/docs/graphql-api/npm-package)
 
 ## See GraphQL in Action
 
 Check out these complete tutorials using the GraphQL API:
 
-- **[Finding Top Dapps](/docs/tutorials/queries/finding-top-dapps-on-coinbase)** - Query and rank decentralized applications by market cap
-- **[Building Activity Feeds](/docs/tutorials/queries/building-user-activity-feeds)** - Create real-time user activity streams
-- **[Discovering Trusted Accounts](/docs/tutorials/queries/discovering-most-trusted-accounts)** - Build trust graphs and find reliable accounts
-- **[Finding Related Claims](/docs/tutorials/queries/finding-related-claims)** - Traverse the knowledge graph to find connections
+- **[Finding Top Dapps](https://docs.intuition.systems/docs/tutorials/queries/finding-top-dapps-on-coinbase)** - Query and rank decentralized applications by market cap
+- **[Building Activity Feeds](https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds)** - Create real-time user activity streams
+- **[Discovering Trusted Accounts](https://docs.intuition.systems/docs/tutorials/queries/discovering-most-trusted-accounts)** - Build trust graphs and find reliable accounts
+- **[Finding Related Claims](https://docs.intuition.systems/docs/tutorials/queries/finding-related-claims)** - Traverse the knowledge graph to find connections
 
-[More tutorials →](/docs/tutorials/overview)
+[More tutorials →](https://docs.intuition.systems/docs/tutorials/overview)
 
 ## Interactive Playground
 
 Try the Intuition GraphQL API straight from your browser! The playground below connects to the live testnet endpoint and allows you to explore the knowledge graph in real time.
 
----
-title: "Following Query"
-description: "Query following relationships in the social graph"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/following"
----
-
 # Following Query
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/accounts/following
 
 Query the social graph to find who an account follows and who follows them.
 
-## Query Structure
+## Following Query - Query Structure
 
 ```graphql
 query GetFollowing(
@@ -7270,22 +6929,17 @@ Following relationships are created through:
 
 ## Related
 
-- [Signals from Following](/docs/graphql-api/queries/signals/signals-from-following) - Activity from followed accounts
-- [Positions from Following](./positions-from-following) - Positions from followed accounts
-- [Social Graph Example](/docs/graphql-api/examples/social-graph) - Building social features
-
----
-title: "List Accounts"
-description: "Query multiple accounts with filtering and pagination"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-accounts"
----
+- [Signals from Following](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) - Activity from followed accounts
+- [Positions from Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following) - Positions from followed accounts
+- [Social Graph Example](https://docs.intuition.systems/docs/graphql-api/examples/social-graph) - Building social features
 
 # List Accounts
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-accounts
+
 Query multiple accounts with filtering, sorting, and pagination.
 
-## Query Structure
+## List Accounts - Query Structure
 
 ```graphql
 query GetAccounts(
@@ -7490,18 +7144,13 @@ accounts(where: { label: { _eq: "vitalik.eth" } })
 
 ## Related
 
-- [Single Account](./single-account) - Query individual accounts
-- [Following](./following) - Social relationships
-- [Aggregations](/docs/graphql-api/queries/advanced/aggregations) - Aggregate patterns
-
----
-title: "Account Queries"
-description: "Query account data, social relationships, and positions"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/overview"
----
+- [Single Account](https://docs.intuition.systems/docs/graphql-api/queries/accounts/single-account) - Query individual accounts
+- [Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Social relationships
+- [Aggregations](https://docs.intuition.systems/docs/graphql-api/queries/advanced/aggregations) - Aggregate patterns
 
 # Account Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/accounts/overview
 
 Query account information including profile data, social relationships (following), and positions from followed accounts.
 
@@ -7509,10 +7158,10 @@ Query account information including profile data, social relationships (followin
 
 | Query | Description |
 |-------|-------------|
-| [`account`](./single-account) | Query a single account by address |
-| [`accounts`](./list-accounts) | Query multiple accounts with filtering |
-| [`following`](./following) | Query following relationships |
-| [`positions_from_following`](./positions-from-following) | Query positions from followed accounts |
+| [`account`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/single-account) | Query a single account by address |
+| [`accounts`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-accounts) | Query multiple accounts with filtering |
+| [`following`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) | Query following relationships |
+| [`positions_from_following`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following) | Query positions from followed accounts |
 
 ## What Are Accounts?
 
@@ -7560,23 +7209,18 @@ const data = await client.request(query, {
 
 ## Related Documentation
 
-- [Single Account](./single-account) - Query individual accounts
-- [List Accounts](./list-accounts) - Query multiple accounts
-- [Following](./following) - Social relationships
-- [Positions from Following](./positions-from-following) - Social position data
-
----
-title: "Positions from Following"
-description: "Query positions held by accounts you follow"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following"
----
+- [Single Account](https://docs.intuition.systems/docs/graphql-api/queries/accounts/single-account) - Query individual accounts
+- [List Accounts](https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-accounts) - Query multiple accounts
+- [Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Social relationships
+- [Positions from Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following) - Social position data
 
 # Positions from Following
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following
+
 Query positions (stakes) held by accounts that a user follows. This enables building social portfolio views and discovering popular investments within your network.
 
-## Query Structure
+## Positions from Following - Query Structure
 
 ```graphql
 query GetPositionsFromFollowing(
@@ -7912,22 +7556,17 @@ query GetNetworkStats($account_id: String!) {
 
 ## Related
 
-- [Following](./following) - Who an account follows
-- [Signals from Following](/docs/graphql-api/queries/signals/signals-from-following) - Activity from followed accounts
-- [User Positions](/docs/graphql-api/queries/vaults/user-positions) - Individual position queries
-
----
-title: "Single Account Query"
-description: "Query individual account details by address"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/single-account"
----
+- [Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Who an account follows
+- [Signals from Following](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) - Activity from followed accounts
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Individual position queries
 
 # Single Account Query
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/accounts/single-account
+
 Fetch detailed information about a specific account using its Ethereum address.
 
-## Query Structure
+## Single Account Query - Query Structure
 
 ```graphql
 query GetAccount($id: String!) {
@@ -8103,22 +7742,17 @@ async function accountExists(address: string): Promise<boolean> {
 
 ## Related
 
-- [List Accounts](./list-accounts) - Query multiple accounts
-- [Following](./following) - Account's social relationships
-- [User Positions](/docs/graphql-api/queries/vaults/user-positions) - Account's positions
-
----
-title: "Aggregations"
-description: "Statistical aggregations with count, sum, avg, stddev"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/aggregations"
----
+- [List Accounts](https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-accounts) - Query multiple accounts
+- [Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Account's social relationships
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Account's positions
 
 # Aggregations
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/advanced/aggregations
+
 Compute statistical aggregations without fetching all nodes.
 
-## Query Structure
+## Aggregations - Query Structure
 
 ```graphql
 query GetPositionStatistics($accountId: String!) {
@@ -8158,14 +7792,9 @@ query GetPositionStatistics($accountId: String!) {
 2. **Combine with filters** for targeted statistics
 3. **Include in paginated queries** for total counts
 
----
-title: "Database Functions"
-description: "Use backend functions for complex queries"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/database-functions"
----
-
 # Database Functions
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/advanced/database-functions
 
 Leverage backend functions for complex queries that would be inefficient client-side.
 
@@ -8250,18 +7879,13 @@ query SearchPositions($addresses: _text!, $searchFields: jsonb!) {
 3. **Less data transfer** over network
 4. **More maintainable** code
 
----
-title: "Pagination"
-description: "Offset-based pagination patterns"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/pagination"
----
-
 # Pagination
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/advanced/pagination
 
 Implement efficient offset-based pagination with total counts.
 
-## Query Structure
+## Pagination - Query Structure
 
 ```graphql
 query GetAtomsPage($limit: Int!, $offset: Int!) {
@@ -8300,18 +7924,13 @@ This fetches page 3 (items 41-60) when using 20 items per page.
 3. **Use reasonable limits** (10-100 items per page)
 4. **Calculate offset** as `(page - 1) * limit`
 
----
-title: "Predicate-Object Aggregations"
-description: "Query denormalized predicate-object collections"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/predicate-objects"
----
-
 # Predicate-Object Aggregations
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/advanced/predicate-objects
 
 Use the denormalized `predicate_objects` table for efficient collection queries.
 
-## Query Structure
+## Predicate-Object Aggregations - Query Structure
 
 ```graphql
 query GetPredicateObjects($predicateId: String!, $limit: Int!) {
@@ -8341,14 +7960,9 @@ query GetPredicateObjects($predicateId: String!, $limit: Int!) {
 3. **Pre-computed metrics** updated automatically
 4. **Order by triple_count** for popular collections
 
----
-title: "Time-Series Analysis"
-description: "Query pre-computed time-series aggregations for share prices, signals, and market state"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series"
----
-
 # Time-Series Analysis
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series
 
 The API provides pre-computed time-series tables (TimescaleDB continuous aggregates) for efficient analytics. These are available at four granularities: hourly, daily, weekly, and monthly.
 
@@ -8582,22 +8196,17 @@ query GetStateChanges($termId: String!, $limit: Int!) {
 
 ## Related
 
-- [Share Price Changes](/docs/graphql-api/queries/vaults/share-price-changes) - Raw share price change events
-- [Position Changes](/docs/graphql-api/queries/vaults/position-changes) - Daily/hourly position change aggregates
-- [Aggregations](/docs/graphql-api/queries/advanced/aggregations) - Custom aggregations on any table
-
----
-title: "List and Filter Atoms"
-description: "Filter atoms by type, creator, date, and other criteria"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/list-filter"
----
+- [Share Price Changes](https://docs.intuition.systems/docs/graphql-api/queries/vaults/share-price-changes) - Raw share price change events
+- [Position Changes](https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes) - Daily/hourly position change aggregates
+- [Aggregations](https://docs.intuition.systems/docs/graphql-api/queries/advanced/aggregations) - Custom aggregations on any table
 
 # List and Filter Atoms
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/atoms/list-filter
+
 Query multiple atoms with filtering, sorting, and pagination to find specific entities in the knowledge graph.
 
-## Query Structure
+## List and Filter Atoms - Query Structure
 
 ```graphql
 query GetAtomsByType($type: atom_type!, $limit: Int!) {
@@ -8932,9 +8541,9 @@ const query = `
 
 ## Related Patterns
 
-- [Single Atom](/docs/graphql-api/queries/atoms/single-atom) - Fetch individual atom
-- [Atom Search](/docs/graphql-api/queries/atoms/search) - Full-text search
-- [Best Practices: Filtering](/docs/graphql-api/best-practices/filtering) - Efficient filtering strategies
+- [Single Atom](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) - Fetch individual atom
+- [Atom Search](https://docs.intuition.systems/docs/graphql-api/queries/atoms/search) - Full-text search
+- [Best Practices: Filtering](https://docs.intuition.systems/docs/graphql-api/best-practices/filtering) - Efficient filtering strategies
 
 ## Best Practices
 
@@ -8944,18 +8553,13 @@ const query = `
 4. **Combine with aggregates** when you need total counts
 5. **Order results** for consistent pagination
 
----
-title: "Atom Search"
-description: "Full-text and pattern matching search for atoms"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/search"
----
-
 # Atom Search
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/atoms/search
 
 Search atoms using pattern matching and full-text query patterns.
 
-## Query Structure
+## Atom Search - Query Structure
 
 ### Pattern Matching Search
 
@@ -9101,8 +8705,8 @@ const query = `
 
 ## Related Patterns
 
-- [Global Search](/docs/graphql-api/examples/complex-filtering) - Search across all entities
-- [Best Practices: Performance](/docs/graphql-api/best-practices/performance) - Optimize searches
+- [Global Search](https://docs.intuition.systems/docs/graphql-api/examples/complex-filtering) - Search across all entities
+- [Best Practices: Performance](https://docs.intuition.systems/docs/graphql-api/best-practices/performance) - Optimize searches
 
 ## Best Practices
 
@@ -9111,18 +8715,13 @@ const query = `
 3. **Combine with type filters** to narrow results
 4. **Limit results** to prevent over-fetching
 
----
-title: "Single Atom Query"
-description: "Fetch individual atom details by term ID"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom"
----
-
 # Single Atom Query
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom
 
 Fetch detailed information about a specific atom using its term ID. This is the most efficient way to retrieve atom data using a primary key lookup.
 
-## Query Structure
+## Single Atom Query - Query Structure
 
 ```graphql
 query GetAtom($id: String!) {
@@ -9301,9 +8900,9 @@ const query = `
 
 ## Related Patterns
 
-- [List Atoms with Filtering](/docs/graphql-api/queries/atoms/list-filter) - Filter atoms by type, creator, date
-- [Atom with Vault Details](/docs/graphql-api/queries/atoms/with-vault) - Include vault information
-- [Atom with Triples](/docs/graphql-api/queries/atoms/with-triples) - Find related triples
+- [List Atoms with Filtering](https://docs.intuition.systems/docs/graphql-api/queries/atoms/list-filter) - Filter atoms by type, creator, date
+- [Atom with Vault Details](https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-vault) - Include vault information
+- [Atom with Triples](https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-triples) - Find related triples
 
 ## Common Errors
 
@@ -9327,22 +8926,17 @@ const query = `
 
 ## See Also
 
-- [SDK: Create Atoms](/docs/intuition-sdk/examples/create-atom-from-string) - Create atoms to query
-- [Protocol: Atom Functions](/docs/protocol/api-reference/multivault/atoms) - Low-level atom creation
-- [Core Concepts: Atoms](/docs/intuition-concepts/primitives/Atoms/fundamentals) - Understanding atoms
-
----
-title: "Atom with Related Triples"
-description: "Find triples where an atom appears as subject, predicate, or object"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-triples"
----
+- [SDK: Create Atoms](https://docs.intuition.systems/docs/intuition-sdk/examples/create-atom-from-string) - Create atoms to query
+- [Protocol: Atom Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms) - Low-level atom creation
+- [Core Concepts: Atoms](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals) - Understanding atoms
 
 # Atom with Related Triples
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-triples
+
 Discover relationships by finding all triples where an atom appears as subject, predicate, or object.
 
-## Query Structure
+## Atom with Related Triples - Query Structure
 
 ```graphql
 query GetAtomWithTriples($atomId: String!, $limit: Int!) {
@@ -9474,8 +9068,8 @@ const query = `
 
 ## Related Patterns
 
-- [Single Triple](/docs/graphql-api/queries/triples/single-triple) - Query triple details
-- [Filter Triples](/docs/graphql-api/queries/triples/filter-by-subject) - Advanced filtering
+- [Single Triple](https://docs.intuition.systems/docs/graphql-api/queries/triples/single-triple) - Query triple details
+- [Filter Triples](https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-subject) - Advanced filtering
 
 ## Best Practices
 
@@ -9484,18 +9078,13 @@ const query = `
 3. **Order by created_at** for chronological results
 4. **Avoid excessive nesting** to prevent slow queries
 
----
-title: "Atom with Vault Details"
-description: "Query atoms with nested vault information and statistics"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-vault"
----
-
 # Atom with Vault Details
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-vault
 
 Fetch atom data along with associated vault statistics, including total shares, current share price, market cap, and position count.
 
-## Query Structure
+## Atom with Vault Details - Query Structure
 
 ```graphql
 query GetAtomWithVault($atomId: String!, $curveId: numeric!) {
@@ -9673,9 +9262,9 @@ const query = `
 
 ## Related Patterns
 
-- [Single Atom](/docs/graphql-api/queries/atoms/single-atom) - Basic atom query
-- [Vault Details](/docs/graphql-api/queries/vaults/vault-details) - Detailed vault queries
-- [User Positions](/docs/graphql-api/queries/vaults/user-positions) - Query user positions
+- [Single Atom](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) - Basic atom query
+- [Vault Details](https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details) - Detailed vault queries
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Query user positions
 
 ## Best Practices
 
@@ -9684,18 +9273,13 @@ const query = `
 3. **Use variables** for dynamic values
 4. **Cache market data** as it updates frequently
 
----
-title: "Get Chart JSON"
-description: "Get chart data as structured JSON"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json"
----
-
 # Get Chart JSON
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json
 
 Retrieve chart data in structured JSON format for use with charting libraries.
 
-## Query Structure
+## Get Chart JSON - Query Structure
 
 ```graphql
 query GetChartJson($input: GetChartJsonInput!) {
@@ -9818,21 +9402,16 @@ async function getChartData(termId: string, curveId: string, days: number = 30) 
 
 ## Related
 
-- [Chart Raw JSON](./chart-raw-json) - Raw JSON format (same input/output types)
-- [Chart SVG](./chart-svg) - Pre-rendered SVG charts
-
----
-title: "Get Chart Raw JSON"
-description: "Get raw chart data as JSON"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-json"
----
+- [Chart Raw JSON](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-json) - Raw JSON format (same input/output types)
+- [Chart SVG](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) - Pre-rendered SVG charts
 
 # Get Chart Raw JSON
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-json
+
 Retrieve raw chart data in JSON format. Uses the same input and output types as `getChartJson`.
 
-## Query Structure
+## Get Chart Raw JSON - Query Structure
 
 ```graphql
 query GetChartRawJson($input: GetChartJsonInput!) {
@@ -9852,7 +9431,7 @@ query GetChartRawJson($input: GetChartJsonInput!) {
 
 ## Variables
 
-Same as [`getChartJson`](./chart-json) -- takes `GetChartJsonInput`:
+Same as [`getChartJson`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) -- takes `GetChartJsonInput`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -9888,21 +9467,16 @@ Same as [`getChartJson`](./chart-json) -- takes `GetChartJsonInput`:
 
 ## Related
 
-- [Chart JSON](./chart-json) - Formatted chart data (same types)
-- [Chart SVG](./chart-svg) - Pre-rendered charts
-
----
-title: "Get Chart Raw SVG"
-description: "Get minimal raw SVG chart output"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-svg"
----
+- [Chart JSON](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) - Formatted chart data (same types)
+- [Chart SVG](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) - Pre-rendered charts
 
 # Get Chart Raw SVG
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-svg
+
 Retrieve a minimal SVG chart, suitable for custom post-processing or styling. Uses the same input type as `getChartSvg`.
 
-## Query Structure
+## Get Chart Raw SVG - Query Structure
 
 ```graphql
 query GetChartRawSvg($input: GetChartSvgInput!) {
@@ -9914,7 +9488,7 @@ query GetChartRawSvg($input: GetChartSvgInput!) {
 
 ## Variables
 
-Same as [`getChartSvg`](./chart-svg) -- takes `GetChartSvgInput`:
+Same as [`getChartSvg`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) -- takes `GetChartSvgInput`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -9951,21 +9525,16 @@ Same as [`getChartSvg`](./chart-svg) -- takes `GetChartSvgInput`:
 
 ## Related
 
-- [Chart SVG](./chart-svg) - Fully styled SVG charts
-- [Chart JSON](./chart-json) - JSON data for custom rendering
-
----
-title: "Get Chart SVG"
-description: "Get chart rendered as SVG"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg"
----
+- [Chart SVG](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) - Fully styled SVG charts
+- [Chart JSON](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) - JSON data for custom rendering
 
 # Get Chart SVG
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg
+
 Retrieve a pre-rendered chart as an SVG image, ready for embedding in HTML or documents.
 
-## Query Structure
+## Get Chart SVG - Query Structure
 
 ```graphql
 query GetChartSvg($input: GetChartSvgInput!) {
@@ -10081,17 +9650,12 @@ async function displayChart(termId: string, curveId: string, containerId: string
 
 ## Related
 
-- [Chart Raw SVG](./chart-raw-svg) - Minimal SVG output
-- [Chart JSON](./chart-json) - JSON data for custom rendering
-
----
-title: "Chart Operations"
-description: "Generate charts as JSON or SVG format"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/overview"
----
+- [Chart Raw SVG](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-svg) - Minimal SVG output
+- [Chart JSON](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) - JSON data for custom rendering
 
 # Chart Operations
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/charts/overview
 
 The Intuition GraphQL API provides chart generation operations to create visualizations of protocol data. These operations return chart data in either JSON or SVG format for flexible integration.
 
@@ -10099,10 +9663,10 @@ The Intuition GraphQL API provides chart generation operations to create visuali
 
 | Operation | Description |
 |-----------|-------------|
-| [`getChartJson`](./chart-json) | Get chart data as structured JSON |
-| [`getChartRawJson`](./chart-raw-json) | Get raw chart JSON data |
-| [`getChartSvg`](./chart-svg) | Get chart rendered as SVG |
-| [`getChartRawSvg`](./chart-raw-svg) | Get raw SVG chart data |
+| [`getChartJson`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) | Get chart data as structured JSON |
+| [`getChartRawJson`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-json) | Get raw chart JSON data |
+| [`getChartSvg`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) | Get chart rendered as SVG |
+| [`getChartRawSvg`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-svg) | Get raw SVG chart data |
 
 ## Use Cases
 
@@ -10165,22 +9729,17 @@ document.getElementById('chart').innerHTML = svg.getChartSvg
 
 ## Related Documentation
 
-- [Chart JSON](./chart-json) - JSON chart data
-- [Chart SVG](./chart-svg) - SVG chart rendering
-- [Time Series Queries](/docs/graphql-api/queries/advanced/time-series) - Raw time-series data
-
----
-title: "Aggregate Events"
-description: "Aggregate statistics for blockchain events"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/events/aggregate-events"
----
+- [Chart JSON](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) - JSON chart data
+- [Chart SVG](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) - SVG chart rendering
+- [Time Series Queries](https://docs.intuition.systems/docs/graphql-api/queries/advanced/time-series) - Raw time-series data
 
 # Aggregate Events
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/events/aggregate-events
+
 Query aggregate statistics for blockchain events.
 
-## Query Structure
+## Aggregate Events - Query Structure
 
 ```graphql
 query GetEventsAggregate($where: events_bool_exp) {
@@ -10276,21 +9835,16 @@ async function getDailyEventCounts(date: Date) {
 
 ## Related
 
-- [List Events](./list-events) - Individual events
-- [Protocol Stats](/docs/graphql-api/queries/stats/protocol-stats) - Higher-level statistics
-
----
-title: "List Events"
-description: "Query raw blockchain events with filtering"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/events/list-events"
----
+- [List Events](https://docs.intuition.systems/docs/graphql-api/queries/events/list-events) - Individual events
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Higher-level statistics
 
 # List Events
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/events/list-events
+
 Query raw blockchain events with filtering, sorting, and pagination.
 
-## Query Structure
+## List Events - Query Structure
 
 ```graphql
 query GetEvents(
@@ -10490,17 +10044,12 @@ events(where: {
 
 ## Related
 
-- [Aggregate Events](./aggregate-events) - Event statistics
-- [Signals](/docs/graphql-api/queries/signals/overview) - Enriched event data
-
----
-title: "Events Queries"
-description: "Query raw blockchain events from the Intuition protocol"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/events/overview"
----
+- [Aggregate Events](https://docs.intuition.systems/docs/graphql-api/queries/events/aggregate-events) - Event statistics
+- [Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/overview) - Enriched event data
 
 # Events Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/events/overview
 
 Query raw blockchain events emitted by the Intuition protocol contracts. Events provide low-level access to all protocol interactions.
 
@@ -10508,8 +10057,8 @@ Query raw blockchain events emitted by the Intuition protocol contracts. Events 
 
 | Query | Description |
 |-------|-------------|
-| [`events`](./list-events) | Query events with filtering and pagination |
-| [`events_aggregate`](./aggregate-events) | Aggregate statistics for events |
+| [`events`](https://docs.intuition.systems/docs/graphql-api/queries/events/list-events) | Query events with filtering and pagination |
+| [`events_aggregate`](https://docs.intuition.systems/docs/graphql-api/queries/events/aggregate-events) | Aggregate statistics for events |
 
 ## What Are Events?
 
@@ -10568,22 +10117,17 @@ const data = await client.request(query, { limit: 20 })
 
 ## Related Documentation
 
-- [List Events](./list-events) - Query events with filters
-- [Aggregate Events](./aggregate-events) - Event statistics
-- [Signals](/docs/graphql-api/queries/signals/overview) - Enriched event data
-
----
-title: "Account PnL Rank"
-description: "Query a single account's leaderboard rank and percentile"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank"
----
+- [List Events](https://docs.intuition.systems/docs/graphql-api/queries/events/list-events) - Query events with filters
+- [Aggregate Events](https://docs.intuition.systems/docs/graphql-api/queries/events/aggregate-events) - Event statistics
+- [Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/overview) - Enriched event data
 
 # Account PnL Rank
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank
+
 Look up a single account's leaderboard rank and percentile using `get_account_pnl_rank`. Returns `account_pnl_rank` rows.
 
-## Query Structure
+## Account PnL Rank - Query Structure
 
 ```graphql
 query GetAccountPnlRank {
@@ -10697,22 +10241,17 @@ async function getAccountRank(accountId: string) {
 
 ## Related
 
-- [PnL Leaderboard](./pnl-leaderboard) - Full leaderboard rankings
-- [Leaderboard Stats](./leaderboard-stats) - Aggregate protocol statistics
-- [Account PnL Current](/docs/graphql-api/queries/pnl/account-pnl-current) - Detailed PnL snapshot
-
----
-title: "Leaderboard Stats"
-description: "Query aggregate leaderboard statistics for the protocol"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats"
----
+- [PnL Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) - Full leaderboard rankings
+- [Leaderboard Stats](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats) - Aggregate protocol statistics
+- [Account PnL Current](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) - Detailed PnL snapshot
 
 # Leaderboard Stats
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats
+
 Get aggregate protocol-level statistics using `get_pnl_leaderboard_stats`. Returns `pnl_leaderboard_stats` rows with metrics like total traders, average PnL, and profitability rates.
 
-## Query Structure
+## Leaderboard Stats - Query Structure
 
 ```graphql
 query GetPnlLeaderboardStats {
@@ -10814,20 +10353,13 @@ async function getProtocolStats() {
 
 ## Related
 
-- [PnL Leaderboard](./pnl-leaderboard) - Individual trader rankings
-- [Account Rank](./account-rank) - Single account rank lookup
-- [Protocol Stats](/docs/graphql-api/queries/stats/protocol-stats) - Other protocol-level statistics
-
----
-title: "Leaderboard Queries Overview"
-description: "Leaderboard queries for ranking accounts and vaults by PnL performance"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/overview"
----
+- [PnL Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) - Individual trader rankings
+- [Account Rank](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) - Single account rank lookup
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Other protocol-level statistics
 
 # Leaderboard Queries Overview
 
-# Leaderboard Queries
+Source: https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/overview
 
 The Intuition GraphQL API provides leaderboard queries for ranking accounts and vaults by PnL performance. These are exposed as Hasura SQL functions that return `pnl_leaderboard_entry` rows.
 
@@ -10837,22 +10369,22 @@ The Intuition GraphQL API provides leaderboard queries for ranking accounts and 
 
 | Operation | Description |
 |-----------|-------------|
-| [`get_pnl_leaderboard`](./pnl-leaderboard) | Full PnL leaderboard with filtering and sorting |
-| [`get_pnl_leaderboard_period`](./pnl-leaderboard#period-scoped) | Period-scoped PnL leaderboard with date range |
+| [`get_pnl_leaderboard`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) | Full PnL leaderboard with filtering and sorting |
+| [`get_pnl_leaderboard_period`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard#period-scoped) | Period-scoped PnL leaderboard with date range |
 
 ### Vault Leaderboard
 
 | Operation | Description |
 |-----------|-------------|
-| [`get_vault_leaderboard`](./vault-leaderboard) | Vault-level leaderboard filtered by term and curve |
-| [`get_pnl_leaderboard_period`](./vault-leaderboard#period-scoped) | Period-scoped leaderboard with date range (use `p_term_id`/`p_curve_id` for vault scoping) |
+| [`get_vault_leaderboard`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard) | Vault-level leaderboard filtered by term and curve |
+| [`get_pnl_leaderboard_period`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard#period-scoped) | Period-scoped leaderboard with date range (use `p_term_id`/`p_curve_id` for vault scoping) |
 
 ### Account Rank & Stats
 
 | Operation | Description |
 |-----------|-------------|
-| [`get_account_pnl_rank`](./account-rank) | Single account rank and percentile |
-| [`get_pnl_leaderboard_stats`](./leaderboard-stats) | Aggregate protocol-level leaderboard statistics |
+| [`get_account_pnl_rank`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) | Single account rank and percentile |
+| [`get_pnl_leaderboard_stats`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats) | Aggregate protocol-level leaderboard statistics |
 
 ### Direct Table Queries
 
@@ -10890,24 +10422,19 @@ query {
 
 ## Related Documentation
 
-- [PnL Leaderboard](./pnl-leaderboard) - Full PnL leaderboard
-- [Vault Leaderboard](./vault-leaderboard) - Vault-level leaderboard
-- [Account Rank](./account-rank) - Single account rank lookup
-- [Leaderboard Stats](./leaderboard-stats) - Aggregate statistics
-- [PnL Queries](/docs/graphql-api/queries/pnl/overview) - Account and position PnL data
-
----
-title: "PnL Leaderboard"
-description: "Query the PnL leaderboard to rank accounts by trading performance"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard"
----
+- [PnL Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) - Full PnL leaderboard
+- [Vault Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard) - Vault-level leaderboard
+- [Account Rank](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) - Single account rank lookup
+- [Leaderboard Stats](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats) - Aggregate statistics
+- [PnL Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview) - Account and position PnL data
 
 # PnL Leaderboard
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard
+
 Rank accounts by PnL performance using `get_pnl_leaderboard` and `get_pnl_leaderboard_period`. Both return `pnl_leaderboard_entry` rows.
 
-## Query Structure
+## PnL Leaderboard - Query Structure
 
 ```graphql
 query GetPnlLeaderboard {
@@ -11085,22 +10612,17 @@ query GetPnlLeaderboardPeriod {
 
 ## Related
 
-- [Vault Leaderboard](./vault-leaderboard) - Vault-level rankings
-- [Account Rank](./account-rank) - Single account rank lookup
-- [Leaderboard Stats](./leaderboard-stats) - Aggregate statistics
-
----
-title: "Vault Leaderboard"
-description: "Query vault-level leaderboard rankings by PnL performance"
-last_updated: "2026-04-01T08:45:01-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard"
----
+- [Vault Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard) - Vault-level rankings
+- [Account Rank](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) - Single account rank lookup
+- [Leaderboard Stats](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/leaderboard-stats) - Aggregate statistics
 
 # Vault Leaderboard
 
-Rank accounts within specific vaults using `get_vault_leaderboard` and `get_pnl_leaderboard_period`. Both return `pnl_leaderboard_entry` rows (same schema as the [PnL Leaderboard](./pnl-leaderboard)).
+Source: https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard
 
-## Query Structure
+Rank accounts within specific vaults using `get_vault_leaderboard` and `get_pnl_leaderboard_period`. Both return `pnl_leaderboard_entry` rows (same schema as the [PnL Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard)).
+
+## Vault Leaderboard - Query Structure
 
 ```graphql
 query GetVaultLeaderboard {
@@ -11178,7 +10700,7 @@ query GetVaultLeaderboardPeriod {
 
 ## Response Fields
 
-Returns `pnl_leaderboard_entry` rows -- see the [full field reference](./pnl-leaderboard#response-fields-pnl_leaderboard_entry) on the PnL Leaderboard page.
+Returns `pnl_leaderboard_entry` rows -- see the [full field reference](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard#response-fields-pnl_leaderboard_entry) on the PnL Leaderboard page.
 
 ## Interactive Example
 
@@ -11207,22 +10729,17 @@ Returns `pnl_leaderboard_entry` rows -- see the [full field reference](./pnl-lea
 
 ## Related
 
-- [PnL Leaderboard](./pnl-leaderboard) - Protocol-wide leaderboard
-- [Account Rank](./account-rank) - Single account rank lookup
-- [Vault Details](/docs/graphql-api/queries/vaults/vault-details) - Vault information
-
----
-title: "Account PnL Chart"
-description: "Query historical Profit and Loss data for charting"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart"
----
+- [PnL Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) - Protocol-wide leaderboard
+- [Account Rank](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/account-rank) - Single account rank lookup
+- [Vault Details](https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details) - Vault information
 
 # Account PnL Chart
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart
+
 Get historical Profit and Loss (PnL) time-series data for an account, suitable for charting portfolio performance over configurable intervals.
 
-## Query Structure
+## Account PnL Chart - Query Structure
 
 ```graphql
 query GetAccountPnlChart($input: GetAccountPnlChartInput!) {
@@ -11378,22 +10895,17 @@ async function getPnlChartData(accountId: string, days: number = 30) {
 
 ## Related
 
-- [Account PnL Current](./account-pnl-current) - Current PnL snapshot
-- [Position PnL Chart](./position-pnl-chart) - Position-level charts
-- [Account PnL Realized](./account-pnl-realized) - Realized PnL data
-
----
-title: "Account PnL Current"
-description: "Query current Profit and Loss snapshot for an account"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current"
----
+- [Account PnL Current](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) - Current PnL snapshot
+- [Position PnL Chart](https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pnl-chart) - Position-level charts
+- [Account PnL Realized](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) - Realized PnL data
 
 # Account PnL Current
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current
+
 Get the current Profit and Loss (PnL) snapshot for an account, including equity value, net invested amount, and unrealized gains.
 
-## Query Structure
+## Account PnL Current - Query Structure
 
 ```graphql
 query GetAccountPnlCurrent($input: GetAccountPnlCurrentInput!) {
@@ -11523,22 +11035,17 @@ console.log(`Total PnL: ${pnl.total_pnl} (${pnl.pnl_pct}%)`)
 
 ## Related
 
-- [Account PnL Chart](./account-pnl-chart) - Historical PnL data
-- [Account PnL Realized](./account-pnl-realized) - Realized PnL data
-- [User Positions](/docs/graphql-api/queries/vaults/user-positions) - Underlying position data
-
----
-title: "Account PnL Realized"
-description: "Query realized Profit and Loss data for an account"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized"
----
+- [Account PnL Chart](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) - Historical PnL data
+- [Account PnL Realized](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) - Realized PnL data
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Underlying position data
 
 # Account PnL Realized
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized
+
 Get realized Profit and Loss (PnL) data for an account over a specified time range.
 
-## Query Structure
+## Account PnL Realized - Query Structure
 
 ```graphql
 query GetAccountPnlRealized($input: GetAccountPnlRealizedInput!) {
@@ -11683,20 +11190,15 @@ async function getRealizedPnl(accountId: string, days: number = 30) {
 
 ## Related
 
-- [Account PnL Current](./account-pnl-current) - Current PnL including unrealized
-- [Account PnL Chart](./account-pnl-chart) - Historical PnL trends
-- [User Positions](/docs/graphql-api/queries/vaults/user-positions) - Active positions
-
----
-title: "PnL Queries Overview"
-description: "Profit and Loss (PnL) queries for tracking account and position performance"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview"
----
+- [Account PnL Current](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) - Current PnL including unrealized
+- [Account PnL Chart](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) - Historical PnL trends
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Active positions
 
 # PnL Queries Overview
 
-# Profit & Loss (PnL) Queries
+Source: https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview
+
+## Profit & Loss (PnL) Queries
 
 The Intuition GraphQL API provides Profit and Loss (PnL) queries to track portfolio performance, analyze realized gains, and visualize value changes over time. These queries are powered by the chart-api service and exposed through Hasura as GraphQL actions.
 
@@ -11704,10 +11206,10 @@ The Intuition GraphQL API provides Profit and Loss (PnL) queries to track portfo
 
 | Operation | Description |
 |-----------|-------------|
-| [`getAccountPnlCurrent`](./account-pnl-current) | Current account PnL snapshot with equity value, net invested, and unrealized gains |
-| [`getAccountPnlChart`](./account-pnl-chart) | Account PnL time-series data with configurable intervals |
-| [`getAccountPnlRealized`](./account-pnl-realized) | Realized PnL data for an account over a time range |
-| [`getPositionPnlChart`](./position-pnl-chart) | Position-level PnL time-series for a specific vault |
+| [`getAccountPnlCurrent`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) | Current account PnL snapshot with equity value, net invested, and unrealized gains |
+| [`getAccountPnlChart`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) | Account PnL time-series data with configurable intervals |
+| [`getAccountPnlRealized`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) | Realized PnL data for an account over a time range |
+| [`getPositionPnlChart`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pnl-chart) | Position-level PnL time-series for a specific vault |
 
 ## PnL Methodology
 
@@ -11767,23 +11269,18 @@ Generate performance reports with:
 
 ## Related Documentation
 
-- [Account PnL Current](./account-pnl-current) - Current PnL snapshot
-- [Account PnL Chart](./account-pnl-chart) - Historical PnL data
-- [Account PnL Realized](./account-pnl-realized) - Realized PnL data
-- [Position PnL Chart](./position-pnl-chart) - Position-level tracking
-
----
-title: "Position PnL Chart"
-description: "Query historical Profit and Loss data for a specific position"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pnl-chart"
----
+- [Account PnL Current](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) - Current PnL snapshot
+- [Account PnL Chart](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) - Historical PnL data
+- [Account PnL Realized](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) - Realized PnL data
+- [Position PnL Chart](https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pnl-chart) - Position-level tracking
 
 # Position PnL Chart
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pnl-chart
+
 Get historical Profit and Loss (PnL) time-series data for a specific position, identified by account, term, and curve.
 
-## Query Structure
+## Position PnL Chart - Query Structure
 
 ```graphql
 query GetPositionPnlChart($input: GetPositionPnlChartInput!) {
@@ -11966,18 +11463,13 @@ async function getPositionPerformance(
 
 ## Related
 
-- [Account PnL Chart](./account-pnl-chart) - Portfolio-level PnL charts
-- [Account PnL Realized](./account-pnl-realized) - Realized PnL data
-- [Vault Details](/docs/graphql-api/queries/vaults/vault-details) - Vault information for the position
-
----
-title: "Search Queries"
-description: "Search atoms, terms, and positions"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/search/overview"
----
+- [Account PnL Chart](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) - Portfolio-level PnL charts
+- [Account PnL Realized](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) - Realized PnL data
+- [Vault Details](https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details) - Vault information for the position
 
 # Search Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/search/overview
 
 Search the Intuition knowledge graph for atoms, terms, and positions using text-based queries.
 
@@ -11985,9 +11477,9 @@ Search the Intuition knowledge graph for atoms, terms, and positions using text-
 
 | Query | Description |
 |-------|-------------|
-| [`search_term`](./search-term) | Search atoms and terms by text |
-| [`search_term_from_following`](./search-from-following) | Search within followed accounts' activity |
-| [`search_positions_on_subject`](./search-positions) | Find positions related to a subject |
+| [`search_term`](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) | Search atoms and terms by text |
+| [`search_term_from_following`](https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following) | Search within followed accounts' activity |
+| [`search_positions_on_subject`](https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions) | Find positions related to a subject |
 
 ## Quick Start
 
@@ -12029,22 +11521,17 @@ const data = await client.request(query, {
 
 ## Related Documentation
 
-- [Search Term](./search-term) - Basic search
-- [Search from Following](./search-from-following) - Social search
-- [Search Positions](./search-positions) - Position-based search
-
----
-title: "Search from Following"
-description: "Search within followed accounts' activity"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following"
----
+- [Search Term](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) - Basic search
+- [Search from Following](https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following) - Social search
+- [Search Positions](https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions) - Position-based search
 
 # Search from Following
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following
+
 Search for terms within the context of accounts you follow, prioritizing results from your social network.
 
-## Query Structure
+## Search from Following - Query Structure
 
 ```graphql
 query SearchTermFromFollowing(
@@ -12174,23 +11661,16 @@ function SocialSearch({ address }: { address: string }) {
 
 ## Related
 
-- [Search Term](./search-term) - Global search
-- [Following](/docs/graphql-api/queries/accounts/following) - Following relationships
-
----
-title: "Search Positions"
-description: "Search positions on a specific subject"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions"
----
-
-# Search Positions
+- [Search Term](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) - Global search
+- [Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Following relationships
 
 # Search Positions on Subject
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions
+
 Search for positions (stakes) related to a specific subject. This function takes an array of addresses and a JSONB search fields object to filter positions.
 
-## Query Structure
+## Search Positions on Subject - Query Structure
 
 ```graphql
 query SearchPositionsOnSubject(
@@ -12315,21 +11795,16 @@ async function getPositionsForAccounts(addresses: string[]) {
 
 ## Related
 
-- [Search Term](./search-term) - Search atoms by text
-- [User Positions](/docs/graphql-api/queries/vaults/user-positions) - Account position queries
-
----
-title: "Search Term"
-description: "Search atoms and terms by text"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/search/search-term"
----
+- [Search Term](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) - Search atoms by text
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Account position queries
 
 # Search Term
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/search/search-term
+
 Search for atoms by their label or data content.
 
-## Query Structure
+## Search Term - Query Structure
 
 ```graphql
 query SearchTerm(
@@ -12533,22 +12008,17 @@ async function searchByType(
 
 ## Related
 
-- [Search from Following](./search-from-following) - Social search
-- [Search Positions](./search-positions) - Position search
-- [List Atoms](/docs/graphql-api/queries/atoms/list-filter) - Filter-based atom queries
-
----
-title: "Aggregate Signals"
-description: "Aggregate statistics for signals"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/aggregate-signals"
----
+- [Search from Following](https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following) - Social search
+- [Search Positions](https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions) - Position search
+- [List Atoms](https://docs.intuition.systems/docs/graphql-api/queries/atoms/list-filter) - Filter-based atom queries
 
 # Aggregate Signals
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/signals/aggregate-signals
+
 Query aggregate statistics for signals including counts, sums, and averages.
 
-## Query Structure
+## Aggregate Signals - Query Structure
 
 ```graphql
 query GetSignalsAggregate($where: signals_bool_exp) {
@@ -12839,22 +12309,17 @@ query GetSignalsByAtom {
 
 ## Related
 
-- [List Signals](./list-signals) - Individual signals
-- [Signals from Following](./signals-from-following) - Social signals
-- [Protocol Stats](/docs/graphql-api/queries/stats/protocol-stats) - Overall statistics
-
----
-title: "List Signals"
-description: "Query signals (deposits/redemptions) with filtering and pagination"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals"
----
+- [List Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals) - Individual signals
+- [Signals from Following](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) - Social signals
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Overall statistics
 
 # List Signals
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals
+
 Query deposit and redemption signals with rich filtering, sorting, and pagination capabilities.
 
-## Query Structure
+## List Signals - Query Structure
 
 ```graphql
 query GetSignals(
@@ -13190,18 +12655,13 @@ signals(where: { triple_id: { _eq: "0x..." } })
 
 ## Related
 
-- [Aggregate Signals](./aggregate-signals) - Signal statistics
-- [Signals from Following](./signals-from-following) - Social feed
-- [Subscriptions](/docs/graphql-api/subscriptions/overview) - Real-time signals
-
----
-title: "Signals Queries"
-description: "Query deposit and redemption signals with rich context"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/overview"
----
+- [Aggregate Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/aggregate-signals) - Signal statistics
+- [Signals from Following](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) - Social feed
+- [Subscriptions](https://docs.intuition.systems/docs/graphql-api/subscriptions/overview) - Real-time signals
 
 # Signals Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/signals/overview
 
 Signals represent deposit and redemption events in the Intuition protocol. Unlike raw blockchain events, signals include enriched context such as account labels, atom metadata, and related positions.
 
@@ -13209,9 +12669,9 @@ Signals represent deposit and redemption events in the Intuition protocol. Unlik
 
 | Query | Description |
 |-------|-------------|
-| [`signals`](./list-signals) | Query signals with filtering and pagination |
-| [`signals_aggregate`](./aggregate-signals) | Aggregate statistics for signals |
-| [`signals_from_following`](./signals-from-following) | Query signals from followed accounts |
+| [`signals`](https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals) | Query signals with filtering and pagination |
+| [`signals_aggregate`](https://docs.intuition.systems/docs/graphql-api/queries/signals/aggregate-signals) | Aggregate statistics for signals |
+| [`signals_from_following`](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) | Query signals from followed accounts |
 
 ## What Are Signals?
 
@@ -13295,23 +12755,18 @@ signals(where: {
 
 ## Related Documentation
 
-- [List Signals](./list-signals) - Query signals with filters
-- [Aggregate Signals](./aggregate-signals) - Signal statistics
-- [Signals from Following](./signals-from-following) - Social signal feed
-- [Activity Feed Example](/docs/graphql-api/examples/activity-feed) - Building activity feeds
-
----
-title: "Signals from Following"
-description: "Query signals from accounts you follow"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following"
----
+- [List Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals) - Query signals with filters
+- [Aggregate Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/aggregate-signals) - Signal statistics
+- [Signals from Following](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) - Social signal feed
+- [Activity Feed Example](https://docs.intuition.systems/docs/graphql-api/examples/activity-feed) - Building activity feeds
 
 # Signals from Following
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following
+
 Query signals (deposits and redemptions) from accounts that a specific user follows. This enables building personalized social activity feeds.
 
-## Query Structure
+## Signals from Following - Query Structure
 
 ```graphql
 query GetSignalsFromFollowing(
@@ -13620,7 +13075,7 @@ The `signals_from_following` query uses the social graph built from:
 - "Follow" triples where the account is the subject
 - Positions on "Follow" atoms involving the account
 
-To see who an account follows, use the [Following Query](/docs/graphql-api/queries/accounts/following).
+To see who an account follows, use the [Following Query](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following).
 
 ## Best Practices
 
@@ -13631,22 +13086,17 @@ To see who an account follows, use the [Following Query](/docs/graphql-api/queri
 
 ## Related
 
-- [List Signals](./list-signals) - All signals
-- [Following Query](/docs/graphql-api/queries/accounts/following) - Who an account follows
-- [Subscriptions](/docs/graphql-api/subscriptions/overview) - Real-time updates
-
----
-title: "Fee Accruals"
-description: "Query protocol fee accrual records by epoch"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accruals"
----
+- [List Signals](https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals) - All signals
+- [Following Query](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Who an account follows
+- [Subscriptions](https://docs.intuition.systems/docs/graphql-api/subscriptions/overview) - Real-time updates
 
 # Fee Accruals
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accruals
+
 Query protocol fee accrual records. Fee accruals track protocol fees accumulated per epoch, including the sender and transaction details.
 
-## Query Structure
+## Fee Accruals - Query Structure
 
 ```graphql
 query GetFeeAccruals($limit: Int!, $offset: Int) {
@@ -13790,21 +13240,16 @@ protocol_fee_accruals(where: {
 
 ## Related
 
-- [Fee Transfers](./fee-transfers) - Individual fee transfer events
-- [Protocol Stats](./protocol-stats) - Aggregate protocol metrics
-
----
-title: "Fee Transfers"
-description: "Query protocol fee transfer events"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers"
----
+- [Fee Transfers](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers) - Individual fee transfer events
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Aggregate protocol metrics
 
 # Fee Transfers
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers
+
 Query protocol fee transfers - the fees collected by the protocol on each transaction.
 
-## Query Structure
+## Fee Transfers - Query Structure
 
 ```graphql
 query GetFeeTransfers(
@@ -14058,17 +13503,12 @@ fee_transfers(where: {
 
 ## Related
 
-- [Protocol Stats](./protocol-stats) - Overall protocol statistics
-- [Events](/docs/graphql-api/queries/events/overview) - Raw fee transfer events
-
----
-title: "Protocol Stats Queries"
-description: "Query protocol-wide statistics and fee transfers"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/overview"
----
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Overall protocol statistics
+- [Events](https://docs.intuition.systems/docs/graphql-api/queries/events/overview) - Raw fee transfer events
 
 # Protocol Stats Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/stats/overview
 
 Query protocol-wide statistics including total value locked (TVL), fee transfers, and aggregate metrics.
 
@@ -14076,9 +13516,9 @@ Query protocol-wide statistics including total value locked (TVL), fee transfers
 
 | Query | Description |
 |-------|-------------|
-| [`stats`](./protocol-stats) | Protocol-wide statistics and metrics |
-| [`fee_transfers`](./fee-transfers) | Protocol fee transfer events |
-| [`protocol_fee_accruals`](./fee-accruals) | Protocol fee accruals by epoch |
+| [`stats`](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) | Protocol-wide statistics and metrics |
+| [`fee_transfers`](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers) | Protocol fee transfer events |
+| [`protocol_fee_accruals`](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accruals) | Protocol fee accruals by epoch |
 
 ## Quick Start
 
@@ -14120,22 +13560,17 @@ const data = await client.request(query)
 
 ## Related Documentation
 
-- [Protocol Stats](./protocol-stats) - Detailed statistics
-- [Fee Transfers](./fee-transfers) - Fee transfer history
-- [Fee Accruals](./fee-accruals) - Fee accruals by epoch
-
----
-title: "Protocol Statistics"
-description: "Query protocol-wide statistics and metrics"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats"
----
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Detailed statistics
+- [Fee Transfers](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers) - Fee transfer history
+- [Fee Accruals](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accruals) - Fee accruals by epoch
 
 # Protocol Statistics
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats
+
 Query aggregate statistics for the entire Intuition protocol.
 
-## Query Structure
+## Protocol Statistics - Query Structure
 
 ```graphql
 query GetProtocolStats {
@@ -14295,21 +13730,16 @@ function ProtocolStats() {
 
 ## Related
 
-- [Fee Transfers](./fee-transfers) - Detailed fee history
-- [Aggregations](/docs/graphql-api/queries/advanced/aggregations) - Custom aggregations
-
----
-title: "Counter Triples"
-description: "Query opposing triple positions"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/counter-triples"
----
+- [Fee Transfers](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers) - Detailed fee history
+- [Aggregations](https://docs.intuition.systems/docs/graphql-api/queries/advanced/aggregations) - Custom aggregations
 
 # Counter Triples
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/counter-triples
+
 Query triples along with their counter (opposing) triples to see both sides of a claim.
 
-## Query Structure
+## Counter Triples - Query Structure
 
 ```graphql
 query GetTripleWithCounter($id: String!, $curveId: numeric!) {
@@ -14371,18 +13801,13 @@ query GetTripleWithCounter($id: String!, $curveId: numeric!) {
 3. **Filter by curve_id** for specific vaults
 4. **Show both sides** in UI for balanced view
 
----
-title: "Filter by Predicate-Object"
-description: "Query predicate-object aggregations and collections"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-predicate-object"
----
-
 # Filter by Predicate-Object
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-predicate-object
 
 Use the denormalized `predicate_objects` table to efficiently query pre-aggregated collections.
 
-## Query Structure
+## Filter by Predicate-Object - Query Structure
 
 ```graphql
 query GetPredicateObjects($predicateId: String!, $limit: Int!) {
@@ -14433,18 +13858,13 @@ query GetPredicateObjects($predicateId: String!, $limit: Int!) {
 3. **Filter by predicate** to find specific relationship types
 4. **More efficient** than aggregating raw triples
 
----
-title: "Filter Triples by Subject"
-description: "Find all triples with a specific atom as subject"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-subject"
----
-
 # Filter Triples by Subject
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-subject
 
 Query all triples where a specific atom is the subject.
 
-## Query Structure
+## Filter Triples by Subject - Query Structure
 
 ```graphql
 query GetTriplesBySubject($subjectId: String!, $limit: Int!) {
@@ -14489,18 +13909,13 @@ query GetTriplesBySubject($subjectId: String!, $limit: Int!) {
 3. **Include limit** to prevent over-fetching
 4. **Filter by predicate** to narrow relationship types
 
----
-title: "Nested Triple Queries"
-description: "Query complex nested triple relationships"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/nested-queries"
----
-
 # Nested Triple Queries
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/nested-queries
 
 Query triples with nested relationships to explore the knowledge graph.
 
-## Query Structure
+## Nested Triple Queries - Query Structure
 
 ```graphql
 query GetNestedTriples($subjectId: String!, $depth: Int!) {
@@ -14526,18 +13941,13 @@ query GetNestedTriples($subjectId: String!, $depth: Int!) {
 3. **Avoid circular references** in graph traversal
 4. **Consider performance** with deep nesting
 
----
-title: "Single Triple Query"
-description: "Fetch individual triple details by term ID"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/single-triple"
----
-
 # Single Triple Query
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/single-triple
 
 Fetch detailed information about a specific triple using its term ID.
 
-## Query Structure
+## Single Triple Query - Query Structure
 
 ```graphql
 query GetTriple($id: String!) {
@@ -14613,18 +14023,13 @@ query GetTriple($id: String!) {
 3. **Query counter triple** to see opposing positions
 4. **Handle null responses** when triple doesn't exist
 
----
-title: "Subject Predicates"
-description: "Query subject-predicate relationship aggregates"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/subject-predicates"
----
-
 # Subject Predicates
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/subject-predicates
 
 Query aggregated subject-predicate pairs across the knowledge graph. Each record represents a unique (subject, predicate) combination with aggregate stats across all triples sharing that pair.
 
-## Query Structure
+## Subject Predicates - Query Structure
 
 ```graphql
 query GetSubjectPredicates($subjectId: String!, $limit: Int!) {
@@ -14748,22 +14153,17 @@ async function exploreEntity(subjectId: string) {
 
 ## Related
 
-- [Filter by Predicate/Object](./filter-by-predicate-object) - Filter triples by predicate and object
-- [Filter by Subject](./filter-by-subject) - Filter triples by subject
-- [Nested Queries](./nested-queries) - Complex triple relationship traversal
-
----
-title: "Triple Terms"
-description: "Query triple-term relationship data with aggregate stats"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-terms"
----
+- [Filter by Predicate/Object](https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-predicate-object) - Filter triples by predicate and object
+- [Filter by Subject](https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-by-subject) - Filter triples by subject
+- [Nested Queries](https://docs.intuition.systems/docs/graphql-api/queries/triples/nested-queries) - Complex triple relationship traversal
 
 # Triple Terms
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-terms
+
 Query the `triple_term` view to get aggregate statistics for triple-term pairs. Each record links a triple's term to its counter-term with position and market cap data.
 
-## Query Structure
+## Triple Terms - Query Structure
 
 ```graphql
 query GetTripleTerms($termId: String!, $limit: Int!) {
@@ -14842,22 +14242,17 @@ query GetTripleTerm($termId: String!) {
 
 ## Related
 
-- [Triple Vaults](./triple-vaults) - Vault-level data for triples
-- [Counter Triples](./counter-triples) - Counter-triple relationships
-- [Single Triple](./single-triple) - Query individual triples
-
----
-title: "Triple Vaults"
-description: "Query vault-level data for triples including market cap and position counts"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-vaults"
----
+- [Triple Vaults](https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-vaults) - Vault-level data for triples
+- [Counter Triples](https://docs.intuition.systems/docs/graphql-api/queries/triples/counter-triples) - Counter-triple relationships
+- [Single Triple](https://docs.intuition.systems/docs/graphql-api/queries/triples/single-triple) - Query individual triples
 
 # Triple Vaults
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-vaults
+
 Query the `triple_vault` view to get vault-level data for triples, including market cap, position counts, shares, and asset totals per curve.
 
-## Query Structure
+## Triple Vaults - Query Structure
 
 ```graphql
 query GetTripleVaults($termId: String!, $limit: Int!) {
@@ -14966,22 +14361,17 @@ async function getTripleVaultPair(termId: string) {
 
 ## Related
 
-- [Triple Terms](./triple-terms) - Aggregate stats across curves
-- [Counter Triples](./counter-triples) - Counter-triple relationships
-- [Vault Details](/docs/graphql-api/queries/vaults/vault-details) - General vault queries
-
----
-title: "Deposits & Redemptions"
-description: "Query deposit and redemption transaction history"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/deposits-redemptions"
----
+- [Triple Terms](https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-terms) - Aggregate stats across curves
+- [Counter Triples](https://docs.intuition.systems/docs/graphql-api/queries/triples/counter-triples) - Counter-triple relationships
+- [Vault Details](https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details) - General vault queries
 
 # Deposits & Redemptions
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/deposits-redemptions
+
 Query transaction history for deposits and redemptions.
 
-## Query Structure
+## Deposits & Redemptions - Query Structure
 
 ```graphql
 query GetTransactionHistory($termId: String!, $curveId: numeric!, $limit: Int!) {
@@ -15023,20 +14413,15 @@ query GetTransactionHistory($termId: String!, $curveId: numeric!, $limit: Int!) 
 3. **Use limit** to paginate results
 4. **Combine deposits and redemptions** for full history
 
----
-title: "Position Changes"
-description: "Track position change history with daily and hourly aggregates"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes"
----
-
 # Position Changes
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes
 
 Track individual position changes and view pre-aggregated daily/hourly summaries. Position changes record every deposit and redemption event that modifies a position.
 
 ## Individual Changes
 
-### Query Structure
+### Individual Changes - Query Structure
 
 ```graphql
 query GetPositionChanges(
@@ -15262,22 +14647,17 @@ async function getPositionActivity(accountId: string, termId: string) {
 
 ## Related
 
-- [Positions with Value](./positions-with-value) - Enriched position data
-- [User Positions](./user-positions) - Basic position queries
-- [Deposits & Redemptions](./deposits-redemptions) - Transaction history
-
----
-title: "Positions with Value"
-description: "Query positions enriched with computed PnL and value data"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/positions-with-value"
----
+- [Positions with Value](https://docs.intuition.systems/docs/graphql-api/queries/vaults/positions-with-value) - Enriched position data
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Basic position queries
+- [Deposits & Redemptions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/deposits-redemptions) - Transaction history
 
 # Positions with Value
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/positions-with-value
+
 Query positions enriched with computed value fields including PnL, redeemable assets, and theoretical value. This is a view that extends the base `positions` table with real-time calculations.
 
-## Query Structure
+## Positions with Value - Query Structure
 
 ```graphql
 query GetPositionsWithValue($accountId: String!, $limit: Int!) {
@@ -15422,22 +14802,17 @@ async function getPortfolio(accountId: string) {
 
 ## Related
 
-- [User Positions](./user-positions) - Basic position queries
-- [Position Changes](./position-changes) - Position change history
-- [PnL Queries](/docs/graphql-api/queries/pnl/overview) - Account-level PnL
-
----
-title: "Share Price Changes"
-description: "Track share price changes over time"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/share-price-changes"
----
+- [User Positions](https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions) - Basic position queries
+- [Position Changes](https://docs.intuition.systems/docs/graphql-api/queries/vaults/position-changes) - Position change history
+- [PnL Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview) - Account-level PnL
 
 # Share Price Changes
 
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/share-price-changes
+
 Track how share prices change over time.
 
-## Query Structure
+## Share Price Changes - Query Structure
 
 ```graphql
 query GetPriceHistory($termId: String!, $curveId: numeric!, $limit: Int!) {
@@ -15464,18 +14839,13 @@ query GetPriceHistory($termId: String!, $curveId: numeric!, $limit: Int!) {
 3. **Track price over time** using `share_price` and `block_timestamp`
 4. **Use daily/hourly stats** for charts
 
----
-title: "Top Vaults"
-description: "Query top vaults by market cap and activity"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/top-vaults"
----
-
 # Top Vaults
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/top-vaults
 
 Query top vaults ranked by market cap, position count, or other metrics.
 
-## Query Structure
+## Top Vaults - Query Structure
 
 ```graphql
 query GetTopVaults($curveId: numeric!, $limit: Int!) {
@@ -15531,18 +14901,13 @@ query GetTopVaults($curveId: numeric!, $limit: Int!) {
 3. **Include term data** for display
 4. **Use limit** to show top N vaults
 
----
-title: "User Positions"
-description: "Query user positions in vaults"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions"
----
-
 # User Positions
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-positions
 
 Query all positions held by a specific account.
 
-## Query Structure
+## User Positions - Query Structure
 
 ```graphql
 query GetUserPositions($accountId: String!, $limit: Int!) {
@@ -15600,18 +14965,13 @@ query GetUserPositions($accountId: String!, $limit: Int!) {
 3. **Use aggregates** for totals
 4. **Filter by shares > 0** for active positions
 
----
-title: "Vault Details"
-description: "Query vault statistics and information"
-last_updated: "2026-04-01T11:08:48-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details"
----
-
 # Vault Details
+
+Source: https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-details
 
 Fetch comprehensive vault statistics including shares, assets, price, and positions.
 
-## Query Structure
+## Vault Details - Query Structure
 
 ```graphql
 query GetVault($termId: String!, $curveId: numeric!) {
@@ -15659,14 +15019,9 @@ query GetVault($termId: String!, $curveId: numeric!) {
 2. **Include aggregates** for statistics
 3. **Cache market data** as it updates frequently
 
----
-title: "Reads"
-description: "Guide to read data using GraphQL queries in the Intuition API"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/reads"
----
-
 # Reads
+
+Source: https://docs.intuition.systems/docs/graphql-api/reads
 
 ## GraphQL API
 
@@ -16196,18 +15551,11 @@ function AtomList() {
 }
 ```
 
----
-
-*For more examples and advanced patterns, check out our [GraphQL SDK](https://github.com/0xIntuition/intuition-ts/tree/main/packages/graphql) and [Example Queries](/docs/graphql-api/examples/atom-with-vault) page.*
-
----
-title: "Subscriptions Overview"
-description: "Real-time subscriptions with cursor-based streaming"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/subscriptions/overview"
----
+*For more examples and advanced patterns, check out our [GraphQL SDK](https://github.com/0xIntuition/intuition-ts/tree/main/packages/graphql) and [Example Queries](https://docs.intuition.systems/docs/graphql-api/examples/atom-with-vault) page.*
 
 # Subscriptions Overview
+
+Source: https://docs.intuition.systems/docs/graphql-api/subscriptions/overview
 
 The GraphQL API supports real-time subscriptions for live data updates using cursor-based streaming.
 
@@ -16490,20 +15838,15 @@ function watchPositionPrices(
 
 ## Related
 
-- [Real-time Positions](/docs/graphql-api/subscriptions/real-time-positions) - Position updates
-- [Price Updates](/docs/graphql-api/subscriptions/price-updates) - Price streaming
-- [Subscriptions vs Polling](/docs/graphql-api/best-practices/subscriptions-vs-polling) - When to use each
-
----
-title: "Price Updates"
-description: "Subscribe to share price changes in real-time"
-last_updated: "2026-02-28T21:52:51-05:00"
-source: "https://docs.intuition.systems/docs/graphql-api/subscriptions/price-updates"
----
+- [Real-time Positions](https://docs.intuition.systems/docs/graphql-api/subscriptions/real-time-positions) - Position updates
+- [Price Updates](https://docs.intuition.systems/docs/graphql-api/subscriptions/price-updates) - Price streaming
+- [Subscriptions vs Polling](https://docs.intuition.systems/docs/graphql-api/best-practices/subscriptions-vs-polling) - When to use each
 
 # Price Updates
 
-# Price Update Subscriptions
+Source: https://docs.intuition.systems/docs/graphql-api/subscriptions/price-updates
+
+## Price Update Subscriptions
 
 Subscribe to real-time share price changes.
 
@@ -16537,16 +15880,11 @@ subscription WatchPriceChanges(
 3. **Track price changes** using `share_price` and `block_timestamp`
 4. **Update charts** with new data points
 
----
-title: "Real-Time Positions"
-description: "Subscribe to position changes in real-time"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/subscriptions/real-time-positions"
----
-
 # Real-Time Positions
 
-# Real-Time Position Updates
+Source: https://docs.intuition.systems/docs/graphql-api/subscriptions/real-time-positions
+
+## Real-Time Position Updates
 
 Subscribe to position changes for live portfolio tracking.
 
@@ -16583,16 +15921,9 @@ subscription WatchPositions(
 3. **Update UI state** with new data
 4. **Resume from last cursor** after disconnection
 
----
-title: "Use Cases"
-description: "Real-world examples and step-by-step tutorials to use the Intuition GraphQL API"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/graphql-api/use-cases/overview"
----
-
-# Use Cases
-
 # GraphQL API Use Cases
+
+Source: https://docs.intuition.systems/docs/graphql-api/use-cases/overview
 
 This section contains practical, step-by-step tutorials for common use cases when working with the Intuition GraphQL API. Each example explains how to build real-world applications with our semantic knowledge graph.
 
@@ -16600,42 +15931,21 @@ This section contains practical, step-by-step tutorials for common use cases whe
 
 Select a use case above to see detailed step-by-step implementation guides.
 
-    <h3>
-      Finding the Top dApps on Coinbase
-    </h3>
+  [Finding the Top dApps on Coinbase Query and rank decentralized applications based on market data.](https://docs.intuition.systems/docs/tutorials/queries/finding-top-dapps-on-coinbase)
 
-      Query and rank decentralized applications based on market data.
+  [Discovering the Most Trusted Accounts Find highly trusted accounts based on stake and activity.](https://docs.intuition.systems/docs/tutorials/queries/discovering-most-trusted-accounts)
 
-    <h3>
-      Discovering the Most Trusted Accounts
-    </h3>
+  [Building User Activity Feeds Create personalized activity streams for users.](https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds)
 
-      Find highly trusted accounts based on stake and activity.
-
-    <h3>
-      Building User Activity Feeds
-    </h3>
-
-      Create personalized activity streams for users.
-
-    <h3>
-      Finding Related Claims
-    </h3>
-
-      Discover linked triples and relationship patterns.
-
----
-title: "Writes"
-description: "Guide to write data using GraphQL mutations in the Intuition API"
-last_updated: "2026-06-25T17:24:12-04:00"
-source: "https://docs.intuition.systems/docs/graphql-api/writes"
----
+  [Finding Related Claims Discover linked triples and relationship patterns.](https://docs.intuition.systems/docs/tutorials/queries/finding-related-claims)
 
 # Writes
 
+Source: https://docs.intuition.systems/docs/graphql-api/writes
+
 ## Understanding Mutations vs Smart Contract Operations
 
-The Intuition GraphQL API provides mutations for **off-chain operations** like uploading metadata to IPFS. For **on-chain operations** like creating atoms, triples, and positions, you must use the [Intuition SDK](/docs/intuition-sdk/installation-and-setup) or interact directly with the smart contracts.
+The Intuition GraphQL API provides mutations for **off-chain operations** like uploading metadata to IPFS. For **on-chain operations** like creating atoms, triples, and positions, you must use the [Intuition SDK](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup) or interact directly with the smart contracts.
 
 Pinning mutations are served from the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, not the read endpoint. Send your Intuition pin API key in an `apikey` request header from a trusted server runtime.
 
@@ -16696,7 +16006,7 @@ const response = await fetch(PIN_API_URL, {
 - Taking positions (depositing/redeeming)
 - All on-chain state changes
 
-Use the [SDK](/docs/intuition-sdk/installation-and-setup) for smart contract interactions.
+Use the [SDK](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup) for smart contract interactions.
 
 ## Available Mutations
 
@@ -16704,17 +16014,17 @@ Use the [SDK](/docs/intuition-sdk/installation-and-setup) for smart contract int
 
 | Mutation             | Description                       | Documentation                                                               |
 | -------------------- | --------------------------------- | --------------------------------------------------------------------------- |
-| `pinThing`           | Pin Thing metadata to IPFS        | [Pin Thing](/docs/graphql-api/mutations/pin-thing)                          |
-| `pinPerson`          | Pin Person metadata to IPFS       | [Pin Person](/docs/graphql-api/mutations/pin-person)                        |
-| `pinOrganization`    | Pin Organization metadata to IPFS | [Pin Organization](/docs/graphql-api/mutations/pin-organization)            |
-| `uploadImage`        | Upload base64 image to IPFS       | [Upload Image](/docs/graphql-api/mutations/images/upload-image)             |
-| `uploadImageFromUrl` | Upload image from URL to IPFS     | [Upload from URL](/docs/graphql-api/mutations/images/upload-image-from-url) |
-| `uploadJsonToIpfs`   | Upload JSON metadata to IPFS      | [Upload JSON](/docs/graphql-api/mutations/images/upload-json-to-ipfs)       |
+| `pinThing`           | Pin Thing metadata to IPFS        | [Pin Thing](https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing)                          |
+| `pinPerson`          | Pin Person metadata to IPFS       | [Pin Person](https://docs.intuition.systems/docs/graphql-api/mutations/pin-person)                        |
+| `pinOrganization`    | Pin Organization metadata to IPFS | [Pin Organization](https://docs.intuition.systems/docs/graphql-api/mutations/pin-organization)            |
+| `uploadImage`        | Upload base64 image to IPFS       | [Upload Image](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image)             |
+| `uploadImageFromUrl` | Upload image from URL to IPFS     | [Upload from URL](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) |
+| `uploadJsonToIpfs`   | Upload JSON metadata to IPFS      | [Upload JSON](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-json-to-ipfs)       |
 
 Chart and PnL operations are **queries**, not mutations. See:
 
-- [PnL Queries](/docs/graphql-api/queries/pnl/overview) - Profit & Loss tracking
-- [Chart Queries](/docs/graphql-api/queries/charts/overview) - Chart generation
+- [PnL Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview) - Profit & Loss tracking
+- [Chart Queries](https://docs.intuition.systems/docs/graphql-api/queries/charts/overview) - Chart generation
   :::
 
 ## Pin Mutations
@@ -16979,19 +16289,14 @@ For browser apps, proxy pinning through a server route so the API key is not exp
 
 ## Related Resources
 
-- [PnL Queries](/docs/graphql-api/queries/pnl/overview) - Profit & Loss tracking
-- [Chart Queries](/docs/graphql-api/queries/charts/overview) - Chart generation
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup) - On-chain operations
-- [GraphQL Reads](/docs/graphql-api/reads) - Query documentation
-
----
-title: "Introduction"
-description: "Introduction to Intuition - the decentralized protocol for building the world's first open, semantic, and token-curated knowledge graph"
-last_updated: "2026-06-03T14:13:55-04:00"
-source: "https://docs.intuition.systems/docs"
----
+- [PnL Queries](https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview) - Profit & Loss tracking
+- [Chart Queries](https://docs.intuition.systems/docs/graphql-api/queries/charts/overview) - Chart generation
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup) - On-chain operations
+- [GraphQL Reads](https://docs.intuition.systems/docs/graphql-api/reads) - Query documentation
 
 # Introduction
+
+Source: https://docs.intuition.systems/docs
 
 **Intuition is a decentralized protocol for building the world's first open, semantic, and token-curated knowledge graph.** It provides the infrastructure for verifiable attestations, portable identity, and trustful interactions at scale—creating a universal data layer that enables information to flow freely across applications, blockchains, and AI agents.
 
@@ -17055,45 +16360,39 @@ Whether you're building applications, contributing data, or exploring the knowle
 
 ## Learn More
 
-- [Introduction](/docs/getting-started/overview) — Understand Intuition's vision and the problems it solves
-- [Quickstart](/docs/quick-start/using-the-sdk) — Get started building with Intuition
-- [Primitives](/docs/intuition-concepts/primitives) — Deep dive into Atoms, Triples, and Signals
-- [Developer Tools](/docs/getting-started/developer-stack) — Explore SDKs, APIs, and integration guides
-- [Developer Resources](/docs/getting-started/developer-resources) — Find Learn Intuition, AI skills, templates, and MCP resources
-- [Network](/docs/intuition-network) — Learn about the Intuition Network architecture
-- [Economics](/docs/intuition-concepts/economics) — Understand the cryptoeconomic incentive model
+- [Introduction](https://docs.intuition.systems/docs/getting-started/overview) — Understand Intuition's vision and the problems it solves
+- [Quickstart](https://docs.intuition.systems/docs/quick-start/using-the-sdk) — Get started building with Intuition
+- [Primitives](https://docs.intuition.systems/docs/intuition-concepts/primitives) — Deep dive into Atoms, Triples, and Signals
+- [Developer Tools](https://docs.intuition.systems/docs/getting-started/developer-stack) — Explore SDKs, APIs, and integration guides
+- [Developer Resources](https://docs.intuition.systems/docs/getting-started/developer-resources) — Find Learn Intuition, AI skills, templates, and MCP resources
+- [Network](https://docs.intuition.systems/docs/intuition-network) — Learn about the Intuition Network architecture
+- [Economics](https://docs.intuition.systems/docs/intuition-concepts/economics) — Understand the cryptoeconomic incentive model
 
 ## For AI Agents
 
 Intuition documentation is optimized for AI agent access:
-- [llms.txt](/llms.txt) — Concise documentation index for LLM consumption
-- [llms-full.txt](/llms-full.txt) — Complete documentation in LLM-friendly format
-- [AI Skills](/docs/getting-started/ai-skills) — Canonical protocol context for AI coding agents
-- [MCP Server](/docs/experimental-applications/mcp-server) — Runtime tools for AI applications querying Intuition data
+- [llms.txt](https://docs.intuition.systems/llms.txt) — Concise documentation index for LLM consumption
+- [llms-full.txt](https://docs.intuition.systems/llms-full.txt) — Complete documentation in LLM-friendly format
+- [AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills) — Canonical protocol context for AI coding agents
+- [MCP Server](https://docs.intuition.systems/docs/experimental-applications/mcp-server) — Runtime tools for AI applications querying Intuition data
 
----
 **Intuition transforms information from passive data into programmable, verifiable, and valuable attestations—building the trust layer for the decentralized web.**
 
----
-title: "Create Atom"
-description: "Learn how to create atoms and manage their associated vaults"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/interaction-guide/create-atom"
----
-
 # Create Atom
+
+Source: https://docs.intuition.systems/docs/interaction-guide/create-atom
 
 Creating atoms in the Intuition protocol involves interacting with the EthMultiVault contract to establish new entities in the knowledge graph. This process includes creating the atom itself and managing its associated vault.
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
+This implementation guide assumes that you've completed the setup steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
 
 ## Implementation
 
 We recommend creating a `multivault.ts` that includes the following atom creation functionality:
 
-<h3 >Core Atom Creation Pattern</h3>
+### Core Atom Creation Pattern
 
 {`// Create atom with initial deposit
 const createAtomConfig = {
@@ -17111,7 +16410,7 @@ const receipt = await publicClient.waitForTransactionReceipt({ hash })`}
 
 Here is a full example of the atom creation pattern used in the `createAtom` function:
 
-<h3 >Full Implementation</h3>
+### Full Implementation
 
 {`export async function createAtom(
   contract: string,
@@ -17165,21 +16464,21 @@ Here is a full example of the atom creation pattern used in the `createAtom` fun
 
 We use this pattern to create atoms and manage their lifecycle:
 
-<h4 >createAtom</h4>
+#### createAtom
 
 Creates a new atom with optional initial deposit and returns atom/vault IDs.
 
-<h4 >validateAtomData</h4>
+#### validateAtomData
 
 Validates atom data format and ensures it meets protocol requirements.
 
-<h4 >estimateAtomCost</h4>
+#### estimateAtomCost
 
 Estimates the cost of creating an atom including fees and gas costs.
 
 ## Usage Example
 
-<h3 >Basic Atom Creation</h3>
+### Basic Atom Creation
 
 {`// Create a new atom
 const atomData = "did:ethr:mainnet:0x1234567890abcdef"
@@ -17204,17 +16503,17 @@ if (result.success) {
 
 ## Error Handling
 
-<h3 >Common Error Scenarios</h3>
+### Common Error Scenarios
 
-<h4 >Insufficient Funds</h4>
+#### Insufficient Funds
 
 Ensure wallet has sufficient ETH for gas and deposit amount.
 
-<h4 >Invalid Atom Data</h4>
+#### Invalid Atom Data
 
 Validate atom data format before submission.
 
-<h4 >Network Issues</h4>
+#### Network Issues
 
 Handle RPC failures and network connectivity issues.
 
@@ -17230,32 +16529,27 @@ Handle RPC failures and network connectivity issues.
 
 After creating atoms, explore:
 
-- [Create Triple](/docs/interaction-guide/create-triple) - Learn how to create relationships between atoms
-- [Deposit & Return](/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
-- [Retrieve Vault Details](/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
+- [Create Triple](https://docs.intuition.systems/docs/interaction-guide/create-triple) - Learn how to create relationships between atoms
+- [Deposit & Return](https://docs.intuition.systems/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
+- [Retrieve Vault Details](https://docs.intuition.systems/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
 
 For a full reference implementation, see the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts).
 
----
-title: "Create Triple"
-description: "Learn how to create triples and manage their relationships"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/interaction-guide/create-triple"
----
-
 # Create Triple
+
+Source: https://docs.intuition.systems/docs/interaction-guide/create-triple
 
 Creating triples in the Intuition protocol involves establishing relationships between atoms through the EthMultiVault contract. This process creates both the triple structure and its associated vaults for positive and negative positions.
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide and have existing atoms to work with.
+This implementation guide assumes that you've completed the setup steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide and have existing atoms to work with.
 
 ## Implementation
 
 We recommend creating a `multivault.ts` that includes the following triple creation functionality:
 
-<h3 >Core Triple Creation Pattern</h3>
+### Core Triple Creation Pattern
 
 {`// Create triple with initial deposit
 const createTripleConfig = {
@@ -17270,21 +16564,21 @@ const hash = await walletClient.writeContract(createTripleConfig)`}
 
 We use this pattern to create triples and manage their lifecycle:
 
-<h4 >createTriple</h4>
+#### createTriple
 
 Creates a new triple with optional initial deposit and returns triple/vault IDs.
 
-<h4 >validateTripleComponents</h4>
+#### validateTripleComponents
 
 Validates that subject, predicate, and object atoms exist and are valid.
 
-<h4 >estimateTripleCost</h4>
+#### estimateTripleCost
 
 Estimates the cost of creating a triple including fees and gas costs.
 
 ## Usage Example
 
-<h3 >Basic Triple Creation</h3>
+### Basic Triple Creation
 
 {`// Create a new triple
 const subjectId = 123n  // Atom ID for "Alice"
@@ -17306,11 +16600,11 @@ const result = await createTriple(
 
 Each triple creates two vaults:
 
-<h4 >Positive Vault</h4>
+#### Positive Vault
 
 For users who believe the triple is true. Deposits here signal agreement.
 
-<h4 >Negative Vault</h4>
+#### Negative Vault
 
 For users who believe the triple is false. Deposits here signal disagreement.
 
@@ -17326,31 +16620,26 @@ For users who believe the triple is false. Deposits here signal disagreement.
 
 After creating triples, explore:
 
-- [Deposit & Return](/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
-- [Retrieve Vault Details](/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
+- [Deposit & Return](https://docs.intuition.systems/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
+- [Retrieve Vault Details](https://docs.intuition.systems/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
 
 For a full reference implementation, see the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts).
 
----
-title: "Deposit & Return"
-description: "Manage deposits and withdrawals from vaults with proper fee handling"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/interaction-guide/deposit-return"
----
-
 # Deposit & Return
+
+Source: https://docs.intuition.systems/docs/interaction-guide/deposit-return
 
 Managing deposits and withdrawals from vaults in the Intuition protocol involves interacting with the EthMultiVault contract to stake and unstake tokens. This process includes proper fee handling and share price calculations.
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
+This implementation guide assumes that you've completed the setup steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
 
 ## Implementation
 
 We recommend creating a `multivault.ts` that includes the following deposit and withdrawal functionality:
 
-<h3 >Core Deposit Pattern</h3>
+### Core Deposit Pattern
 
 {`// Deposit into vault
 const depositConfig = {
@@ -17365,21 +16654,21 @@ const hash = await walletClient.writeContract(depositConfig)`}
 
 We use these patterns to manage vault deposits and withdrawals:
 
-<h4 >deposit</h4>
+#### deposit
 
 Deposit tokens into a vault and receive shares based on current share price.
 
-<h4 >withdraw</h4>
+#### withdraw
 
 Withdraw tokens from a vault by burning shares at current share price.
 
-<h4 >estimateDeposit</h4>
+#### estimateDeposit
 
 Estimate the number of shares received for a given deposit amount.
 
 ## Usage Examples
 
-<h3 >Basic Deposit</h3>
+### Basic Deposit
 
 {`// Deposit into vault
 const vaultId = 123n
@@ -17393,7 +16682,7 @@ const result = await deposit(
   publicClient
 )`}
 
-<h3 >Basic Withdrawal</h3>
+### Basic Withdrawal
 
 {`// Withdraw from vault
 const vaultId = 123n
@@ -17409,33 +16698,33 @@ const result = await withdraw(
 
 ## Fee Structure
 
-<h3 >Understanding Fees</h3>
+### Understanding Fees
 
-<h4 >Entry Fee</h4>
+#### Entry Fee
 
 Fee charged when depositing into a vault, calculated as a percentage of deposit.
 
-<h4 >Exit Fee</h4>
+#### Exit Fee
 
 Fee charged when withdrawing from a vault, calculated as a percentage of withdrawal.
 
-<h4 >Protocol Fee</h4>
+#### Protocol Fee
 
 Fee collected by the protocol for maintaining the system and infrastructure.
 
 ## Share Price Dynamics
 
-<h3 >Bonding Curve Mechanics</h3>
+### Bonding Curve Mechanics
 
-<h4 >Price Discovery</h4>
+#### Price Discovery
 
 Share price increases as more tokens are deposited into the vault.
 
-<h4 >Early Adopter Advantage</h4>
+#### Early Adopter Advantage
 
 Early depositors receive more shares for the same token amount.
 
-<h4 >Liquidity Provision</h4>
+#### Liquidity Provision
 
 Vaults provide continuous liquidity for depositors and withdrawers.
 
@@ -17452,36 +16741,29 @@ Vaults provide continuous liquidity for depositors and withdrawers.
 
 After managing deposits and withdrawals, explore:
 
-- [Retrieve Vault Details](/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
-- [Create Atom](/docs/interaction-guide/create-atom) - Create atoms to deposit into
-- [Create Triple](/docs/interaction-guide/create-triple) - Create triples with associated vaults
+- [Retrieve Vault Details](https://docs.intuition.systems/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
+- [Create Atom](https://docs.intuition.systems/docs/interaction-guide/create-atom) - Create atoms to deposit into
+- [Create Triple](https://docs.intuition.systems/docs/interaction-guide/create-triple) - Create triples with associated vaults
 
 For a full reference implementation, see the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts).
 
----
-title: "Overview"
-description: "Introduction to Intuition contract interactions and smart contract operations"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/interaction-guide/overview"
----
-
-# Overview
-
 # Contract Interactions Overview
+
+Source: https://docs.intuition.systems/docs/interaction-guide/overview
 
 The Intuition protocol's smart contracts manage complex state involving Atoms, Triples, and their associated vaults. When interacting with these primitives, we recommend retrieving state data directly from the EthMultiVault contract.
 
 ## Key Concepts
 
-<h4 >Multicall Operations</h4>
+#### Multicall Operations
 
 Batch multiple read-only contract calls into a single request to reduce RPC calls and improve performance.
 
-<h4 >State Management</h4>
+#### State Management
 
 Retrieve comprehensive vault information including assets, share prices, and user positions.
 
-<h4 >Configuration Access</h4>
+#### Configuration Access
 
 Access global protocol configuration including fee structures and minimum deposits.
 
@@ -17489,7 +16771,7 @@ Access global protocol configuration including fee structures and minimum deposi
 
 We utilize multicall operations that batch multiple read-only contract calls into a single request. This approach significantly reduces RPC calls and provides data you'll need for contract interactions, such as the `atomCost` that is referenced in the contract interaction guides.
 
-<h3 >Core Multicall Pattern</h3>
+### Core Multicall Pattern
 
 {`// Core multicall configuration
 const coreContractConfigs = [
@@ -17513,19 +16795,19 @@ const resp: MulticallResponse[] = await publicClient.multicall({
 
 ## Available Interactions
 
-<h4 >Create Atom</h4>
+#### Create Atom
 
 Learn how to create new atoms and manage their associated vaults.
 
-<h4 >Create Triple</h4>
+#### Create Triple
 
 Understand how to create triples and manage their relationships.
 
-<h4 >Deposit & Return</h4>
+#### Deposit & Return
 
 Manage deposits and withdrawals from vaults with proper fee handling.
 
-<h4 >Retrieve Vault Details</h4>
+#### Retrieve Vault Details
 
 Get comprehensive vault information including assets, prices, and positions.
 
@@ -17549,14 +16831,9 @@ Explore the specific interaction guides to learn how to:
 
 Each guide provides detailed implementation examples and best practices for working with Intuition's smart contracts.
 
----
-title: "Retrieve Vault Details"
-description: "Get comprehensive vault information including assets, prices, and positions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/interaction-guide/retrieve-vault-details"
----
-
 # Retrieve Vault Details
+
+Source: https://docs.intuition.systems/docs/interaction-guide/retrieve-vault-details
 
 The Intuition protocol's EthMultiVault contract manages complex state involving Atoms, Triples, and their associated vaults. When interacting with these primitives, we recommend retrieving the state data directly from the EthMultiVault contract.
 
@@ -17564,11 +16841,11 @@ We utilize multicall operations that batch multiple read-only contract calls int
 
 ## Implementation
 
-This implementation guide assumes that you've completed the steps in the [Overview](/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
+This implementation guide assumes that you've completed the steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
 
 We recommend creating a `multivault.ts` that includes the following:
 
-<h3 >Core Multicall Configuration</h3>
+### Core Multicall Configuration
 
 {`// createMultiVaultcontract
 const multiVaultContract = createMultiVaultContract(contract)
@@ -17597,7 +16874,7 @@ const resp: MulticallResponse[] = await publicClient.multicall({
 
 Here is a full example of the multicall pattern used in the `getMultivaultConfig` function:
 
-<h3 >Full Implementation</h3>
+### Full Implementation
 
 {`export async function getMultiVaultConfig(contract: string) {
   const multiVaultContract = createMultiVaultContract(contract)
@@ -17668,11 +16945,11 @@ Here is a full example of the multicall pattern used in the `getMultivaultConfig
 
 We use this multicall pattern to retrieve configuration that we're able to use throughout the app:
 
-<h4 >getVaultDetails</h4>
+#### getVaultDetails
 
 Retrieves comprehensive vault information including total assets, conviction, current share price, fee configurations, user-specific positions, and counter-vault details.
 
-<h4 >getMultiVaultConfig</h4>
+#### getMultiVaultConfig
 
 Retrieves global protocol configuration including fee structures, minimum deposits, and protocol admin addresses.
 
@@ -17680,7 +16957,7 @@ Retrieves global protocol configuration including fee structures, minimum deposi
 
 The full `getVaultDetails` function follows the same pattern used in the `getMultiVaultConfig` example but is too large to include in the docs. We recommend looking at the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts/blob/main/apps/portal/app/.server/multivault.ts) for a full reference implementation.
 
-<h3 >Basic Usage</h3>
+### Basic Usage
 
 {`// Fetch vault and countervault details with user positions:
 const vaultDetails = await getVaultDetails(
@@ -17713,20 +16990,15 @@ For a full example of how we implement all of our EthMultiVault multicalls, you 
 
 After retrieving vault details, explore:
 
-- [Create Atom](/docs/interaction-guide/create-atom) - Create atoms and manage their vaults
-- [Create Triple](/docs/interaction-guide/create-triple) - Create triples with associated vaults
-- [Deposit & Return](/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
+- [Create Atom](https://docs.intuition.systems/docs/interaction-guide/create-atom) - Create atoms and manage their vaults
+- [Create Triple](https://docs.intuition.systems/docs/interaction-guide/create-triple) - Create triples with associated vaults
+- [Deposit & Return](https://docs.intuition.systems/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
 
 For a full reference implementation, see the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts).
 
----
-title: "System Architecture"
-description: "Overview of Intuition's technical architecture and design principles"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/architecture"
----
-
 # System Architecture
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/architecture
 
 This guide provides an overview of Intuition's technical architecture and how the various components work together.
 
@@ -17882,22 +17154,15 @@ event FeeTransfer(uint256 indexed vaultId, address indexed recipient, uint256 am
 - Sharding for data distribution
 - Cross-chain bridges
 
----
-
 ## Next Steps
 
-- [Protocol Overview](/docs/protocol/getting-started/overview) - Detailed contract documentation
-- [SDK Overview](/docs/intuition-sdk/quick-start) - Using the SDK
-- [GraphQL API](/docs/graphql-api/overview) - Querying the system
-
----
-title: "Bonding Curves"
-description: "How bonding curves create markets for knowledge"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves"
----
+- [Protocol Overview](https://docs.intuition.systems/docs/protocol/getting-started/overview) - Detailed contract documentation
+- [SDK Overview](https://docs.intuition.systems/docs/intuition-sdk/quick-start) - Using the SDK
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview) - Querying the system
 
 # Bonding Curves
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves
 
 Bonding curves are a core economic primitive in Intuition, determining how the price of shares changes as more users stake tokens in Atom and Triple vaults.
 
@@ -17948,19 +17213,19 @@ More complex pricing with offset:
 
 Intuition uses bonding curves to create dynamic pricing mechanisms that automatically adjust based on supply and demand. This sophisticated approach provides multiple benefits:
 
-<h3>Automated Market Making</h3>
+### Automated Market Making
 
 Liquidity is provided automatically through mathematical curves, eliminating the need for traditional order books or manual market makers.
 
-<h3>Early Incentives</h3>
+### Early Incentives
 
 Early participants get better prices, encouraging adoption and rewarding pioneers who identify valuable data structures before they become widely recognized.
 
-<h3>Supply Control</h3>
+### Supply Control
 
 Prices increase as more tokens are minted, preventing inflation while ensuring scarcity creates value for established data structures.
 
-<h3>Economic Alignment</h3>
+### Economic Alignment
 
 Pricing automatically reflects the value of underlying assets, ensuring market mechanisms accurately represent the true worth of data and relationships.
 
@@ -18021,24 +17286,17 @@ Pricing automatically reflects the value of underlying assets, ensuring market m
 - Different curves for different vault types
 - Balances accessibility and sustainability
 
----
-
 ## Next Steps
 
-- [Fees & Rewards](/docs/intuition-concepts/economics/fees-and-rewards) - Understanding the fee structure
-- [Tokenomics](/docs/intuition-concepts/economics/tokenomics) - Learn about $TRUST token utility
-- [Incentive Design](/docs/intuition-concepts/economics/incentive-design) - How economics drive consensus
-
----
-title: "Fees and Rewards"
-description: "Understanding fee structure and reward mechanisms"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards"
----
+- [Fees & Rewards](https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards) - Understanding the fee structure
+- [Tokenomics](https://docs.intuition.systems/docs/intuition-concepts/economics/tokenomics) - Learn about $TRUST token utility
+- [Incentive Design](https://docs.intuition.systems/docs/intuition-concepts/economics/incentive-design) - How economics drive consensus
 
 # Fees and Rewards
 
-# Fees & Rewards
+Source: https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards
+
+## Fees & Rewards
 
 In the Intuition system, interactions incur fees similar to gas costs in blockchain transactions. These fees serve critical roles in maintaining system integrity, incentivizing contributions, and fostering high-quality data.
 
@@ -18089,15 +17347,15 @@ Because Intuition breaks data down into discrete, tokenized units, the system is
 
 When users interact with or create data, these combined fees support both network operations and data contributor rewards through the following mechanisms:
 
-<h3>Purchasing Equity in the Data</h3>
+### Purchasing Equity in the Data
 
 To purchase tokens of an Atom or Triple, users deposit $TRUST (the native token of the Intuition Network and Protocol) into the Vault of the respective Atom or Triple. You pay a protocol fee proportional to your deposit amount. In return, you receive tokens of that specific Atom or Triple, entitling you to rewards generated by that data point proportional to your ownership percentage.
 
-<h3>Rewarding Prior Contributors</h3>
+### Rewarding Prior Contributors
 
 When interacting with data, part of the protocol fee is distributed to all existing shareholders (prior contributors). This encourages early, meaningful contributions, as users who add valuable data will continue to be rewarded over time through protocol fees, while gas fees go to network validators.
 
-<h3>Protocol Maintenance</h3>
+### Protocol Maintenance
 
 A portion of the protocol fee is paid to the Intuition protocol for platform maintenance and development. This ensures Intuition can be self-sustaining and exist in perpetuity, without risk of shutting down.
 
@@ -18189,22 +17447,15 @@ Economic integration achieves:
 - **Structured Consensus**: Incentive-driven standardization
 - **Sustainable Growth**: Value flows support development
 
----
-
 ## Next Steps
 
-- [Bonding Curves](/docs/intuition-concepts/economics/bonding-curves) - Understand pricing mechanics
-- [Tokenomics](/docs/intuition-concepts/economics/tokenomics) - Learn about $TRUST token
-- [Incentive Design](/docs/intuition-concepts/economics/incentive-design) - How economics drive consensus
-
----
-title: "Incentive Design"
-description: "How economics drive consensus and reduce fragmentation"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/economics/incentive-design"
----
+- [Bonding Curves](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - Understand pricing mechanics
+- [Tokenomics](https://docs.intuition.systems/docs/intuition-concepts/economics/tokenomics) - Learn about $TRUST token
+- [Incentive Design](https://docs.intuition.systems/docs/intuition-concepts/economics/incentive-design) - How economics drive consensus
 
 # Incentive Design
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/economics/incentive-design
 
 Intuition's economic model is carefully designed to solve fundamental challenges in decentralized knowledge systems: fragmentation, quality control, and consensus formation.
 
@@ -18315,24 +17566,15 @@ By integrating these economic principles, Intuition creates a dynamic, decentral
 
 This economic framework ensures sustainable growth while maintaining the platform's security and reliability, creating a virtuous cycle of value creation and distribution that benefits all participants in the Intuition ecosystem.
 
----
-
 ## Next Steps
 
-- [Tokenomics](/docs/intuition-concepts/economics/tokenomics) - Understand $TRUST token utility
-- [Bonding Curves](/docs/intuition-concepts/economics/bonding-curves) - Learn about dynamic pricing
-- [Fees & Rewards](/docs/intuition-concepts/economics/fees-and-rewards) - See how rewards flow
-
----
-title: "Economics"
-description: "Understanding Intuition's token-curated knowledge graph economics"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/economics"
----
-
-# Economics
+- [Tokenomics](https://docs.intuition.systems/docs/intuition-concepts/economics/tokenomics) - Understand $TRUST token utility
+- [Bonding Curves](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - Learn about dynamic pricing
+- [Fees & Rewards](https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards) - See how rewards flow
 
 # Economics Overview
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/economics
 
 Intuition is built on the idea that information deserves its own decentralized distribution and financial rails.
 
@@ -18346,13 +17588,11 @@ The economics of Intuition transform every digital interaction into an economic 
 
 The goal is not to tokenize data just for the sake of a token. The economics of Intuition are designed to:
 
-<h3>1. Incentivize Expression</h3>
+### 1. Incentivize Expression
 
-<h3>2. Incentivize Convergence on Canonical Identifiers</h3>
+### 2. Incentivize Convergence on Canonical Identifiers
 
-<h3>3. Incentivize Consensus on Standards and Structures</h3>
-
----
+### 3. Incentivize Consensus on Standards and Structures
 
 ## $TRUST Token
 
@@ -18367,8 +17607,6 @@ For deeper understanding of Intuition's economic foundations:
 
 - **[Trust Whitepaper](https://cdn.prod.website-files.com/65cdf366e68587fd384547f0/68316bdfe42a265d3dc45498_trust-whitepaper.pdf)** - Comprehensive overview of the economic model and theoretical foundations
 - **[$TRUST Tokenomics Dashboard](https://app.forgd.com/share/trust/9837b0d0-e11f-410f-80e6-62a0b6fe13ff/public)** - Detailed token economics, distribution, and utility
-
----
 
 ## Example Flow: How the Incentives Work
 
@@ -18391,47 +17629,38 @@ For deeper understanding of Intuition's economic foundations:
 **As developers and AI agents query Tesla-related data, fees flow back to the identifiers and attestations that power those queries**
 - Alice, Bob, and Carol all share in the economic upside of having built durable, widely used pieces of the graph
 
----
-
 ## Reward Dynamics
 
 To maximize engagement and data quality, the system favors contributions that are:
 
-<h3>New or Early</h3>
+### New or Early
 
 First-mover advantages for valuable identifiers and attestations
 
-<h3>Widely Useful</h3>
+### Widely Useful
 
 Network effects amplify rewards for commonly referenced knowledge
 
-<h3>Standards-Aligned</h3>
+### Standards-Aligned
 
 Stronger incentives for adopting schemas and canonical identifiers
 
-<h3>Future-Facing</h3>
+### Future-Facing
 
 Forward-looking value assessment ensures durable contributions
-
----
 
 ## Next Steps
 
 Explore the specific mechanisms that power Intuition's economics:
 
-- [Tokenomics](/docs/intuition-concepts/economics/tokenomics) - Deep dive into $TRUST token distribution and utility
-- [Bonding Curves](/docs/intuition-concepts/economics/bonding-curves) - How dynamic pricing creates markets for knowledge
-- [Fees & Rewards](/docs/intuition-concepts/economics/fees-and-rewards) - Understanding the fee structure and reward mechanisms
-- [Incentive Design](/docs/intuition-concepts/economics/incentive-design) - How economics drive consensus and reduce fragmentation
-
----
-title: "$TRUST Tokenomics"
-description: "Understanding the $TRUST token distribution and utility"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/economics/tokenomics"
----
+- [Tokenomics](https://docs.intuition.systems/docs/intuition-concepts/economics/tokenomics) - Deep dive into $TRUST token distribution and utility
+- [Bonding Curves](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - How dynamic pricing creates markets for knowledge
+- [Fees & Rewards](https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards) - Understanding the fee structure and reward mechanisms
+- [Incentive Design](https://docs.intuition.systems/docs/intuition-concepts/economics/incentive-design) - How economics drive consensus and reduce fragmentation
 
 # $TRUST Tokenomics
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/economics/tokenomics
 
 $TRUST is the native token of the Intuition Network and Protocol, designed to enable economic participation in the decentralized knowledge graph.
 
@@ -18512,22 +17741,15 @@ For comprehensive information about $TRUST tokenomics:
 - **[Trust Whitepaper](https://cdn.prod.website-files.com/65cdf366e68587fd384547f0/68316bdfe42a265d3dc45498_trust-whitepaper.pdf)** - Full technical and economic specification
 - **[$TRUST Tokenomics Dashboard](https://app.forgd.com/share/trust/9837b0d0-e11f-410f-80e6-62a0b6fe13ff/public)** - Live tokenomics data, distribution details, and analytics
 
----
-
 ## Next Steps
 
-- [Bonding Curves](/docs/intuition-concepts/economics/bonding-curves) - Understand how $TRUST pricing works
-- [Fees & Rewards](/docs/intuition-concepts/economics/fees-and-rewards) - Learn how rewards are distributed
-- [Incentive Design](/docs/intuition-concepts/economics/incentive-design) - Explore economic incentive mechanisms
-
----
-title: "Atom Best Practices"
-description: "Patterns and guidelines for creating high-quality, reusable Atoms in the Intuition ecosystem"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/best-practices"
----
+- [Bonding Curves](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - Understand how $TRUST pricing works
+- [Fees & Rewards](https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards) - Learn how rewards are distributed
+- [Incentive Design](https://docs.intuition.systems/docs/intuition-concepts/economics/incentive-design) - Explore economic incentive mechanisms
 
 # Atom Best Practices
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/best-practices
 
 This guide provides comprehensive best practices for creating effective, reusable Atoms that contribute to a high-quality Intuition knowledge graph.
 
@@ -18857,22 +18079,15 @@ Before creating an Atom, verify:
 - [ ] Respects community standards
 - [ ] Documented if complex
 
----
-
 ## Next Steps
 
-- [Triple Fundamentals](../triples/fundamentals) - Learn how to connect Atoms into meaningful relationships
-- [Signal Fundamentals](../signals/fundamentals) - Understand how to build trust in your Atoms
-- [Atom Structuring](./structuring) - Review advanced structuring techniques
-
----
-title: "Atom Fundamentals"
-description: "Understanding Atoms - the fundamental units of data in the Intuition knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals"
----
+- [Triple Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals) - Learn how to connect Atoms into meaningful relationships
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Understand how to build trust in your Atoms
+- [Atom Structuring](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/structuring) - Review advanced structuring techniques
 
 # Atom Fundamentals
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals
 
 Atoms are the foundational building blocks of Intuition's knowledge graph – the words in our global dictionary. Think of Intuition as a vast, collaborative dictionary where anyone can create a new word, and each word has its own globally persistent, unique digital identifier that can be used to reference it across the entire internet.
 
@@ -18880,15 +18095,15 @@ Atoms are the foundational building blocks of Intuition's knowledge graph – th
 
 A system facilitating the arrival at social consensus around globally persistent canonical identifiers for all things demands that these identifiers possess a few key attributes.
 
-<h3 >Decentralized Identifiers</h3>
+### Decentralized Identifiers
 
 These identifiers should be decentralized identifiers, providing unique, secure, and verifiable identification without any reliance on a central authority.
 
-<h3 >Associated Data</h3>
+### Associated Data
 
 These identifiers should have a sufficient amount of associated data to ensure precise referencing of specific entities, concepts, or pieces of information.
 
-<h3 >Agent-Centric State</h3>
+### Agent-Centric State
 
 These identifiers must have some agent-centric state that is capable of tracking the usage of the identifier across contexts.
 
@@ -18906,17 +18121,17 @@ In the spirit of the Semantic Web and linked data, an Atom can correspond to vir
 - **Categories**: Tags, classifications, taxonomies
 - **Concepts**: Ideas, words, phrases, abstract notions
 
-<h3 >Key Benefits of Atoms</h3>
+### Key Benefits of Atoms
 
-<h4 >Universal Reference</h4>
+#### Universal Reference
 
 Start to reference data universally across the web.
 
-<h4 >User Equity</h4>
+#### User Equity
 
 Grant users equity in data as they signal its relevancy through usage.
 
-<h4 >Active Participation</h4>
+#### Active Participation
 
 Reward users for signaling the relevancy of data, encouraging active participation.
 
@@ -18944,7 +18159,7 @@ The uniqueness of each Atom is enforced by hashing its underlying data, preventi
 
 ### Decentralized Identifiers (DIDs)
 
-<h3 >Example DID</h3>
+### Example DID
 
 {`// An example DID
 
@@ -18976,15 +18191,15 @@ did:ethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736
 
 ## Components of an Atom
 
-<h4>Atom Data</h4>
+#### Atom Data
 
 Describes the concept or entity represented by an Atom, typically stored off-chain using decentralized storage solutions like IPFS or Arweave, with a URI pointing to this data stored on-chain.
 
-<h4>Atom Wallet</h4>
+#### Atom Wallet
 
 A smart contract wallet associated with each Atom, granting it agency over its identity. This wallet is controlled by a specialized smart contract known as the Atom Warden.
 
-<h4>Atom Vault</h4>
+#### Atom Vault
 
 A mechanism that allows users to deposit tokens into an Atom, signaling its relevance and support within the system. The Total Value Locked (TVL) in an Atom Vault indicates the Atom's acceptance and importance.
 
@@ -19004,17 +18219,17 @@ This mechanism incentivizes early discovery of important Atoms and creates a for
 
 To ensure reliable referencing of entities, concepts, or data within an Atom, each Atom must include at least minimal corresponding data. This data can be of any type, stored anywhere, and presented in any format.
 
-<h3 >Recommended Data Practices</h3>
+### Recommended Data Practices
 
-<h4 >Verifiable Data Registry</h4>
+#### Verifiable Data Registry
 
 Use a Verifiable Data Registry to strengthen data usability through guarantees around immutability, availability, liveness, and persistence.
 
-<h4 >Supported Structures</h4>
+#### Supported Structures
 
 Adhere to supported data structures and schemas for better interoperability and reliability.
 
-<h4 >Timestamp Inclusion</h4>
+#### Timestamp Inclusion
 
 For mutable data, include a timestamp to ensure future references understand exactly what the data represented at the moment of attestation.
 
@@ -19022,17 +18237,17 @@ For mutable data, include a timestamp to ensure future references understand exa
 
 Given the permissionless nature of the system, multiple Atoms may be representative of the same concept. To foster consensus on high-quality Atoms and establish canonical identifiers for all things, Intuition employs the concept of a Token Curated Registry (TCR).
 
-<h3 >TCR Benefits</h3>
+### TCR Benefits
 
-<h4 >Fractional Ownership</h4>
+#### Fractional Ownership
 
 Users gain fractional ownership over the Atoms they interact with and receive a portion of the interaction fees each respective Atom generates.
 
-<h4 >Incentivized Engagement</h4>
+#### Incentivized Engagement
 
 This model incentivizes engagement with popular Atoms, encouraging active participation in the ecosystem.
 
-<h4 >Quality Ranking</h4>
+#### Quality Ranking
 
 A TCR emerges, ranking Atoms based on their relevance using metrics such as an Atom's Total Value Locked (TVL).
 
@@ -19053,25 +18268,18 @@ The value or characteristic attributed to the subject through the predicate.
 
 This structure facilitates the creation of **Triples** that articulate specific assertions or facts about the world, which we'll explore in the next section.
 
----
-
 ## Next Steps
 
 Now that you understand Atom fundamentals, explore:
 
-- [Atom Structuring](./structuring) - Learn advanced techniques for structuring Atoms effectively
-- [Atom Best Practices](./best-practices) - Discover patterns and guidelines for creating high-quality Atoms
-- [Triple Fundamentals](../triples/fundamentals) - Learn how Atoms combine to form relationships
-- [Signal Fundamentals](../signals/fundamentals) - Understand how users interact with Atoms through signaling
-
----
-title: "Atom Structuring"
-description: "Advanced techniques for structuring Atoms effectively in the Intuition knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/structuring"
----
+- [Atom Structuring](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/structuring) - Learn advanced techniques for structuring Atoms effectively
+- [Atom Best Practices](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/best-practices) - Discover patterns and guidelines for creating high-quality Atoms
+- [Triple Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals) - Learn how Atoms combine to form relationships
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Understand how users interact with Atoms through signaling
 
 # Atom Structuring
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/structuring
 
 Understanding how to properly structure Atoms is crucial for building effective applications on the Intuition protocol. This guide covers advanced techniques and patterns for creating well-designed, reusable Atoms.
 
@@ -19295,22 +18503,15 @@ Ensure your atoms follow these validation rules:
 - Contribute to the ecosystem's growth
 - Engage with the community constructively
 
----
-
 ## Next Steps
 
-- [Atom Best Practices](./best-practices) - Detailed guidelines for effective Atom design
-- [Triple Fundamentals](../triples/fundamentals) - Learn how to connect Atoms into relationships
-- [Signal Fundamentals](../signals/fundamentals) - Understand how to measure Atom usage and relevance
-
----
-title: "Capturing Signal"
-description: "Advanced techniques for capturing and interpreting signal in the knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/capturing"
----
+- [Atom Best Practices](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/best-practices) - Detailed guidelines for effective Atom design
+- [Triple Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals) - Learn how to connect Atoms into relationships
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Understand how to measure Atom usage and relevance
 
 # Capturing Signal
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/capturing
 
 This guide covers advanced techniques for capturing signal from users and interpreting signal data within the Intuition ecosystem.
 
@@ -19419,21 +18620,14 @@ The economic model drives system improvement:
 3. Useful information becomes economically advantageous to support
 4. Irrelevant claims naturally receive less stake
 
----
-
 ## Next Steps
 
-- [Signal Rewards](./rewards) - Understand fee and reward calculations
-- [Signal Fundamentals](./fundamentals) - Review signal basics
-
----
-title: "Signal Fundamentals"
-description: "Understanding Signals - the trust and consensus layer of the knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals"
----
+- [Signal Rewards](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/rewards) - Understand fee and reward calculations
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Review signal basics
 
 # Signal Fundamentals
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals
 
 Signals represent the trust, confidence, or relevance that the community assigns to Atoms and Triples in the Intuition knowledge graph. Think of the knowledge graph as a weighted graph where Signal is the weight on each node (Atom) or edge (Triple), indicating how strongly people believe in or care about this information.
 
@@ -19531,23 +18725,16 @@ The consensus score weighs multiple variables:
 
 Creating an Atom or Triple is distinctly different from taking a position on them. While users have the option to both create and take a position at the time of creation, the Initial Deposit is not required. A user who makes no Initial Deposit will only create an Atom or Triple, which does not constitute a Signal.
 
----
-
 ## Next Steps
 
-- [Capturing Signal](./capturing) - Learn advanced techniques for signal capture
-- [Signal Rewards](./rewards) - Understand the economic incentives and reward distribution
-- [Atom Fundamentals](../atoms/fundamentals) - Review Atom basics
-- [Triple Fundamentals](../triples/fundamentals) - Review Triple basics
-
----
-title: "Signal Rewards"
-description: "Understanding fee structures and reward distribution for signal participants"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/rewards"
----
+- [Capturing Signal](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/capturing) - Learn advanced techniques for signal capture
+- [Signal Rewards](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/rewards) - Understand the economic incentives and reward distribution
+- [Atom Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals) - Review Atom basics
+- [Triple Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals) - Review Triple basics
 
 # Signal Rewards
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/rewards
 
 Understanding the economic incentives and reward mechanisms is crucial for participating effectively in the Intuition signal economy.
 
@@ -19667,22 +18854,15 @@ This creates an economy where:
 - Short-term speculation
 - Ignoring signal quality
 
----
-
 ## Next Steps
 
-- [Economics Overview](../../economics/bonding-curves) - Deep dive into bonding curve mechanics
-- [Fees & Rewards](../../economics/fees-rewards) - Detailed fee structure
-- [Signal Fundamentals](./fundamentals) - Review signal basics
-
----
-title: "Triple Fundamentals"
-description: "Understanding Triples - semantic relationships that form the knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals"
----
+- [Economics Overview](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - Deep dive into bonding curve mechanics
+- [Fees & Rewards](https://docs.intuition.systems/docs/intuition-concepts/economics/fees-and-rewards) - Detailed fee structure
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Review signal basics
 
 # Triple Fundamentals
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals
 
 If Atoms are the words in Intuition's global dictionary, Triples are the sentences we create from those words. A Triple connects three Atoms to assert a relationship or fact in the form **[Subject] – [Predicate] – [Object]**.
 
@@ -19696,15 +18876,15 @@ With discrete units of data established through Atoms, defining relationships be
 
 Triples consist of three elements: Subject, Predicate, and Object, with each element represented as an Atom. This Subject-Predicate-Object format allows users to clearly and explicitly define relationships between Atoms.
 
-<h3 >Subject</h3>
+### Subject
 
 The entity or concept being described in the relationship.
 
-<h3 >Predicate</h3>
+### Predicate
 
 The relationship or attribute that connects the subject to the object.
 
-<h3 >Object</h3>
+### Object
 
 The value or characteristic attributed to the subject through the predicate.
 
@@ -19790,24 +18970,15 @@ Triples allow Intuition to form a living, searchable web of knowledge. When addi
 
 With Atoms as the words in our global dictionary and Triples as the sentences we construct from them, we can express any arbitrarily-complex concept while maintaining discrete, referenceable structure.
 
----
-
 ## Next Steps
 
-- [Triple Structuring](./structuring) - Learn advanced techniques for creating effective Triples
-- [Nested Triples](./nested-triples) - Understand how to build complex, layered claims
-- [Signal Fundamentals](../signals/fundamentals) - Discover how the community validates Triples
-
----
-title: "Nested Triples"
-description: "Creating meta-claims and context through nested Triple structures"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples"
----
-
-# Nested Triples
+- [Triple Structuring](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/structuring) - Learn advanced techniques for creating effective Triples
+- [Nested Triples](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples) - Understand how to build complex, layered claims
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Discover how the community validates Triples
 
 # Nested Triples: Meta-Claims & Context
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples
 
 One of Intuition's most powerful features is that Triples can reference other Triples, effectively nesting statements to provide context or provenance. Intuition supports using a Triple itself as a Subject or Object in another Triple.
 
@@ -19866,21 +19037,14 @@ Each ID carries with it not just data, but the entire graph of relationships, ev
 [[Product X is good]] -- [number of attestors] --> [150]
 ```
 
----
-
 ## Next Steps
 
-- [Signal Fundamentals](../signals/fundamentals) - Learn how the community validates nested claims
-- [Triple Structuring](./structuring) - Review best practices for Triple design
-
----
-title: "Triple Structuring"
-description: "Advanced techniques for structuring effective Triples in the knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/structuring"
----
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Learn how the community validates nested claims
+- [Triple Structuring](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/structuring) - Review best practices for Triple design
 
 # Triple Structuring
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/structuring
 
 Understanding how to properly structure Triples is essential for building rich, queryable knowledge graphs. This guide covers techniques for creating well-designed semantic relationships.
 
@@ -19991,39 +19155,28 @@ const result = await createTripleStatement(
 - Consider how Triples might be queried together
 - Think about nested Triple possibilities
 
----
-
 ## Next Steps
 
-- [Nested Triples](./nested-triples) - Learn how to create meta-claims and context
-- [Signal Fundamentals](../signals/fundamentals) - Understand how to validate Triples
-
----
-title: "Primitives"
-description: "Understanding Intuition's core primitives - Atoms, Triples, and Signals - the building blocks of a decentralized knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/primitives"
----
-
-# Primitives
+- [Nested Triples](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples) - Learn how to create meta-claims and context
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - Understand how to validate Triples
 
 # Primitives Overview
 
+Source: https://docs.intuition.systems/docs/intuition-concepts/primitives
+
 Intuition's data model is built on three fundamental primitives that work together to create a rich, self-regulating knowledge graph. These primitives form the foundation of the ecosystem and enable the creation of a structured, semantic web of trust.
 
-<h2>Atoms</h2>
+## Atoms
 
 The basic entities or identifiers - unique decentralized identifiers for everything in existence. Think of them as the nodes in the knowledge graph, or the words in the dictionary. Atoms are Intuition's atomic unit of knowledge, enabling unique, persistent, canonical identifiers for all things - not just people.
 
-<h2>Triples</h2>
+## Triples
 
 Structured relationships or claims linking entities together in Subject-Predicate-Object format. These are the edges in the knowledge graph / the sentences in the language of Intuition. A composition of Atoms - defined as Semantic Triples which represent the relationships between Atoms.
 
-<h2>Signals</h2>
+## Signals
 
 The weight of Atoms and Triples, derived from the total amount of ETH deposited in Atom and Triple Vaults. These represent the edge weights in the graph, or 'who is saying what about what, with what level of conviction'. The weight of trust or consensus behind each entity or claim, determined by community staking.
-
----
 
 ## The Three Primitives Explained
 
@@ -20076,8 +19229,6 @@ Atoms are sometimes called "identities" in the protocol because they give any en
 
 Atoms are categorized into three primary roles within semantic structures: **Subjects**, **Predicates**, and **Objects**. This structure facilitates the creation of **Triples** that articulate specific assertions or facts about the world.
 
----
-
 ### Triples: Expressing Relationships as Claims
 
 A **Triple** is a structured claim that follows the semantic format of **[Subject] – [Predicate] – [Object]**, where each component is itself an Atom. This creates a precise, machine-readable way to express facts, relationships, and assertions about the world.
@@ -20110,23 +19261,21 @@ This meta-claim adds temporal context to the friendship relationship. Triples ca
 
 In many contexts, Triples are also referred to as **Claims** or **Attestations** because they represent assertions that can be verified, disputed, or supported by the community.
 
----
-
 ### Signals: Quantified Trust Through Staking
 
 **Signal** represents the aggregated attestation state of an Atom or Triple – essentially, how much the community trusts or believes in that piece of information. Signal is generated through economic staking, where users deposit tokens into an entity's vault to express their conviction.
 
 Signal in Intuition refers to any action that expresses intent, belief, or support within the system. Signals can be explicit, such as voting mechanisms or signed attestations, or implicit, inferred from user behavior.
 
-<h4>Positive Signal</h4>
+#### Positive Signal
 
 Users stake tokens to support an Atom or Triple, indicating they believe it's true, valuable, or important.
 
-<h4>Counter Signal</h4>
+#### Counter Signal
 
 Users can stake against claims they disagree with, creating a market for truth discovery.
 
-<h4>Dynamic Updates</h4>
+#### Dynamic Updates
 
 Signal changes in real-time as users stake, withdraw, or shift their positions, creating a living consensus.
 
@@ -20142,8 +19291,6 @@ Signal changes in real-time as users stake, withdraw, or shift their positions, 
 Users hold positions on Atoms and Triples, signaling their stance by increasing their balance on the relevant entities. Signals contribute to the nuanced expression of trust and belief, allowing for a dynamic and tiered system of preferences within the decentralized ecosystem.
 
 Creating an Atom or Triple is distinctly different from taking a position on them. While users have the option to both create and take a position on an Atom/Triple at the time of creation, this Initial Deposit is not required. A user who makes no Initial Deposit will only create an Atom or Triple, which does not constitute a Signal.
-
----
 
 ## How the Primitives Work Together
 
@@ -20174,27 +19321,23 @@ In this example:
 - **Triples** express relationships (Alice is a developer, Alice knows React)
 - **Signals** quantify community confidence (1000 TRUST backs the developer claim)
 
----
-
 ## Key Benefits of This Architecture
 
-<h3>Universal Composability</h3>
+### Universal Composability
 
 Any data type can become an Atom, and any relationship can be expressed as a Triple, creating infinite possibilities for knowledge representation.
 
-<h3>Self-Regulating Truth</h3>
+### Self-Regulating Truth
 
 Economic incentives through Signal staking create a market for truth, where accurate information naturally accumulates more support.
 
-<h3>Interoperability</h3>
+### Interoperability
 
 Standardized semantic structure enables different applications to understand and build upon the same knowledge graph.
 
-<h3>Progressive Trust</h3>
+### Progressive Trust
 
 Trust isn't binary – it's a spectrum measured by Signal strength, allowing for nuanced representation of confidence and belief.
-
----
 
 ## Getting Started with Primitives
 
@@ -20218,34 +19361,19 @@ To begin working with Intuition's primitives, consider these pathways:
 3. **Track Atom evolution** over time
 4. **Build prediction models** based on Signal dynamics
 
----
-
 ## Explore Primitives
 
-<h3>Atoms</h3>
+[Atoms Deep dive into Atoms - the fundamental building blocks. Learn about their structure, design principles, and best practices for creating effective Atoms.](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
-Deep dive into Atoms - the fundamental building blocks. Learn about their structure, design principles, and best practices for creating effective Atoms.
+[Triples Explore Triples - semantic relationships between Atoms. Understand how to structure complex claims, work with nested triples, and query the knowledge graph.](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
-<h3>Triples</h3>
-
-Explore Triples - semantic relationships between Atoms. Understand how to structure complex claims, work with nested triples, and query the knowledge graph.
-
-<h3>Signals</h3>
-
-Master Signals - the trust layer. Learn about staking mechanisms, signal interpretation, reward distribution, and how to leverage signals for consensus.
-
----
+[Signals Master Signals - the trust layer. Learn about staking mechanisms, signal interpretation, reward distribution, and how to leverage signals for consensus.](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 The beauty of Intuition's primitives lies in their simplicity and composability. Three simple concepts – Atoms, Triples, and Signals – combine to create a powerful system for decentralized knowledge and trust.
 
----
-title: "Trust Mechanisms Overview"
-description: "Understanding how trust and attestation work in the Intuition ecosystem"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-concepts/trust-mechanisms"
----
-
 # Trust Mechanisms Overview
+
+Source: https://docs.intuition.systems/docs/intuition-concepts/trust-mechanisms
 
 Intuition creates a decentralized trust layer through its primitives and economic incentives. This guide explains how trust emerges and is validated in the system.
 
@@ -20398,22 +19526,15 @@ Create personalized trust lenses:
 - Misinformation campaigns
 - Addressed through counter-signals
 
----
-
 ## Next Steps
 
-- [Signal Fundamentals](../primitives/signals/fundamentals) - How trust is expressed
-- [Architecture Overview](../architecture/system-design) - System design for trust
-- [Economics](../economics/bonding-curves) - Economic trust incentives
-
----
-title: "Intuition Network"
-description: "Intuition Network architecture and infrastructure"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/intuition-network"
----
+- [Signal Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) - How trust is expressed
+- [Architecture Overview](https://docs.intuition.systems/docs/intuition-concepts/architecture) - System design for trust
+- [Economics](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - Economic trust incentives
 
 # Intuition Network
+
+Source: https://docs.intuition.systems/docs/intuition-network
 
 Intuition Network is a specialized Layer 3 blockchain built on Arbitrum Orbit, optimized for knowledge graph operations and decentralized attestations.
 
@@ -20436,7 +19557,7 @@ Intuition leverages a multi-layer architecture designed for performance, cost-ef
 
 ## Network Details
 
-**For developer setup and configuration, see:** [Network Configuration](/docs/quick-start/network-details)
+**For developer setup and configuration, see:** [Network Configuration](https://docs.intuition.systems/docs/quick-start/network-details)
 
 ### Testnet
 
@@ -20462,7 +19583,7 @@ The Intuition mainnet is live.
 - **Explorer:** https://explorer.intuition.systems
 - **Currency:** $TRUST
 
-See the [Mainnet page](/docs/intuition-network/mainnet) for hub, bridge, explorer, and RPC details.
+See the [Mainnet page](https://docs.intuition.systems/docs/intuition-network/mainnet) for hub, bridge, explorer, and RPC details.
 
 ## Running a Node
 
@@ -20495,7 +19616,7 @@ The Rust-based indexing subnet provides:
 - **Real-time updates** - Live data synchronization
 - **Search APIs** - Query atoms, triples, and indexed graph data
 
-Learn more: [GraphQL API](/docs/graphql-api/overview)
+Learn more: [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)
 
 ### Settlement Layer
 
@@ -20520,21 +19641,21 @@ Gas costs on Intuition are dramatically lower than Ethereum:
 - **Staking** - Signal on atoms and triples
 - **Governance** - (Coming soon)
 
-See [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals) for information about staking and token usage.
+See [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals) for information about staking and token usage.
 
 ## Getting Started
 
 ### For Users
 
-1. **[Connect to Testnet](/docs/resources/faq#how-do-i-connect-to-the-intuition-testnet)** - Setup your wallet
+1. **[Connect to Testnet](https://docs.intuition.systems/docs/resources/faq#how-do-i-connect-to-the-intuition-testnet)** - Setup your wallet
 2. **[Get Test Tokens](https://intuition-testnet.hub.caldera.xyz/)** - Use the faucet
 3. **Explore Tools** - Use Portal and Explorer to interact with the network
 
 ### For Developers
 
-1. **[Network Configuration](/docs/quick-start/network-details)** - Configure your environment
-2. **[SDK Setup](/docs/intuition-sdk/installation-and-setup)** - Install development tools
-3. **[Quickstart Guide](/docs/quick-start/using-the-sdk)** - Build something!
+1. **[Network Configuration](https://docs.intuition.systems/docs/quick-start/network-details)** - Configure your environment
+2. **[SDK Setup](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)** - Install development tools
+3. **[Quickstart Guide](https://docs.intuition.systems/docs/quick-start/using-the-sdk)** - Build something!
 
 ### For Node Operators
 
@@ -20543,37 +19664,32 @@ Contact support for node setup and deployment information.
 ## Support & Monitoring
 
 - **[Network Status](https://status.intuition.systems)** - Real-time status monitoring
-- **[Community Support](/docs/resources/community-and-support)** - Get help
-- **[FAQ](/docs/resources/faq)** - Common questions
+- **[Community Support](https://docs.intuition.systems/docs/resources/community-and-support)** - Get help
+- **[FAQ](https://docs.intuition.systems/docs/resources/faq)** - Common questions
 
 ## Next Steps
 
-<h3 >
-Configure Development
-</h3>
+### Configure Development
 
 Set up your development environment to start building on Intuition.
 
-<h3 >
-Run a Node
-</h3>
+[Network Configuration →](https://docs.intuition.systems/docs/quick-start/network-details)
+
+### Run a Node
 
 Self-host the indexing layer for direct database access and GraphQL API.
 
-<h3 >
-Use Testnet Tools
-</h3>
+[Contact Support →](https://docs.intuition.systems/docs/resources/community-and-support)
+
+### Use Testnet Tools
 
 Access Portal, Bridge, Explorer, and other testnet services.
 
----
-title: "Intuition Mainnet"
-description: "Welcome to the Intuition Mainnet — the live Intuition network for building on the knowledge graph."
-last_updated: "2026-06-22T14:32:12-04:00"
-source: "https://docs.intuition.systems/docs/intuition-network/mainnet"
----
+[Testnet Explorer →](https://testnet.explorer.intuition.systems)
 
 # Intuition Mainnet
+
+Source: https://docs.intuition.systems/docs/intuition-network/mainnet
 
 Welcome to the Intuition Mainnet — the live Intuition network for building on the knowledge graph.
 
@@ -20613,14 +19729,9 @@ Access the Intuition Mainnet RPC directly at:
 
 The Intuition RPC accepts JSON-RPC requests and returns JSON-RPC responses. It provides programmatic access to the Intuition network.
 
----
-title: "Powered By Caldera"
-description: "The Intuition Network is powered by Caldera's Metalayer, a cross-chain infrastructure that enables seamless asset transfers between different blockchain networks."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-network/powered-by-caldera"
----
-
 # Powered By Caldera
+
+Source: https://docs.intuition.systems/docs/intuition-network/powered-by-caldera
 
 ### Intuition is Powered by Caldera's Metalayer
 The Intuition Network is powered by Caldera's Metalayer, a cross-chain infrastructure that enables seamless asset transfers between different blockchain networks.
@@ -20671,14 +19782,9 @@ The Metalayer uses advanced cryptographic techniques and consensus mechanisms to
 
 Need help? Join our [Discord](https://discord.gg/RgBenkX4mx) community for support.
 
----
-title: "Remote Procedure Call (RPC)"
-description: "The Intuition RPC (Remote Procedure Call) service provides programmatic access to the Intuition network."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-network/rpc"
----
-
 # Remote Procedure Call (RPC)
+
+Source: https://docs.intuition.systems/docs/intuition-network/rpc
 
 The Intuition RPC (Remote Procedure Call) service provides programmatic access to the Intuition network.
 
@@ -20735,30 +19841,9 @@ const block = await provider.getBlock('latest');
 
 RPC access requires authentication for production use:
 
-<svg width="14" height="14" viewBox="0 0 24 24" fill="white">
-<path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,7C13.4,7 14.8,8.6 14.8,10V11.5C14.8,14.1 12.4,16.5 9.8,16.5C7.2,16.5 4.8,14.1 4.8,11.5V10C4.8,8.6 6.2,7 7.6,7H12M12,8.2C11.2,8.2 10.5,8.9 10.5,9.7V11.5C10.5,12.9 11.6,14 13,14C14.4,14 15.5,12.9 15.5,11.5V9.7C15.5,8.9 14.8,8.2 14,8.2H12Z"/>
-</svg>
-
-<svg width="14" height="14" viewBox="0 0 24 24" fill="white">
-<path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,7C13.4,7 14.8,8.6 14.8,10V11.5C14.8,14.1 12.4,16.5 9.8,16.5C7.2,16.5 4.8,14.1 4.8,11.5V10C4.8,8.6 6.2,7 7.6,7H12M12,8.2C11.2,8.2 10.5,8.9 10.5,9.7V11.5C10.5,12.9 11.6,14 13,14C14.4,14 15.5,12.9 15.5,11.5V9.7C15.5,8.9 14.8,8.2 14,8.2H12Z"/>
-</svg>
-
-<svg width="14" height="14" viewBox="0 0 24 24" fill="white">
-<path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,7C13.4,7 14.8,8.6 14.8,10V11.5C14.8,14.1 12.4,16.5 9.8,16.5C7.2,16.5 4.8,14.1 4.8,11.5V10C4.8,8.6 6.2,7 7.6,7H12M12,8.2C11.2,8.2 10.5,8.9 10.5,9.7V11.5C10.5,12.9 11.6,14 13,14C14.4,14 15.5,12.9 15.5,11.5V9.7C15.5,8.9 14.8,8.2 14,8.2H12Z"/>
-</svg>
-
-<svg width="14" height="14" viewBox="0 0 24 24" fill="white">
-<path d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M12,7C13.4,7 14.8,8.6 14.8,10V11.5C14.8,14.1 12.4,16.5 9.8,16.5C7.2,16.5 4.8,14.1 4.8,11.5V10C4.8,8.6 6.2,7 7.6,7H12M12,8.2C11.2,8.2 10.5,8.9 10.5,9.7V11.5C10.5,12.9 11.6,14 13,14C14.4,14 15.5,12.9 15.5,11.5V9.7C15.5,8.9 14.8,8.2 14,8.2H12Z"/>
-</svg>
-
----
-title: "Intuition Testnet"
-description: "Welcome to the Intuition Testnet - your development and testing environment for building on the Intuition Network."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-network/testnet"
----
-
 # Intuition Testnet
+
+Source: https://docs.intuition.systems/docs/intuition-network/testnet
 
 Welcome to the Intuition Testnet - your development and testing environment for building on the Intuition Network.
 
@@ -20797,14 +19882,9 @@ Access the Intuition Testnet RPC directly at:
 
 The Intuition RPC accepts JSON-RPC requests and returns JSON-RPC responses. It provides programmatic access to the Intuition network.
 
----
-title: "Run on Kubernetes Cluster"
-description: "A comprehensive Kubernetes-based deployment infrastructure for blockchain indexing and data services, managed with ArgoCD and Terraform."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-node/kubernetes"
----
-
 # Run on Kubernetes Cluster
+
+Source: https://docs.intuition.systems/docs/intuition-node/kubernetes
 
 A comprehensive Kubernetes-based deployment infrastructure for blockchain indexing and data services, managed with ArgoCD and Terraform.
 
@@ -21039,14 +20119,9 @@ terraform plan
 - [Alchemy Dashboard](https://dashboard.alchemy.com/)
 - [Pinata Documentation](https://docs.pinata.cloud/)
 
----
-title: "Local Development Setup"
-description: "Set up your local environment for developing and testing Intuition node services."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-node/local-setup"
----
-
 # Local Development Setup
+
+Source: https://docs.intuition.systems/docs/intuition-node/local-setup
 
 Set up your local environment for developing and testing Intuition node services.
 
@@ -21078,14 +20153,9 @@ docker-compose -f docker/docker-compose-apps.yml up -d
 docker-compose -f docker/docker-compose-apps.yml logs -f
 ```
 
----
-title: "Overview"
-description: "Learn how to set up and run your own Intuition node to participate in the network using the official Rust implementation."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-node/overview"
----
-
 # Overview
+
+Source: https://docs.intuition.systems/docs/intuition-node/overview
 
 Learn how to set up and run your own Intuition node to participate in the network using the official Rust implementation.
 
@@ -21113,22 +20183,28 @@ Running your own Intuition node provides several key benefits:
 
 This workspace contains the following core services:
 
-<h3>Core Services</h3>
+### Core Services
 
 CLI: Terminal UI client for interacting with the Intuition system
+
 Consumer: Event processing pipeline using Redis Streams (RAW, DECODED, and RESOLVER consumers)
+
 Models: Domain models and data structures for the Intuition system
 
-<h3>Infrastructure Services</h3>
+### Infrastructure Services
 
 Hasura: GraphQL API with database migrations and configuration
+
 Image Guard: Image processing and validation service
+
 RPC Proxy: RPC call proxy with caching for eth_call methods
 
-<h3>Supporting Services</h3>
+### Supporting Services
 
 Histocrawler: Historical data crawler
+
 Shared Utils: Common utilities and shared code
+
 Migration Scripts: Database migration utilities
 
 ### Event Processing Pipeline
@@ -21143,14 +20219,6 @@ The system processes blockchain events through multiple stages:
 ## Prerequisites
 
 ### Required Tools
-
-<svg width="12" height="12" viewBox="0 0 24 24" fill="white"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"/></svg>
-
-<svg width="12" height="12" viewBox="0 0 24 24" fill="white"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"/></svg>
-
-<svg width="12" height="12" viewBox="0 0 24 24" fill="white"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"/></svg>
-
-<svg width="12" height="12" viewBox="0 0 24 24" fill="white"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"/></svg>
 
 ### Environment Configuration
 
@@ -21179,13 +20247,9 @@ Once you understand the architecture and have the prerequisites ready:
 2. Explore [Local Development Setup](local-setup.md) for development workflows
 3. Check [Kubernetes Deployment](kubernetes.md) for production deployments
 
----
-title: "Run an Intuition Node"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-node/run-an-intuition-node"
----
-
 # Run an Intuition Node
+
+Source: https://docs.intuition.systems/docs/intuition-node/run-an-intuition-node
 
 ## Running the System
 
@@ -21333,14 +20397,9 @@ Once your node is running successfully:
 
 The node implementation is under active development, so check the repository regularly for updates and new features.
 
----
-title: "Rust Backend"
-description: "The `intuition-rs` repository is organized as a Rust workspace, which provides several key benefits:"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-node/rust-backend"
----
-
 # Rust Backend
+
+Source: https://docs.intuition.systems/docs/intuition-node/rust-backend
 
 ## The Intuition Rust Monorepo
 
@@ -21417,31 +20476,31 @@ intuition-rs/
 
 ### Core Applications
 
-<h3>CLI</h3>
+### CLI
 
 Terminal UI client for interacting with the Intuition system
 
-<h3>Consumer</h3>
+### Consumer
 
 Event processing pipeline using Redis Streams
 
-<h3>Histocrawler</h3>
+### Histocrawler
 
 Historical data crawler for blockchain indexing
 
-<h3>Image Guard</h3>
+### Image Guard
 
 Image processing and validation service
 
-<h3>RPC Proxy</h3>
+### RPC Proxy
 
 RPC call proxy with intelligent caching
 
-<h3>Models</h3>
+### Models
 
 Domain models and data structures
 
-<h3>Shared Utils</h3>
+### Shared Utils
 
 Common utilities used across services
 
@@ -21468,58 +20527,63 @@ The repository includes comprehensive tooling:
 
 The Intuition backend is built with Rust, a systems programming language that offers unique advantages for blockchain infrastructure:
 
-<h3>Performance and Efficiency</h3>
+### Performance and Efficiency
 
 Zero-cost abstractions: Write high-level code without runtime overhead
+
 Memory efficiency: Minimal memory footprint compared to garbage-collected languages
+
 Concurrent processing: Built-in support for safe concurrent operations
+
 Native performance: Compiles to machine code for maximum speed
 
-<h3>Safety and Reliability</h3>
+### Safety and Reliability
 
 Memory safety: Eliminates entire classes of bugs (null pointer dereferences, buffer overflows, data races)
+
 Type safety: Strong static typing catches errors at compile time
+
 Error handling: Explicit error handling through Result types
+
 No runtime crashes: Memory safety guarantees prevent unexpected crashes
 
-<h3>Developer Experience</h3>
+### Developer Experience
 
 Modern tooling: Cargo package manager and build system
+
 Rich ecosystem: Growing library ecosystem for blockchain and web services
+
 Documentation: Built-in documentation tools and testing framework
+
 Community: Active and supportive open-source community
 
-<h3>Blockchain-Specific Benefits</h3>
+### Blockchain-Specific Benefits
 
 Predictable performance: No garbage collection pauses during critical operations
-Resource optimization: Efficient resource usage for indexing large amounts of blockchain data
-WebAssembly support: Can compile to WASM for cross-platform compatibility
-Security: Memory safety is crucial when handling financial transactions and user data
 
----
-title: "Working with Atoms"
-description: "Create and query atoms using the SDK"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/atoms-guide"
----
+Resource optimization: Efficient resource usage for indexing large amounts of blockchain data
+
+WebAssembly support: Can compile to WASM for cross-platform compatibility
+
+Security: Memory safety is crucial when handling financial transactions and user data
 
 # Working with Atoms
 
-**Conceptual overview:** [Atoms Fundamentals](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+Source: https://docs.intuition.systems/docs/intuition-sdk/atoms-guide
+
+**Conceptual overview:** [Atoms Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 Atoms are unique identifiers for any entity—people, concepts, smart contracts, or data. This guide covers all ways to create and query atoms using the SDK.
 
 ## Table of Contents
 
-- [Creating from Strings](#creating-from-strings)
-- [Creating from Thing (JSON-LD)](#creating-from-thing)
-- [Creating from Ethereum Accounts](#creating-from-ethereum-accounts)
-- [Creating from Smart Contracts](#creating-from-smart-contracts)
-- [Creating from IPFS](#creating-from-ipfs)
-- [Batch Creation](#batch-creation)
-- [Querying Atoms](#querying-atoms)
-
----
+- [Creating from Strings](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-strings)
+- [Creating from Thing (JSON-LD)](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-thing)
+- [Creating from Ethereum Accounts](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-ethereum-accounts)
+- [Creating from Smart Contracts](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-smart-contracts)
+- [Creating from IPFS](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-ipfs)
+- [Batch Creation](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#batch-creation)
+- [Querying Atoms](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#querying-atoms)
 
 ## Creating from Strings
 
@@ -21535,7 +20599,7 @@ function createAtomFromString(
 ): Promise<AtomCreationResult>;
 ```
 
-### Parameters
+### Creating from Strings - Parameters
 
 | Parameter | Type          | Description                                                           | Required |
 | --------- | ------------- | --------------------------------------------------------------------- | -------- |
@@ -21642,8 +20706,6 @@ if (exists) {
 }
 ```
 
----
-
 ## Creating from Thing
 
 Create atoms from structured JSON-LD objects for rich metadata.
@@ -21737,8 +20799,6 @@ const person = await createAtomFromThing(
 3. **Create Atom**: The atom is created with the IPFS URI as its data
 4. **Return**: Returns the atom details with the IPFS URI
 
----
-
 ## Creating from Ethereum Accounts
 
 Create atoms representing Ethereum wallet addresses.
@@ -21807,8 +20867,6 @@ const triple = await createTripleStatement(config, {
 });
 ```
 
----
-
 ## Creating from Smart Contracts
 
 Create atoms representing smart contract addresses.
@@ -21859,8 +20917,6 @@ const compound = await createAtomFromSmartContract(
   '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP token
 );
 ```
-
----
 
 ## Creating from IPFS
 
@@ -21938,8 +20994,6 @@ console.log('Atom ID:', atom.state.termId);
 console.log('IPFS URI:', atom.uri); // ipfs://bafkrei...
 ```
 
----
-
 ## Batch Creation
 
 Create multiple atoms in a single transaction for improved efficiency and reduced gas costs.
@@ -21991,8 +21045,6 @@ Batch creation saves significant gas compared to individual transactions:
 | 5     | ~750k gas      | ~300k gas | 60%     |
 | 10    | ~1.5M gas      | ~450k gas | 70%     |
 | 50    | ~7.5M gas      | ~1.5M gas | 80%     |
-
----
 
 ## Querying Atoms
 
@@ -22097,8 +21149,6 @@ async function getMultipleAtoms(atomIds: string[]) {
 }
 ```
 
----
-
 ## Response Data Structure
 
 After successfully creating an atom, the SDK returns a data object with transaction details and state:
@@ -22127,28 +21177,21 @@ console.log('Creator:', result.state.creator);
 console.log('Vault Wallet:', result.state.atomWallet);
 ```
 
----
-
 ## Complete Examples
 
 See working examples in the SDK Examples section
 
 ## Next Steps
 
-- [Working with Triples](/docs/intuition-sdk/triples-guide)
-- [Working with Vaults](/docs/intuition-sdk/vaults-guide)
-- [SDK Integrations](/docs/intuition-sdk/integrations/react)
-
----
-title: "Example: Batch Create Ethereum Accounts"
-description: "Create multiple identity atoms from Ethereum addresses in one transaction"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/batch-ethereum-accounts"
----
+- [Working with Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
+- [Working with Vaults](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
+- [SDK Integrations](https://docs.intuition.systems/docs/intuition-sdk/integrations/react)
 
 # Example: Batch Create Ethereum Accounts
 
-# Example: Batch Create Ethereum Account Atoms
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/batch-ethereum-accounts
+
+## Example: Batch Create Ethereum Account Atoms
 
 This example demonstrates creating multiple identity atoms from Ethereum addresses in a single transaction.
 
@@ -22223,17 +21266,12 @@ main()
 
 ## See Also
 
-- [batchCreateAtomsFromEthereumAccounts](../atoms/batch-creation.md)
-- [Batch Creation Guide](../atoms/batch-creation.md)
-
----
-title: "Example: Bulk Sync with Cost Estimation"
-description: "Use the experimental sync function to estimate costs for bulk operations"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/bulk-sync-cost-estimation"
----
+- [batchCreateAtomsFromEthereumAccounts](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [Batch Creation Guide](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 # Example: Bulk Sync with Cost Estimation
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/bulk-sync-cost-estimation
 
 This example demonstrates using the experimental `sync` function to estimate costs for creating a knowledge graph.
 
@@ -22361,16 +21399,11 @@ npx tsx bulk-sync-example.ts --execute
 ## See Also
 
 - sync Function (Experimental)
-- [Batch Creation](../atoms/batch-creation.md)
-
----
-title: "Example: Create Atom from String"
-description: "Complete example of creating an atom from a text string"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/create-atom-from-string"
----
+- [Batch Creation](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 # Example: Create Atom from String
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/create-atom-from-string
 
 This example demonstrates creating an atom from a plain text string, including setup, error handling, and querying the result.
 
@@ -22504,18 +21537,13 @@ Success!
 
 ## See Also
 
-- [createAtomFromString](../atoms/create-from-string.md)
-- [getAtomDetails](../atoms/querying.md)
-- [Quick Start Guide](../getting-started/quick-start.md)
-
----
-title: "Example: Create Triple Statement"
-description: "Complete example of creating a subject-predicate-object triple"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/create-triple-statement"
----
+- [createAtomFromString](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [getAtomDetails](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [Quick Start Guide](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 # Example: Create Triple Statement
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/create-triple-statement
 
 This example demonstrates creating a complete triple (subject-predicate-object statement).
 
@@ -22617,17 +21645,12 @@ main()
 
 ## See Also
 
-- [createTripleStatement](../triples/create-triple.md)
-- [Create Atom Example](./create-atom-from-string.md)
-
----
-title: "Example: Deposit into Vault"
-description: "Deposit assets into an atom vault and receive shares"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/deposit-into-vault"
----
+- [createTripleStatement](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
+- [Create Atom Example](https://docs.intuition.systems/docs/intuition-sdk/examples/create-atom-from-string)
 
 # Example: Deposit into Vault
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/deposit-into-vault
 
 This example demonstrates depositing assets into a vault and tracking share balances.
 
@@ -22733,18 +21756,13 @@ main()
 
 ## See Also
 
-- [deposit](../vaults/deposits.md)
-- [Vault Queries](../vaults/queries.md)
-- [Vault Previews](../vaults/previews.md)
-
----
-title: "Example: Find Existing Entities"
-description: "Search for existing atoms and triples before creating new ones"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/find-existing-entities"
----
+- [deposit](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
+- [Vault Queries](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
+- [Vault Previews](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 # Example: Find Existing Entities
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/find-existing-entities
 
 This example demonstrates how to find existing atoms and triples to avoid creating duplicates.
 
@@ -22884,19 +21902,14 @@ main()
 
 ## See Also
 
-- [findAtomIds](../search/advanced-queries.md#findatomids)
-- [findTripleIds](../search/advanced-queries.md#findtripleids)
-- [calculateAtomId](../atoms/querying.md#calculateatomid)
-- [calculateTripleId](../triples/querying.md#calculatetripleid)
-
----
-title: "Example: Global Search"
-description: "Search across atoms, accounts, triples, and collections"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/global-search"
----
+- [findAtomIds](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
+- [findTripleIds](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
+- [calculateAtomId](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [calculateTripleId](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
 
 # Example: Global Search
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/global-search
 
 This example demonstrates using global search to find entities across the Intuition protocol.
 
@@ -22971,17 +21984,12 @@ main()
 
 ## See Also
 
-- [globalSearch](../search/global-search.md)
-- [getAtomDetails](../atoms/querying.md)
-
----
-title: "Example: Thing IPFS Pinning"
-description: "Create rich entities with JSON-LD and automatic IPFS pinning"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/examples/thing-ipfs-pinning"
----
+- [globalSearch](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
+- [getAtomDetails](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 # Example: Thing IPFS Pinning
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/examples/thing-ipfs-pinning
 
 This example demonstrates creating a rich entity (Thing) with automatic IPFS pinning.
 
@@ -23075,18 +22083,13 @@ main()
 
 ## See Also
 
-- [createAtomFromThing](../atoms-guide.md#creating-from-thing)
-- [pinThing](../integrations/pinata-ipfs.md)
-- [IPFS Integration](../integrations/pinata-ipfs.md)
-
----
-title: "Installation & Setup"
-description: "Install the Intuition SDK and configure your development environment"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup"
----
+- [createAtomFromThing](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-thing)
+- [pinThing](https://docs.intuition.systems/docs/intuition-sdk/integrations/pinata-ipfs)
+- [IPFS Integration](https://docs.intuition.systems/docs/intuition-sdk/integrations/pinata-ipfs)
 
 # Installation & Setup
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup
 
 The Intuition SDK is a comprehensive TypeScript library for building applications on the Intuition protocol. This guide covers installation, configuration, and getting your development environment ready.
 
@@ -23138,8 +22141,6 @@ console.log(
 ```
 
 Run it with `npx tsx test-install.ts` or your preferred TypeScript runner.
-
----
 
 ## Client Configuration
 
@@ -23194,8 +22195,6 @@ const config: WriteConfig = {
 };
 ```
 
----
-
 ## Network Configuration
 
 The SDK supports multiple networks with built-in chain definitions.
@@ -23245,8 +22244,6 @@ const publicClient = createPublicClient({
 // Explorer: https://explorer.intuition.systems
 ```
 
----
-
 ## Contract Addresses
 
 The SDK provides utilities to get contract addresses for any supported network:
@@ -23265,8 +22262,6 @@ const multiVaultAddress = getMultiVaultAddressFromChainId(chainId);
 const trustBonding = getContractAddressFromChainId('TrustBonding', chainId);
 const wrappedTrust = getContractAddressFromChainId('WrappedTrust', chainId);
 ```
-
----
 
 ## Account Options
 
@@ -23298,8 +22293,6 @@ const walletClient = createWalletClient({
 });
 ```
 
----
-
 ## Environment Variables
 
 Store sensitive data in environment variables:
@@ -23321,8 +22314,6 @@ configureSdk({
 });
 ```
 
----
-
 ## TypeScript Configuration
 
 For optimal TypeScript support:
@@ -23341,8 +22332,6 @@ For optimal TypeScript support:
   }
 }
 ```
-
----
 
 ## Advanced Configuration
 
@@ -23384,8 +22373,6 @@ const publicClient = createPublicClient({
   },
 });
 ```
-
----
 
 ## Complete Configuration Example
 
@@ -23437,8 +22424,6 @@ export const config: WriteConfig = {
 };
 ```
 
----
-
 ## Optional: Pinata for IPFS
 
 For direct Pinata upload operations, you'll need a Pinata API token:
@@ -23464,13 +22449,9 @@ const atom = await createAtomFromIpfsUpload(
 );
 ```
 
----
-
 ## Local Development
 
 For contributing or testing with a custom build:
-
----
 
 ## Troubleshooting
 
@@ -23491,36 +22472,27 @@ npm install
 2. Update `@types/node` to the latest version
 3. Run `npx tsc --noEmit` to check for type errors
 
----
-
 ## Package Information
 
 - **NPM**: [@0xintuition/sdk](https://www.npmjs.com/package/@0xintuition/sdk)
 - **Repository**: [github.com/0xIntuition/intuition-ts](https://github.com/0xIntuition/intuition-ts)
 - **Discord**: [Intuition Discord](https://discord.gg/RgBenkX4mx)
 
----
-
 ## Next Steps
 
-- [**Quick Start**](./quick-start.md) - Create your first atom and triple
-- [**Working with Atoms**](./atoms-guide.md) - Learn about creating atoms
-- [**React Integration**](./integrations/react.md) - Use the SDK with React
+- [**Quick Start**](https://docs.intuition.systems/docs/intuition-sdk/quick-start) - Create your first atom and triple
+- [**Working with Atoms**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide) - Learn about creating atoms
+- [**React Integration**](https://docs.intuition.systems/docs/intuition-sdk/integrations/react) - Use the SDK with React
 
 ## See Also
 
 - [Viem Documentation](https://viem.sh)
-- [Protocol Package](/docs/protocol/getting-started/overview) - Low-level contract interactions
-- [GraphQL API](/docs/graphql-api/overview) - Query protocol data
-
----
-title: "IPFS Pinning"
-description: "Pin metadata to IPFS using the Intuition pinning service or direct Pinata uploads"
-last_updated: "2026-06-25T15:48:40-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/integrations/pinata-ipfs"
----
+- [Protocol Package](https://docs.intuition.systems/docs/protocol/getting-started/overview) - Low-level contract interactions
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview) - Query protocol data
 
 # IPFS Pinning
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/integrations/pinata-ipfs
 
 The SDK supports two IPFS paths:
 
@@ -23723,24 +22695,19 @@ Common causes include a missing `pinApiKey`, an invalid API key, missing metadat
 
 ## Related Functions
 
-- [**createAtomFromThing**](../atoms-guide.md#creating-from-thing) - Create atom with auto-pinning
-- [**createAtomFromIpfsUri**](../atoms-guide.md#createatomfromipfsuri) - Create from IPFS URI
-- [**createAtomFromIpfsUpload**](../atoms-guide.md#createatomfromipfsupload) - Upload directly to Pinata and create
+- [**createAtomFromThing**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-thing) - Create atom with auto-pinning
+- [**createAtomFromIpfsUri**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#createatomfromipfsuri) - Create from IPFS URI
+- [**createAtomFromIpfsUpload**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#createatomfromipfsupload) - Upload directly to Pinata and create
 
 ## See Also
 
-- [Example: Thing IPFS Pinning](../examples/thing-ipfs-pinning.md)
+- [Example: Thing IPFS Pinning](https://docs.intuition.systems/docs/intuition-sdk/examples/thing-ipfs-pinning)
 - [Pinata Documentation](https://docs.pinata.cloud/)
 - [IPFS Documentation](https://docs.ipfs.tech/)
 
----
-title: "React Integration"
-description: "Integrate the Intuition SDK with React applications using Wagmi hooks"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/integrations/react"
----
-
 # React Integration
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/integrations/react
 
 Use the Intuition SDK with React applications via Wagmi hooks for wallet connectivity and blockchain interactions.
 
@@ -24029,23 +22996,18 @@ export function AtomManager() {
 
 ## Related Resources
 
-- [TanStack Query Integration](./tanstack-query.md)
+- [TanStack Query Integration](https://docs.intuition.systems/docs/intuition-sdk/integrations/tanstack-query)
 - [Wagmi Documentation](https://wagmi.sh)
-- [SDK Quick Start](../getting-started/quick-start.md)
+- [SDK Quick Start](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ## See Also
 
 - [Wagmi Hooks Reference](https://wagmi.sh/react/hooks)
 - [TanStack Query](https://tanstack.com/query)
 
----
-title: "TanStack Query Integration"
-description: "Use the Intuition SDK with TanStack Query for optimized data fetching and caching"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/integrations/tanstack-query"
----
-
 # TanStack Query Integration
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/integrations/tanstack-query
 
 Integrate the Intuition SDK with TanStack Query (React Query) for powerful data fetching, caching, and synchronization.
 
@@ -24360,24 +23322,19 @@ function AtomWithTriples({ atomId }: { atomId: string }) {
 
 ## Related Resources
 
-- [React Integration](./react.md)
+- [React Integration](https://docs.intuition.systems/docs/intuition-sdk/integrations/react)
 - [TanStack Query Documentation](https://tanstack.com/query)
 
 ## See Also
 
 - [Wagmi Hooks](https://wagmi.sh)
-- [SDK Query Functions](../search/global-search.md)
-
----
-title: "SDK Migration V1 to V2"
-description: "Migrating SDK from v1.5 to v2.0"
-last_updated: "2026-06-22T14:26:07-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/migration-guide"
----
+- [SDK Query Functions](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
 
 # SDK Migration V1 to V2
 
-# Migrating SDK from v1.5 to v2.0
+Source: https://docs.intuition.systems/docs/intuition-sdk/migration-guide
+
+## Migrating SDK from v1.5 to v2.0
 
 This guide helps you migrate your code from v1.x to v2.0.0-alpha of the Intuition TypeScript packages. This is a **major version update** with significant breaking changes due to the underlying contract migration from `EthMultiVault` to `MultiVault`.
 
@@ -25010,14 +23967,9 @@ This major version update consolidates and simplifies the API while adding new f
 
 Take your time with the migration and test thoroughly. The new API is more powerful and consistent, providing a better developer experience.
 
----
-title: "Quick Start"
-description: "Create your first atom and triple with the Intuition SDK in minutes"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/quick-start"
----
-
 # Quick Start
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/quick-start
 
 Get started with the Intuition SDK by creating your first atom and triple in minutes.
 
@@ -25049,7 +24001,7 @@ In this quick start guide, you'll:
 
 ## Prerequisites
 
-- [Installed the SDK](./installation.md)
+- [Installed the SDK](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
 - Have a wallet with testnet TRUST tokens ([get testnet tokens](https://testnet.faucet.intuition.systems))
 - Your wallet private key
 
@@ -25302,20 +24254,20 @@ Each atom and triple has a vault for deposits:
 Now that you've created your first atom and triple, explore:
 
 ### Atom Operations
-- [**Create from Thing**](../atoms/create-from-thing.md) - Create rich entities with metadata
-- [**Create from Ethereum Account**](../atoms/create-from-ethereum-account.md) - Create identity atoms
-- [**Batch Creation**](../atoms/batch-creation.md) - Create multiple atoms efficiently
+- [**Create from Thing**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide) - Create rich entities with metadata
+- [**Create from Ethereum Account**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide) - Create identity atoms
+- [**Batch Creation**](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide) - Create multiple atoms efficiently
 
 ### Triple Operations
-- [**Querying Triples**](../triples/querying.md) - Fetch triple details
-- [**Counter Triples**](../triples/counter-triples.md) - Work with opposing positions
+- [**Querying Triples**](https://docs.intuition.systems/docs/intuition-sdk/triples-guide) - Fetch triple details
+- [**Counter Triples**](https://docs.intuition.systems/docs/intuition-sdk/triples-guide) - Work with opposing positions
 
 ### Vault Operations
-- [**Deposits**](../vaults/deposits.md) - Deposit into vaults
-- [**Redemptions**](../vaults/redemptions.md) - Redeem shares
+- [**Deposits**](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide) - Deposit into vaults
+- [**Redemptions**](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide) - Redeem shares
 
 ### Search & Discovery
-- [**Global Search**](../search/global-search.md) - Search across all entities
+- [**Global Search**](https://docs.intuition.systems/docs/intuition-sdk/search-guide) - Search across all entities
 
 ## Common Issues
 
@@ -25346,29 +24298,22 @@ console.log('Chain ID:', intuitionTestnet.id)
 
 ## See Also
 
-- [Core Concepts](../../../core-concepts/primitives/overview.md) - Understand atoms and triples
-- [SDK Examples](../examples/create-atom-from-string.md) - More detailed examples
-- [GraphQL Queries](../../graphql-api/queries/atoms/single-atom.md) - Query protocol data
-
----
-title: "Search and Discovery"
-description: "Search atoms, triples, and perform advanced queries"
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/search-guide"
----
+- [Core Concepts](https://docs.intuition.systems/docs/intuition-concepts/primitives) - Understand atoms and triples
+- [SDK Examples](https://docs.intuition.systems/docs/intuition-sdk/examples/create-atom-from-string) - More detailed examples
+- [GraphQL Queries](https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-atom) - Query protocol data
 
 # Search and Discovery
+
+Source: https://docs.intuition.systems/docs/intuition-sdk/search-guide
 
 Discover atoms, triples, accounts, and collections using search, filters, and batch entity lookups.
 
 ## Table of Contents
 
-- [Global Search](#global-search)
-- [Searching Atoms](#searching-atoms)
-- [Searching Triples](#searching-triples)
-- [Advanced Queries](#advanced-queries)
-
----
+- [Global Search](https://docs.intuition.systems/docs/intuition-sdk/search-guide#global-search)
+- [Searching Atoms](https://docs.intuition.systems/docs/intuition-sdk/search-guide#searching-atoms)
+- [Searching Triples](https://docs.intuition.systems/docs/intuition-sdk/search-guide#searching-triples)
+- [Advanced Queries](https://docs.intuition.systems/docs/intuition-sdk/search-guide#advanced-queries)
 
 ## Global Search
 
@@ -25383,7 +24328,7 @@ function globalSearch(
 ): Promise<GlobalSearchResults | null>
 ```
 
-### Parameters
+### Global Search - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -25566,8 +24511,6 @@ if (!results) {
 console.log('Found', results.atoms.length, 'atoms')
 ```
 
----
-
 ## Searching Atoms
 
 Search for atoms using the global search function and other query methods.
@@ -25611,8 +24554,6 @@ atoms.forEach(atom => {
   }
 })
 ```
-
----
 
 ## Searching Triples
 
@@ -25659,8 +24600,6 @@ triples.forEach(triple => {
   }
 })
 ```
-
----
 
 ## Advanced Queries
 
@@ -25848,39 +24787,30 @@ await processInBatches(allData, 100, async (batch) => {
 })
 ```
 
----
-
 ## Complete Examples
 
 See working examples in the SDK Examples section
 
 ## Next Steps
 
-- [Working with Atoms](/docs/intuition-sdk/atoms-guide) - Create and manage atoms
-- [Working with Triples](/docs/intuition-sdk/triples-guide) - Build relationships
-- [SDK Integrations](/docs/intuition-sdk/integrations/react) - Use with React
-
----
-title: "Working with Triples"
-description: "Create and query triples using the SDK"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/triples-guide"
----
+- [Working with Atoms](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide) - Create and manage atoms
+- [Working with Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide) - Build relationships
+- [SDK Integrations](https://docs.intuition.systems/docs/intuition-sdk/integrations/react) - Use with React
 
 # Working with Triples
 
-**Conceptual overview:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+Source: https://docs.intuition.systems/docs/intuition-sdk/triples-guide
+
+**Conceptual overview:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 Triples are subject-predicate-object statements that connect three atoms to form relationships in the knowledge graph. This guide covers all ways to create and query triples using the SDK.
 
 ## Table of Contents
 
-- [Creating Triples](#creating-triples)
-- [Batch Creation](#batch-creation)
-- [Querying Triples](#querying-triples)
-- [Counter-Triples](#counter-triples)
-
----
+- [Creating Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#creating-triples)
+- [Batch Creation](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#batch-creation)
+- [Querying Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#querying-triples)
+- [Counter-Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#counter-triples)
 
 ## Creating Triples
 
@@ -25903,7 +24833,7 @@ function createTripleStatement(
 ): Promise<TripleCreationResult>
 ```
 
-### Parameters
+### Creating Triples - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -25914,7 +24844,7 @@ function createTripleStatement(
 | `args.args[3]` | `bigint[]` | Deposit per triple | Yes |
 | `args.value` | `bigint` | Total transaction value | Yes |
 
-### Returns
+### Creating Triples - Returns
 
 ```typescript
 type TripleCreationResult = {
@@ -26114,8 +25044,6 @@ const triple = await createTripleStatement(config, {
 })
 ```
 
----
-
 ## Batch Creation
 
 Create multiple triples in a single transaction for improved efficiency and reduced gas costs.
@@ -26132,7 +25060,7 @@ function batchCreateTripleStatements(
 ): Promise<TripleCreationResult>
 ```
 
-### Parameters
+### Batch Creation - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -26216,8 +25144,6 @@ Batch triple creation saves significant gas:
 | 5 | ~1M gas | ~500k gas | 50% |
 | 10 | ~2M gas | ~850k gas | 57% |
 
----
-
 ## Querying Triples
 
 Query triple information and calculate triple IDs.
@@ -26232,13 +25158,13 @@ Fetch comprehensive triple details from the Intuition API.
 function getTripleDetails(tripleId: string): Promise<TripleDetails>
 ```
 
-#### Parameters
+#### getTripleDetails - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | `tripleId` | `string` | Triple ID (hex string) | Yes |
 
-#### Returns
+#### getTripleDetails - Returns
 
 ```typescript
 type TripleDetails = {
@@ -26321,8 +25247,6 @@ async function tripleExists(
 }
 ```
 
----
-
 ## Counter-Triples
 
 Every triple has a counter-triple representing the opposing position. Users can stake either FOR or AGAINST a statement.
@@ -26337,7 +25261,7 @@ Calculate the counter-triple ID from a triple ID.
 function calculateCounterTripleId(tripleId: Hex): Hex
 ```
 
-#### Parameters
+#### calculateCounterTripleId - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -26473,39 +25397,30 @@ async function comparePositions(tripleId: Hex) {
 }
 ```
 
----
-
 ## Complete Examples
 
 See working examples in the SDK Examples section
 
 ## Next Steps
 
-- [Working with Vaults](/docs/intuition-sdk/vaults-guide) - Deposit and redeem from vaults
-- [Search and Discovery](/docs/intuition-sdk/search-guide) - Find triples
-- [SDK Integrations](/docs/intuition-sdk/integrations/react) - Use with React
-
----
-title: "Working with Vaults"
-description: "Deposit, redeem, and query vaults using the SDK"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-sdk/vaults-guide"
----
+- [Working with Vaults](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide) - Deposit and redeem from vaults
+- [Search and Discovery](https://docs.intuition.systems/docs/intuition-sdk/search-guide) - Find triples
+- [SDK Integrations](https://docs.intuition.systems/docs/intuition-sdk/integrations/react) - Use with React
 
 # Working with Vaults
 
-**Conceptual overview:** [Signals Fundamentals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+Source: https://docs.intuition.systems/docs/intuition-sdk/vaults-guide
+
+**Conceptual overview:** [Signals Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 Vaults enable staking on atoms and triples through bonding curve-based share pricing. This guide covers deposits, redemptions, queries, and preview operations.
 
 ## Table of Contents
 
-- [Deposits](#deposits)
-- [Redemptions](#redemptions)
-- [Vault Queries](#vault-queries)
-- [Preview Operations](#preview-operations)
-
----
+- [Deposits](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#deposits)
+- [Redemptions](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#redemptions)
+- [Vault Queries](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#vault-queries)
+- [Preview Operations](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#preview-operations)
 
 ## Deposits
 
@@ -26530,7 +25445,7 @@ function deposit(
 ): Promise<TransactionReceipt>
 ```
 
-#### Parameters
+#### deposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -26763,8 +25678,6 @@ await deposit(config, [
 ])
 ```
 
----
-
 ## Redemptions
 
 Redeem shares from atom or triple vaults to receive assets back.
@@ -26788,7 +25701,7 @@ function redeem(
 ): Promise<TransactionReceipt>
 ```
 
-#### Parameters
+#### redeem - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -26994,8 +25907,6 @@ await redeem(config, [
 ])
 ```
 
----
-
 ## Vault Queries
 
 Query vault information including share balances, vault details, and asset conversions.
@@ -27079,8 +25990,6 @@ const price = await multiVaultCurrentSharePrice(
 
 console.log('Share price:', formatEther(price), 'TRUST')
 ```
-
----
 
 ## Preview Operations
 
@@ -27197,26 +26106,19 @@ const bestIndex = previews.indexOf(Math.max(...previews.map(Number)))
 console.log('Best vault:', vaults[bestIndex])
 ```
 
----
-
 ## Complete Examples
 
 See working examples in the SDK Examples section
 
 ## Next Steps
 
-- [Search and Discovery](/docs/intuition-sdk/search-guide) - Find atoms and triples
-- [SDK Integrations](/docs/intuition-sdk/integrations/react) - Use with React
-- [Protocol Reference](/docs/protocol/api-reference/multivault/vaults) - Low-level vault operations
-
----
-title: "Audit Reports"
-description: "Security audit reports for Intuition smart contracts"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-smart-contracts/audit-reports"
----
+- [Search and Discovery](https://docs.intuition.systems/docs/intuition-sdk/search-guide) - Find atoms and triples
+- [SDK Integrations](https://docs.intuition.systems/docs/intuition-sdk/integrations/react) - Use with React
+- [Protocol Reference](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults) - Low-level vault operations
 
 # Audit Reports
+
+Source: https://docs.intuition.systems/docs/intuition-smart-contracts/audit-reports
 
 ## Overview
 
@@ -27234,14 +26136,9 @@ This page contains security audit reports for Intuition smart contracts. All con
 #### March 2024
 - [Intuition Smart Contracts](https://github.com/0xIntuition/intuition-contracts-v0.1/blob/main/audits/tob/Intuition%20Summary%20Report%20-%20ToB%20Audit%201.pdf)
 
----
-title: "Configurations & Fees"
-description: "The Intuition protocol smart contracts utilize a configuration system that allows for dynamic adjustment of various parameters effecting the behavior of the protocol. This document outlines the key..."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-smart-contracts/configuration"
----
-
 # Configurations & Fees
+
+Source: https://docs.intuition.systems/docs/intuition-smart-contracts/configuration
 
 The Intuition protocol smart contracts utilize a configuration system that allows for dynamic adjustment of various parameters effecting the behavior of the protocol. This document outlines the key configuration parameters and fees associated with the **mainnet Intuition protocol** deployment.
 
@@ -27309,16 +26206,9 @@ The Offset Progressive Curve is used to calculate the amount of shares minted wh
 
 The OffsetProgressiveCurve parameters are fixed and cannot be changed by governance.
 
----
-title: "Deployments"
-description: "The Intuition protocol contracts are deployed on both the Base Mainnet and the Intuition Layer 3 network, as well as their respective testnets. Below are the details of the deployed contracts,..."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-smart-contracts/deployments"
----
-
-# Deployments
-
 # Contract Deployments
+
+Source: https://docs.intuition.systems/docs/intuition-smart-contracts/deployments
 
 The Intuition protocol contracts are deployed on both the Base Mainnet and the Intuition Layer 3 network, as well as their respective testnets. Below are the details of the deployed contracts, including their addresses and network configurations.
 
@@ -27418,20 +26308,13 @@ Contract ABIs can be found in the following locations:
 - **GitHub**: [0xIntuition/intuition-contracts-v2](https://github.com/0xIntuition/intuition-contracts-v2/tree/main/abis)
 - **Block Explorer**: Available on verified contract pages
 
----
-title: "Overview"
-description: "Overview of Intuition's smart contract architecture and design patterns"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-smart-contracts"
----
-
-# Overview
-
 # Contract Architecture Overview
+
+Source: https://docs.intuition.systems/docs/intuition-smart-contracts
 
 Intuition's smart contracts are central to the user experience, handling critical onchain activities such as the creation of Atoms (also known as Identities) and Triples (also known as Claims), as well as the staking and rewards.
 
-# MultiVault
+## MultiVault
 
 The MultiVault contract is the core component of Intuition's architecture, responsible for managing the creation of Atoms/Triples and handling deposits, redemptions, and share distributions. It supports multiple bonding curve implementations through a registry system.
 
@@ -27442,7 +26325,7 @@ The MultiVault contract is the core component of Intuition's architecture, respo
 - **Share Distribution**: Manages the minting and burning of shares
 - **Fee Collection**: Collects small fees to maintain the system
 
-# Trust Token
+## Trust Token
 The Trust Token contract is an ERC-20 compliant token that serves as the native utility token within the Intuition ecosystem. It is used for deposits, staking, governance, and accessing various features of the platform. 
 
 - **ERC-20 Compliance**: Fully compliant with the ERC-20 standard
@@ -27451,12 +26334,12 @@ The Trust Token contract is an ERC-20 compliant token that serves as the native 
 
 The Trust Token contract is **deployed on Base** and is the **native gas token on the Intuition Network L3 chain**.
 
-# Wrapped Trust
+## Wrapped Trust
 The Wrapped Trust contract is an ERC-20 compliant token that lives on the Intuition Network L3 chain. After users bridge their Trust tokens from Base to the Intuition Network L3 chain, they can receive Wrapped Trust tokens by depositing Trust tokens into the Wrapped Trust contract.
 
 **Wrapped Trust tokens can be used for staking in the Trust Bonding contract.**
 
-# Trust Bonding
+## Trust Bonding
 The Trust Bonding contract is a smart contract introduced in V2. Inheriting from the Curve VotingEscrow contract, it enables staking of Wrapped Trust to earn rewards and participate in governance. Key features include:
 
 - **Staking**: Users can stake Wrapped Trust to earn rewards
@@ -27464,35 +26347,30 @@ The Trust Bonding contract is a smart contract introduced in V2. Inheriting from
 - **Rewards**: Users earn rewards based on their stake and lock duration
 - **Governance**: Stakers can participate in governance decisions
 
-# Bonding Curve Registry
+## Bonding Curve Registry
 The Bonding Curve Registry contract is a registry for bonding curve implementations. It allows the MultiVault contract to look up and use different bonding curve implementations. Key features include:
 
 - **Registration**: Developers can register new bonding curve implementations
 - **Lookup**: The MultiVault contract can look up bonding curve implementations by ID
 - **Management**: The registry can be managed by the contract owner
 
-# BaseEmissionsController
+## BaseEmissionsController
 The BaseEmissionsController contract is responsible for managing the emissions of Trust tokens. It controls the rate at which new Trust tokens are minted and distributed to stakers in the Trust Bonding contract. Key features include:
 
 - **Emission Rate**: Controls the rate of Trust token emissions
 - **Distribution**: Distributes newly minted Trust tokens to the SatelliteEmissionsController
 - **Bridging**: Uses the Caldera MetaLayer protocol to bridge emissions to the Intuition Network L3 chain
 
-# SatelliteEmissionsController
+## SatelliteEmissionsController
 The SatelliteEmissionsController contract is responsible for managing the emissions of Trust tokens on the Intuition Network L3 chain. It receives emissions from the BaseEmissionsController and distributes them to stakers via the Trust Bonding contract. Key features include:
 
 - **Receiving Emissions**: Receives Trust token emissions from the BaseEmissionsController
 - **Distribution**: Distributes Trust tokens to stakers via the Trust Bonding contract
 - **Bridging/Burning**: Uses the Caldera MetaLayer protocol to bridge/burn emissions back to Base
 
----
-title: "MultiVault.sol"
-description: "Documentation for the MultiVault smart contract"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-smart-contracts/multivault"
----
-
 # MultiVault.sol
+
+Source: https://docs.intuition.systems/docs/intuition-smart-contracts/multivault
 
 The MultiVault contract is the core economic engine of the Intuition protocol, managing deposits, redemptions, and creation of atoms and triples. It implements a sophisticated vault system that supports multiple bonding curves and provides the foundation for the protocol's economic incentives.
 
@@ -27817,14 +26695,9 @@ event SharePriceChanged(
 
 For more detailed information on the MultiVault contract and its functions, please refer to the [Intuition Smart Contract V2 repository](https://github.com/0xIntuition/intuition-contracts-v2).
 
----
-title: "TrustBonding.sol"
-description: "Documentation for the TrustBonding smart contract"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/intuition-smart-contracts/trust-bonding"
----
-
 # TrustBonding.sol
+
+Source: https://docs.intuition.systems/docs/intuition-smart-contracts/trust-bonding
 
 The TrustBonding contract is the primary smart contract for bonding/staking of TRUST tokens within the Intuition protocol. Responsible for managing emissions of new TRUST tokens for various stakeholders, including atom creators, triple creators, and other participants in the ecosystem.
 
@@ -27936,16 +26809,11 @@ event RewardsClaimed(address indexed user, address indexed recipient, uint256 am
 
 For more detailed information on the MultiVault contract and its functions, please refer to the [Intuition Smart Contract V2 repository](https://github.com/0xIntuition/intuition-contracts-v2).
 
----
-title: "Portal (Explorer) Guide"
-description: "Documentation for the Intuition Portal application - create identities, make claims, stake, and explore the knowledge graph"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/portal"
----
-
 # Portal (Explorer) Guide
 
-# The Intuition Portal
+Source: https://docs.intuition.systems/docs/portal
+
+## The Intuition Portal
 
 The Portal is Intuition's first Explorer (akin to a block explorer), which provides users with easy access to the social and knowledge graph. Positioned at the application layer, the Portal offers an intuitive interface for users to create, manage, and interact with Identities (Atoms) and Claims (Triples). It serves as the gateway for creating decentralized identities, making claims, and managing your stake, transforming the exploration of the knowledge graph into an accessible and user-friendly experience.
 
@@ -28056,20 +26924,15 @@ Visit **[portal.intuition.systems](https://portal.intuition.systems)** to start 
 
 ## Related Resources
 
-**[Explorer](/docs/intuition-network)** - Network exploration tools
+**[Explorer](https://docs.intuition.systems/docs/intuition-network)** - Network exploration tools
 
-**[Bridge](/docs/intuition-network)** - Cross-chain functionality
+**[Bridge](https://docs.intuition.systems/docs/intuition-network)** - Cross-chain functionality
 
-**[RPC](/docs/intuition-network/rpc)** - Network connectivity options
-
----
-title: "Atom Functions"
-description: "API reference for MultiVault atom management functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms"
----
+**[RPC](https://docs.intuition.systems/docs/intuition-network/rpc)** - Network connectivity options
 
 # Atom Functions
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms
 
 Functions for creating and querying atoms in the MultiVault contract.
 
@@ -28077,7 +26940,7 @@ Functions for creating and querying atoms in the MultiVault contract.
 
 Create one or more atoms with optional initial deposits.
 
-### Parameters
+### multiVaultCreateAtoms - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -28085,7 +26948,7 @@ Create one or more atoms with optional initial deposits.
 | args | `[bytes[], bigint[]]` | Array of atom URIs (hex) and deposit amounts | Yes |
 | value | `bigint` | Total ETH to send (sum of deposits) | Yes |
 
-### Returns
+### multiVaultCreateAtoms - Returns
 
 ```typescript
 Promise<Hash> // Transaction hash
@@ -28155,9 +27018,9 @@ try {
 
 ### Related Functions
 
-- [multiVaultGetAtomCost](#multivaultgetatomcost) - Get atom creation cost
-- [multiVaultPreviewAtomCreate](#multivaultpreviewatomcreate) - Preview atom creation
-- [eventParseAtomCreated](/docs/protocol/events/atom-events#eventparseatomcreated) - Parse creation events
+- [multiVaultGetAtomCost](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultgetatomcost) - Get atom creation cost
+- [multiVaultPreviewAtomCreate](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultpreviewatomcreate) - Preview atom creation
+- [eventParseAtomCreated](https://docs.intuition.systems/docs/protocol/events/atom-events#eventparseatomcreated) - Parse creation events
 
 ### Common Use Cases
 
@@ -28165,20 +27028,18 @@ try {
 - **Create tag atoms**: Build categorization systems
 - **Batch creation**: Create multiple related atoms in one transaction
 
----
-
 ## multiVaultGetAtom
 
 Query atom details by ID.
 
-### Parameters
+### multiVaultGetAtom - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Atom ID to query | Yes |
 
-### Returns
+### multiVaultGetAtom - Returns
 
 ```typescript
 Promise<[bigint, bytes, bigint]> // [id, termData, creatorAtomId]
@@ -28232,27 +27093,25 @@ try {
 
 ### Related Functions
 
-- [multiVaultCreateAtoms](#multivaultcreateatoms) - Create atoms
-- [multiVaultIsTermCreated](/docs/protocol/api-reference/multivault/vault-queries#multivaultistermcreated) - Check if atom exists
+- [multiVaultCreateAtoms](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultcreateatoms) - Create atoms
+- [multiVaultIsTermCreated](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vault-queries#multivaultistermcreated) - Check if atom exists
 
 ### Common Use Cases
 
 - **Verify atom data**: Check atom URI and creator
 - **Resolve references**: Get detailed information about atoms referenced in triples
 
----
-
 ## multiVaultGetAtomCost
 
 Get the base cost to create an atom (protocol fee).
 
-### Parameters
+### multiVaultGetAtomCost - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 
-### Returns
+### multiVaultGetAtomCost - Returns
 
 ```typescript
 Promise<bigint> // Atom creation cost in wei
@@ -28296,28 +27155,26 @@ try {
 
 ### Related Functions
 
-- [multiVaultCreateAtoms](#multivaultcreateatoms) - Create atoms with this cost
-- [multiVaultGetAtomConfig](/docs/protocol/api-reference/multivault/configuration#multivaultgetatomconfig) - Get detailed atom configuration
+- [multiVaultCreateAtoms](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultcreateatoms) - Create atoms with this cost
+- [multiVaultGetAtomConfig](https://docs.intuition.systems/docs/protocol/api-reference/multivault/configuration#multivaultgetatomconfig) - Get detailed atom configuration
 
 ### Common Use Cases
 
 - **Budget estimation**: Calculate total cost before creating atoms
 - **Wallet preparation**: Ensure sufficient funds for atom creation
 
----
-
 ## multiVaultPreviewAtomCreate
 
 Preview atom creation results before executing the transaction.
 
-### Parameters
+### multiVaultPreviewAtomCreate - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `WriteConfig` | Contract address, publicClient, walletClient | Yes |
 | args | `[bytes, bigint]` | Atom URI and deposit amount | Yes |
 
-### Returns
+### multiVaultPreviewAtomCreate - Returns
 
 ```typescript
 Promise<[bigint, bigint, bigint]> // [shares, assetsAfterFixedFees, assetsAfterFees]
@@ -28375,28 +27232,26 @@ try {
 
 ### Related Functions
 
-- [multiVaultCreateAtoms](#multivaultcreateatoms) - Execute atom creation
-- [multiVaultEntryFeeAmount](/docs/protocol/api-reference/multivault/fees#multivaultentryfeeamount) - Calculate entry fees
+- [multiVaultCreateAtoms](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultcreateatoms) - Execute atom creation
+- [multiVaultEntryFeeAmount](https://docs.intuition.systems/docs/protocol/api-reference/multivault/fees#multivaultentryfeeamount) - Calculate entry fees
 
 ### Common Use Cases
 
 - **Fee estimation**: Calculate fees before creating atoms
 - **Share calculation**: Determine expected shares from deposit
 
----
-
 ## multiVaultCreateAtomsEncode
 
 Encode atom creation call data for building transactions manually.
 
-### Parameters
+### multiVaultCreateAtomsEncode - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | atomUris | `bytes[]` | Array of atom URIs (hex-encoded) | Yes |
 | deposits | `bigint[]` | Array of deposit amounts | Yes |
 
-### Returns
+### multiVaultCreateAtomsEncode - Returns
 
 ```typescript
 Hex // Encoded function call data
@@ -28449,8 +27304,8 @@ try {
 
 ### Related Functions
 
-- [multiVaultCreateAtoms](#multivaultcreateatoms) - Higher-level creation function
-- [multiVaultDepositEncode](/docs/protocol/api-reference/multivault/vaults#multivaultdepositencode) - Encode deposit calls
+- [multiVaultCreateAtoms](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultcreateatoms) - Higher-level creation function
+- [multiVaultDepositEncode](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults#multivaultdepositencode) - Encode deposit calls
 
 ### Common Use Cases
 
@@ -28458,22 +27313,15 @@ try {
 - **Custom transaction builders**: Build transactions with specific gas/nonce settings
 - **Smart contract interactions**: Call from another contract
 
----
-
 ## See Also
 
-- [Core Concepts: Atoms](/docs/intuition-concepts/primitives/Atoms/fundamentals)
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Examples: Creating Atoms](/docs/protocol/examples/creating-atoms-triples)
-
----
-title: "Configuration Queries"
-description: "API reference for querying protocol configuration parameters"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/configuration"
----
+- [Core Concepts: Atoms](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Examples: Creating Atoms](https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples)
 
 # Configuration Queries
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/configuration
 
 Functions for querying protocol configuration settings.
 
@@ -28481,7 +27329,7 @@ Functions for querying protocol configuration settings.
 
 Get general protocol configuration.
 
-### Returns
+### multiVaultGetGeneralConfig - Returns
 
 ```typescript
 Promise<{
@@ -28493,7 +27341,7 @@ Promise<{
 }>
 ```
 
-### Example
+### multiVaultGetGeneralConfig - Example
 
 ```typescript
 import { multiVaultGetGeneralConfig } from '@0xintuition/protocol'
@@ -28505,13 +27353,11 @@ console.log('Protocol vault:', config.protocolVault)
 console.log('Min deposit:', formatEther(config.minDeposit))
 ```
 
----
-
 ## multiVaultGetAtomConfig
 
 Get atom-specific configuration.
 
-### Returns
+### multiVaultGetAtomConfig - Returns
 
 ```typescript
 Promise<{
@@ -28522,7 +27368,7 @@ Promise<{
 }>
 ```
 
-### Example
+### multiVaultGetAtomConfig - Example
 
 ```typescript
 import { multiVaultGetAtomConfig } from '@0xintuition/protocol'
@@ -28534,13 +27380,11 @@ console.log('Max URI length:', config.atomUriMaxLength)
 console.log('Protocol fee:', formatEther(config.atomCreationProtocolFee))
 ```
 
----
-
 ## multiVaultGetTripleConfig
 
 Get triple-specific configuration.
 
-### Returns
+### multiVaultGetTripleConfig - Returns
 
 ```typescript
 Promise<{
@@ -28550,7 +27394,7 @@ Promise<{
 }>
 ```
 
-### Example
+### multiVaultGetTripleConfig - Example
 
 ```typescript
 import { multiVaultGetTripleConfig } from '@0xintuition/protocol'
@@ -28561,13 +27405,11 @@ console.log('Triple cost:', formatEther(config.tripleCreationProtocolFee))
 console.log('Atom deposit fraction:', config.atomDepositFractionOnTripleCreation)
 ```
 
----
-
 ## multiVaultGetBondingCurveConfig
 
 Get bonding curve configuration.
 
-### Returns
+### multiVaultGetBondingCurveConfig - Returns
 
 ```typescript
 Promise<{
@@ -28575,7 +27417,7 @@ Promise<{
 }>
 ```
 
-### Example
+### multiVaultGetBondingCurveConfig - Example
 
 ```typescript
 import { multiVaultGetBondingCurveConfig } from '@0xintuition/protocol'
@@ -28585,13 +27427,11 @@ const config = await multiVaultGetBondingCurveConfig({ address, publicClient })
 console.log('Curve registry:', config.registry)
 ```
 
----
-
 ## multiVaultGetWalletConfig
 
 Get wallet configuration.
 
-### Returns
+### multiVaultGetWalletConfig - Returns
 
 ```typescript
 Promise<{
@@ -28600,7 +27440,7 @@ Promise<{
 }>
 ```
 
-### Example
+### multiVaultGetWalletConfig - Example
 
 ```typescript
 import { multiVaultGetWalletConfig } from '@0xintuition/protocol'
@@ -28611,13 +27451,11 @@ console.log('Atom warden:', config.atomWarden)
 console.log('Wallet factory:', config.atomWalletFactory)
 ```
 
----
-
 ## multiVaultMultiCallIntuitionConfigs
 
 Get all configurations in a single multicall.
 
-### Returns
+### multiVaultMultiCallIntuitionConfigs - Returns
 
 ```typescript
 Promise<{
@@ -28630,7 +27468,7 @@ Promise<{
 }>
 ```
 
-### Example
+### multiVaultMultiCallIntuitionConfigs - Example
 
 ```typescript
 import { multiVaultMultiCallIntuitionConfigs } from '@0xintuition/protocol'
@@ -28668,21 +27506,14 @@ console.log('\nWallet Config:')
 console.log('- Atom warden:', configs.walletConfig.atomWarden)
 ```
 
----
-
 ## See Also
 
-- [Configuration Guide](/docs/protocol/getting-started/configuration)
-- [Fee Calculations](/docs/protocol/api-reference/multivault/fees)
-
----
-title: "Share & Asset Conversions"
-description: "API reference for converting between shares and assets"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions"
----
+- [Configuration Guide](https://docs.intuition.systems/docs/protocol/getting-started/configuration)
+- [Fee Calculations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/fees)
 
 # Share & Asset Conversions
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions
 
 Functions for converting between shares and assets, and querying share balances and prices.
 
@@ -28690,20 +27521,20 @@ Functions for converting between shares and assets, and querying share balances 
 
 Convert asset amount to expected shares.
 
-### Parameters
+### multiVaultConvertToShares - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint, bigint]` | VaultId, curveId, assets | Yes |
 
-### Returns
+### multiVaultConvertToShares - Returns
 
 ```typescript
 Promise<bigint> // Expected shares
 ```
 
-### Example
+### multiVaultConvertToShares - Example
 
 ```typescript
 import { multiVaultConvertToShares } from '@0xintuition/protocol'
@@ -28717,26 +27548,24 @@ const shares = await multiVaultConvertToShares(
 console.log('Shares for 1 ETH:', formatEther(shares))
 ```
 
----
-
 ## multiVaultConvertToAssets
 
 Convert shares to expected assets.
 
-### Parameters
+### multiVaultConvertToAssets - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint, bigint]` | VaultId, curveId, shares | Yes |
 
-### Returns
+### multiVaultConvertToAssets - Returns
 
 ```typescript
 Promise<bigint> // Expected assets
 ```
 
-### Example
+### multiVaultConvertToAssets - Example
 
 ```typescript
 import { multiVaultConvertToAssets } from '@0xintuition/protocol'
@@ -28749,26 +27578,24 @@ const assets = await multiVaultConvertToAssets(
 console.log('Assets for 10 shares:', formatEther(assets))
 ```
 
----
-
 ## multiVaultGetShares
 
 Get user's share balance in a vault.
 
-### Parameters
+### multiVaultGetShares - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bytes32]` | User address, vaultId | Yes |
 
-### Returns
+### multiVaultGetShares - Returns
 
 ```typescript
 Promise<bigint> // User's shares
 ```
 
-### Example
+### multiVaultGetShares - Example
 
 ```typescript
 import { multiVaultGetShares } from '@0xintuition/protocol'
@@ -28781,26 +27608,24 @@ const shares = await multiVaultGetShares(
 console.log('User shares:', formatEther(shares))
 ```
 
----
-
 ## multiVaultCurrentSharePrice
 
 Get current share price for a vault.
 
-### Parameters
+### multiVaultCurrentSharePrice - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint]` | VaultId, curveId | Yes |
 
-### Returns
+### multiVaultCurrentSharePrice - Returns
 
 ```typescript
 Promise<bigint> // Current share price
 ```
 
-### Example
+### multiVaultCurrentSharePrice - Example
 
 ```typescript
 import { multiVaultCurrentSharePrice } from '@0xintuition/protocol'
@@ -28834,26 +27659,24 @@ const trackPrice = async () => {
 }
 ```
 
----
-
 ## multiVaultMaxRedeem
 
 Get maximum redeemable shares for a user.
 
-### Parameters
+### multiVaultMaxRedeem - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bytes32]` | User address, vaultId | Yes |
 
-### Returns
+### multiVaultMaxRedeem - Returns
 
 ```typescript
 Promise<bigint> // Maximum redeemable shares
 ```
 
-### Example
+### multiVaultMaxRedeem - Example
 
 ```typescript
 import { multiVaultMaxRedeem } from '@0xintuition/protocol'
@@ -28888,22 +27711,15 @@ const txHash = await multiVaultRedeem(
 )
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Vaults](/docs/protocol/core-concepts/vaults)
-- [Core Concepts: Bonding Curves](/docs/intuition-concepts/economics/bonding-curves)
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-
----
-title: "Epochs & Utilization"
-description: "API reference for epoch and utilization tracking functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/epochs-utilization"
----
+- [Core Concepts: Vaults](https://docs.intuition.systems/docs/protocol/core-concepts/vaults)
+- [Core Concepts: Bonding Curves](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
 
 # Epochs & Utilization
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/epochs-utilization
 
 Functions for querying epoch information and utilization metrics.
 
@@ -28911,13 +27727,13 @@ Functions for querying epoch information and utilization metrics.
 
 Get the current epoch number.
 
-### Returns
+### multiVaultCurrentEpoch - Returns
 
 ```typescript
 Promise<bigint> // Current epoch number
 ```
 
-### Example
+### multiVaultCurrentEpoch - Example
 
 ```typescript
 import { multiVaultCurrentEpoch } from '@0xintuition/protocol'
@@ -28926,26 +27742,24 @@ const epoch = await multiVaultCurrentEpoch({ address, publicClient })
 console.log('Current epoch:', epoch)
 ```
 
----
-
 ## multiVaultGetTotalUtilizationForEpoch
 
 Get total protocol utilization for an epoch.
 
-### Parameters
+### multiVaultGetTotalUtilizationForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### multiVaultGetTotalUtilizationForEpoch - Returns
 
 ```typescript
 Promise<bigint> // Total utilization
 ```
 
-### Example
+### multiVaultGetTotalUtilizationForEpoch - Example
 
 ```typescript
 import { multiVaultGetTotalUtilizationForEpoch } from '@0xintuition/protocol'
@@ -28958,26 +27772,24 @@ const totalUtil = await multiVaultGetTotalUtilizationForEpoch(
 console.log('Total utilization:', totalUtil)
 ```
 
----
-
 ## multiVaultGetUserUtilizationForEpoch
 
 Get user's total utilization for an epoch.
 
-### Parameters
+### multiVaultGetUserUtilizationForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bigint]` | User address, epoch number | Yes |
 
-### Returns
+### multiVaultGetUserUtilizationForEpoch - Returns
 
 ```typescript
 Promise<bigint> // User's total utilization
 ```
 
-### Example
+### multiVaultGetUserUtilizationForEpoch - Example
 
 ```typescript
 import { multiVaultGetUserUtilizationForEpoch } from '@0xintuition/protocol'
@@ -28990,26 +27802,24 @@ const userUtil = await multiVaultGetUserUtilizationForEpoch(
 console.log('User utilization:', userUtil)
 ```
 
----
-
 ## multiVaultGetUserUtilizationInEpoch
 
 Get user's utilization in a specific vault for an epoch.
 
-### Parameters
+### multiVaultGetUserUtilizationInEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bytes32, bigint]` | User address, vaultId, epoch number | Yes |
 
-### Returns
+### multiVaultGetUserUtilizationInEpoch - Returns
 
 ```typescript
 Promise<bigint> // User's vault-specific utilization
 ```
 
-### Example
+### multiVaultGetUserUtilizationInEpoch - Example
 
 ```typescript
 import { multiVaultGetUserUtilizationInEpoch } from '@0xintuition/protocol'
@@ -29022,26 +27832,24 @@ const vaultUtil = await multiVaultGetUserUtilizationInEpoch(
 console.log('Vault utilization:', vaultUtil)
 ```
 
----
-
 ## multiVaultGetUserLastActiveEpoch
 
 Get user's last active epoch.
 
-### Parameters
+### multiVaultGetUserLastActiveEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address]` | User address | Yes |
 
-### Returns
+### multiVaultGetUserLastActiveEpoch - Returns
 
 ```typescript
 Promise<bigint> // Last active epoch number
 ```
 
-### Example
+### multiVaultGetUserLastActiveEpoch - Example
 
 ```typescript
 import { multiVaultGetUserLastActiveEpoch } from '@0xintuition/protocol'
@@ -29054,21 +27862,14 @@ const lastEpoch = await multiVaultGetUserLastActiveEpoch(
 console.log('Last active epoch:', lastEpoch)
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Epochs](/docs/protocol/core-concepts/epochs)
-- [Trust Bonding](/docs/protocol/api-reference/trust-bonding/epochs)
-
----
-title: "Fee Calculations"
-description: "API reference for fee calculation functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/fees"
----
+- [Core Concepts: Epochs](https://docs.intuition.systems/docs/protocol/core-concepts/epochs)
+- [Trust Bonding](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs)
 
 # Fee Calculations
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/fees
 
 Functions for calculating various fees in the protocol.
 
@@ -29076,20 +27877,20 @@ Functions for calculating various fees in the protocol.
 
 Calculate entry fee for a deposit.
 
-### Parameters
+### multiVaultEntryFeeAmount - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint]` | VaultId, assets | Yes |
 
-### Returns
+### multiVaultEntryFeeAmount - Returns
 
 ```typescript
 Promise<bigint> // Entry fee amount
 ```
 
-### Example
+### multiVaultEntryFeeAmount - Example
 
 ```typescript
 import { multiVaultEntryFeeAmount } from '@0xintuition/protocol'
@@ -29105,26 +27906,24 @@ console.log('Entry fee:', formatEther(entryFee))
 console.log('Net deposit:', formatEther(depositAmount - entryFee))
 ```
 
----
-
 ## multiVaultExitFeeAmount
 
 Calculate exit fee for a redemption.
 
-### Parameters
+### multiVaultExitFeeAmount - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint]` | VaultId, assets | Yes |
 
-### Returns
+### multiVaultExitFeeAmount - Returns
 
 ```typescript
 Promise<bigint> // Exit fee amount
 ```
 
-### Example
+### multiVaultExitFeeAmount - Example
 
 ```typescript
 import { multiVaultExitFeeAmount } from '@0xintuition/protocol'
@@ -29139,26 +27938,24 @@ console.log('Exit fee:', formatEther(exitFee))
 console.log('Net withdrawal:', formatEther(expectedAssets - exitFee))
 ```
 
----
-
 ## multiVaultProtocolFeeAmount
 
 Calculate protocol fee.
 
-### Parameters
+### multiVaultProtocolFeeAmount - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint]` | VaultId, assets | Yes |
 
-### Returns
+### multiVaultProtocolFeeAmount - Returns
 
 ```typescript
 Promise<bigint> // Protocol fee amount
 ```
 
-### Example
+### multiVaultProtocolFeeAmount - Example
 
 ```typescript
 import { multiVaultProtocolFeeAmount } from '@0xintuition/protocol'
@@ -29171,26 +27968,24 @@ const protocolFee = await multiVaultProtocolFeeAmount(
 console.log('Protocol fee:', formatEther(protocolFee))
 ```
 
----
-
 ## multiVaultAtomDepositFractionAmount
 
 Calculate atom deposit fraction for triple creation.
 
-### Parameters
+### multiVaultAtomDepositFractionAmount - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Total assets | Yes |
 
-### Returns
+### multiVaultAtomDepositFractionAmount - Returns
 
 ```typescript
 Promise<bigint> // Atom deposit fraction
 ```
 
-### Example
+### multiVaultAtomDepositFractionAmount - Example
 
 ```typescript
 import { multiVaultAtomDepositFractionAmount } from '@0xintuition/protocol'
@@ -29237,21 +28032,14 @@ const fees = await calculateTotalFees(vaultId, parseEther('1'))
 console.log(fees)
 ```
 
----
-
 ## See Also
 
-- [Examples: Fee Calculations](/docs/protocol/examples/fee-calculations)
-- [Configuration](/docs/protocol/api-reference/multivault/configuration)
-
----
-title: "Triple Functions"
-description: "API reference for MultiVault triple management functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples"
----
+- [Examples: Fee Calculations](https://docs.intuition.systems/docs/protocol/examples/fee-calculations)
+- [Configuration](https://docs.intuition.systems/docs/protocol/api-reference/multivault/configuration)
 
 # Triple Functions
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples
 
 Functions for creating and managing triples (statements) in the MultiVault contract.
 
@@ -29259,7 +28047,7 @@ Functions for creating and managing triples (statements) in the MultiVault contr
 
 Create one or more triples (subject-predicate-object statements).
 
-### Parameters
+### multiVaultCreateTriples - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -29267,7 +28055,7 @@ Create one or more triples (subject-predicate-object statements).
 | args | `[bytes32[], bytes32[], bytes32[], bigint[]]` | Subject IDs, predicate IDs, object IDs, deposit amounts | Yes |
 | value | `bigint` | Total ETH to send | Yes |
 
-### Returns
+### multiVaultCreateTriples - Returns
 
 ```typescript
 Promise<Hash> // Transaction hash
@@ -29323,30 +28111,28 @@ console.log('Created triple IDs:', events.map(e => e.args.tripleId))
 
 ### Related Functions
 
-- [multiVaultGetTriple](#multivaultgettriple) - Query triple details
-- [multiVaultGetTripleCost](#multivaultgettriplecost) - Get creation cost
-
----
+- [multiVaultGetTriple](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples#multivaultgettriple) - Query triple details
+- [multiVaultGetTripleCost](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples#multivaultgettriplecost) - Get creation cost
 
 ## multiVaultGetTriple
 
 Query triple details by ID.
 
-### Parameters
+### multiVaultGetTriple - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Triple ID | Yes |
 
-### Returns
+### multiVaultGetTriple - Returns
 
 ```typescript
 Promise<[bigint, bigint, bigint, bigint, bigint, bigint]>
 // [id, subjectId, predicateId, objectId, counterVaultId, creatorAtomId]
 ```
 
-### Example
+### multiVaultGetTriple - Example
 
 ```typescript
 const triple = await multiVaultGetTriple({ address, publicClient }, { args: [tripleId] })
@@ -29359,19 +28145,17 @@ console.log('Counter vault:', triple[4])
 console.log('Creator:', triple[5])
 ```
 
----
-
 ## multiVaultGetTripleCost
 
 Get the base cost to create a triple.
 
-### Returns
+### multiVaultGetTripleCost - Returns
 
 ```typescript
 Promise<bigint> // Triple creation cost in wei
 ```
 
-### Example
+### multiVaultGetTripleCost - Example
 
 ```typescript
 import { formatEther } from 'viem'
@@ -29380,26 +28164,24 @@ const cost = await multiVaultGetTripleCost({ address, publicClient })
 console.log('Triple cost:', formatEther(cost), 'ETH')
 ```
 
----
-
 ## multiVaultIsTriple
 
 Check if a vault ID represents a triple.
 
-### Parameters
+### multiVaultIsTriple - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Vault ID to check | Yes |
 
-### Returns
+### multiVaultIsTriple - Returns
 
 ```typescript
 Promise<boolean>
 ```
 
-### Example
+### multiVaultIsTriple - Example
 
 ```typescript
 const isTriple = await multiVaultIsTriple({ address, publicClient }, { args: [vaultId] })
@@ -29411,26 +28193,24 @@ if (isTriple) {
 }
 ```
 
----
-
 ## multiVaultIsCounterTriple
 
 Check if two triples are counter-triples (opposing positions).
 
-### Parameters
+### multiVaultIsCounterTriple - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bytes32]` | Two triple IDs to compare | Yes |
 
-### Returns
+### multiVaultIsCounterTriple - Returns
 
 ```typescript
 Promise<boolean>
 ```
 
-### Example
+### multiVaultIsCounterTriple - Example
 
 ```typescript
 const isCounter = await multiVaultIsCounterTriple(
@@ -29443,26 +28223,24 @@ if (isCounter) {
 }
 ```
 
----
-
 ## multiVaultGetInverseTripleId
 
 Get the counter-triple ID for a given triple.
 
-### Parameters
+### multiVaultGetInverseTripleId - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Triple ID | Yes |
 
-### Returns
+### multiVaultGetInverseTripleId - Returns
 
 ```typescript
 Promise<bigint> // Counter-triple vault ID
 ```
 
-### Example
+### multiVaultGetInverseTripleId - Example
 
 ```typescript
 const inverseId = await multiVaultGetInverseTripleId(
@@ -29480,13 +28258,11 @@ const txHash = await multiVaultDeposit(
 )
 ```
 
----
-
 ## multiVaultCreateTriplesEncode
 
 Encode triple creation call data.
 
-### Parameters
+### multiVaultCreateTriplesEncode - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -29495,13 +28271,13 @@ Encode triple creation call data.
 | objects | `bytes32[]` | Object atom IDs | Yes |
 | deposits | `bigint[]` | Deposit amounts | Yes |
 
-### Returns
+### multiVaultCreateTriplesEncode - Returns
 
 ```typescript
 Hex // Encoded function call data
 ```
 
-### Example
+### multiVaultCreateTriplesEncode - Example
 
 ```typescript
 const data = multiVaultCreateTriplesEncode(
@@ -29520,22 +28296,15 @@ const tx = {
 const hash = await walletClient.sendTransaction(tx)
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Triples](/docs/intuition-concepts/primitives/Triples/fundamentals)
-- [Triple Events](/docs/protocol/events/triple-events)
-- [Examples: Creating Triples](/docs/protocol/examples/creating-atoms-triples)
-
----
-title: "Vault Queries"
-description: "API reference for vault query functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/vault-queries"
----
+- [Core Concepts: Triples](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
+- [Examples: Creating Triples](https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples)
 
 # Vault Queries
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/vault-queries
 
 Functions for querying vault information and state.
 
@@ -29543,20 +28312,20 @@ Functions for querying vault information and state.
 
 Get vault details.
 
-### Parameters
+### multiVaultGetVault - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Vault ID | Yes |
 
-### Returns
+### multiVaultGetVault - Returns
 
 ```typescript
 Promise<VaultData> // Vault information
 ```
 
-### Example
+### multiVaultGetVault - Example
 
 ```typescript
 import { multiVaultGetVault } from '@0xintuition/protocol'
@@ -29569,26 +28338,24 @@ const vault = await multiVaultGetVault(
 console.log('Vault details:', vault)
 ```
 
----
-
 ## multiVaultGetVaultType
 
 Get vault type (atom or triple).
 
-### Parameters
+### multiVaultGetVaultType - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Vault ID | Yes |
 
-### Returns
+### multiVaultGetVaultType - Returns
 
 ```typescript
 Promise<bigint> // 0 for atom, 1 for triple
 ```
 
-### Example
+### multiVaultGetVaultType - Example
 
 ```typescript
 import { multiVaultGetVaultType } from '@0xintuition/protocol'
@@ -29605,26 +28372,24 @@ if (vaultType === 0n) {
 }
 ```
 
----
-
 ## multiVaultIsTermCreated
 
 Check if a term (atom/triple) has been created.
 
-### Parameters
+### multiVaultIsTermCreated - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes]` | Term data (atom URI or triple hash) | Yes |
 
-### Returns
+### multiVaultIsTermCreated - Returns
 
 ```typescript
 Promise<boolean>
 ```
 
-### Example
+### multiVaultIsTermCreated - Example
 
 ```typescript
 import { multiVaultIsTermCreated } from '@0xintuition/protocol'
@@ -29674,21 +28439,14 @@ const checkAndCreate = async (atomUri: string) => {
 const txHash = await checkAndCreate('My Unique Atom')
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Vaults](/docs/protocol/core-concepts/vaults)
-- [Core Concepts: Atoms](/docs/intuition-concepts/primitives/Atoms/fundamentals)
-
----
-title: "Vault Operations"
-description: "API reference for vault deposit and redemption functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults"
----
+- [Core Concepts: Vaults](https://docs.intuition.systems/docs/protocol/core-concepts/vaults)
+- [Core Concepts: Atoms](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 # Vault Operations
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults
 
 Functions for depositing to and redeeming from vaults.
 
@@ -29696,7 +28454,7 @@ Functions for depositing to and redeeming from vaults.
 
 Deposit assets into a vault to receive shares.
 
-### Parameters
+### multiVaultDeposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -29704,7 +28462,7 @@ Deposit assets into a vault to receive shares.
 | args | `[Address, bytes32, bigint, bigint]` | Receiver, vaultId, curveId, minShares | Yes |
 | value | `bigint` | Deposit amount in wei | Yes |
 
-### Example
+### multiVaultDeposit - Example
 
 ```typescript
 import { multiVaultDeposit } from '@0xintuition/protocol'
@@ -29719,13 +28477,11 @@ const txHash = await multiVaultDeposit(
 )
 ```
 
----
-
 ## multiVaultDepositBatch
 
 Deposit to multiple vaults in a single transaction.
 
-### Parameters
+### multiVaultDepositBatch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -29733,7 +28489,7 @@ Deposit to multiple vaults in a single transaction.
 | args | `[Address, bytes32[], bigint[], bigint[], bigint[]]` | Receiver, vaultIds, curveIds, assets, minShares | Yes |
 | value | `bigint` | Total deposit amount | Yes |
 
-### Example
+### multiVaultDepositBatch - Example
 
 ```typescript
 const txHash = await multiVaultDepositBatch(
@@ -29751,20 +28507,18 @@ const txHash = await multiVaultDepositBatch(
 )
 ```
 
----
-
 ## multiVaultRedeem
 
 Redeem shares from a vault to receive assets.
 
-### Parameters
+### multiVaultRedeem - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `WriteConfig` | Contract address, publicClient, walletClient | Yes |
 | args | `[Address, bytes32, bigint, bigint, bigint]` | Receiver, vaultId, curveId, shares, minAssets | Yes |
 
-### Example
+### multiVaultRedeem - Example
 
 ```typescript
 const txHash = await multiVaultRedeem(
@@ -29775,20 +28529,18 @@ const txHash = await multiVaultRedeem(
 )
 ```
 
----
-
 ## multiVaultRedeemBatch
 
 Redeem shares from multiple vaults in a single transaction.
 
-### Parameters
+### multiVaultRedeemBatch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `WriteConfig` | Contract address, publicClient, walletClient | Yes |
 | args | `[bigint[], Address, bytes32[], bigint[], bigint[]]` | Shares, receiver, vaultIds, curveIds, minAssets | Yes |
 
-### Example
+### multiVaultRedeemBatch - Example
 
 ```typescript
 const txHash = await multiVaultRedeemBatch(
@@ -29805,26 +28557,24 @@ const txHash = await multiVaultRedeemBatch(
 )
 ```
 
----
-
 ## multiVaultPreviewDeposit
 
 Preview deposit results before executing.
 
-### Parameters
+### multiVaultPreviewDeposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint, bigint]` | VaultId, curveId, assets | Yes |
 
-### Returns
+### multiVaultPreviewDeposit - Returns
 
 ```typescript
 Promise<bigint> // Expected shares
 ```
 
-### Example
+### multiVaultPreviewDeposit - Example
 
 ```typescript
 const expectedShares = await multiVaultPreviewDeposit(
@@ -29835,26 +28585,24 @@ const expectedShares = await multiVaultPreviewDeposit(
 const minShares = (expectedShares * 99n) / 100n // 1% slippage
 ```
 
----
-
 ## multiVaultPreviewRedeem
 
 Preview redemption results before executing.
 
-### Parameters
+### multiVaultPreviewRedeem - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint, bigint]` | VaultId, curveId, shares | Yes |
 
-### Returns
+### multiVaultPreviewRedeem - Returns
 
 ```typescript
 Promise<bigint> // Expected assets
 ```
 
-### Example
+### multiVaultPreviewRedeem - Example
 
 ```typescript
 const expectedAssets = await multiVaultPreviewRedeem(
@@ -29865,13 +28613,11 @@ const expectedAssets = await multiVaultPreviewRedeem(
 const minAssets = (expectedAssets * 99n) / 100n // 1% slippage
 ```
 
----
-
 ## multiVaultDepositEncode
 
 Encode deposit call data.
 
-### Example
+### multiVaultDepositEncode - Example
 
 ```typescript
 import { multiVaultDepositEncode } from '@0xintuition/protocol'
@@ -29879,13 +28625,11 @@ import { multiVaultDepositEncode } from '@0xintuition/protocol'
 const data = multiVaultDepositEncode(receiver, vaultId, curveId, minShares)
 ```
 
----
-
 ## multiVaultRedeemEncode
 
 Encode redeem call data.
 
-### Example
+### multiVaultRedeemEncode - Example
 
 ```typescript
 import { multiVaultRedeemEncode } from '@0xintuition/protocol'
@@ -29893,13 +28637,11 @@ import { multiVaultRedeemEncode } from '@0xintuition/protocol'
 const data = multiVaultRedeemEncode(receiver, vaultId, curveId, shares, minAssets)
 ```
 
----
-
 ## multiVaultDepositBatchEncode
 
 Encode batch deposit call data.
 
-### Example
+### multiVaultDepositBatchEncode - Example
 
 ```typescript
 import { multiVaultDepositBatchEncode } from '@0xintuition/protocol'
@@ -29913,13 +28655,11 @@ const data = multiVaultDepositBatchEncode(
 )
 ```
 
----
-
 ## multiVaultRedeemBatchEncode
 
 Encode batch redeem call data.
 
-### Example
+### multiVaultRedeemBatchEncode - Example
 
 ```typescript
 import { multiVaultRedeemBatchEncode } from '@0xintuition/protocol'
@@ -29933,21 +28673,14 @@ const data = multiVaultRedeemBatchEncode(
 )
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Vaults](/docs/protocol/core-concepts/vaults)
-- [Examples: Deposit & Redeem](/docs/protocol/examples/deposit-redeem)
-
----
-title: "Balance Queries"
-description: "API reference for Trust Bonding balance query functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/balances"
----
+- [Core Concepts: Vaults](https://docs.intuition.systems/docs/protocol/core-concepts/vaults)
+- [Examples: Deposit & Redeem](https://docs.intuition.systems/docs/protocol/examples/deposit-redeem)
 
 # Balance Queries
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/balances
 
 Functions for querying bonded balances and locked amounts.
 
@@ -29955,13 +28688,13 @@ Functions for querying bonded balances and locked amounts.
 
 Get the total bonded balance across all users.
 
-### Returns
+### trustBondingTotalBondedBalance - Returns
 
 ```typescript
 Promise<bigint> // Total bonded balance
 ```
 
-### Example
+### trustBondingTotalBondedBalance - Example
 
 ```typescript
 import { trustBondingTotalBondedBalance } from '@0xintuition/protocol'
@@ -29971,26 +28704,24 @@ const totalBonded = await trustBondingTotalBondedBalance({ address: bondingAddre
 console.log('Total bonded:', formatEther(totalBonded))
 ```
 
----
-
 ## trustBondingTotalBondedBalanceAtEpochEnd
 
 Get total bonded balance at the end of an epoch.
 
-### Parameters
+### trustBondingTotalBondedBalanceAtEpochEnd - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### trustBondingTotalBondedBalanceAtEpochEnd - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingTotalBondedBalanceAtEpochEnd - Example
 
 ```typescript
 import { trustBondingTotalBondedBalanceAtEpochEnd } from '@0xintuition/protocol'
@@ -30002,26 +28733,24 @@ const balance = await trustBondingTotalBondedBalanceAtEpochEnd(
 console.log('Total bonded at epoch end:', formatEther(balance))
 ```
 
----
-
 ## trustBondingUserBondedBalanceAtEpochEnd
 
 Get user's bonded balance at the end of an epoch.
 
-### Parameters
+### trustBondingUserBondedBalanceAtEpochEnd - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bigint]` | User address, epoch number | Yes |
 
-### Returns
+### trustBondingUserBondedBalanceAtEpochEnd - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingUserBondedBalanceAtEpochEnd - Example
 
 ```typescript
 import { trustBondingUserBondedBalanceAtEpochEnd } from '@0xintuition/protocol'
@@ -30033,19 +28762,17 @@ const userBalance = await trustBondingUserBondedBalanceAtEpochEnd(
 console.log('User bonded at epoch end:', formatEther(userBalance))
 ```
 
----
-
 ## trustBondingTotalLocked
 
 Get total locked amount.
 
-### Returns
+### trustBondingTotalLocked - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingTotalLocked - Example
 
 ```typescript
 import { trustBondingTotalLocked } from '@0xintuition/protocol'
@@ -30054,21 +28781,14 @@ const locked = await trustBondingTotalLocked({ address: bondingAddress, publicCl
 console.log('Total locked:', formatEther(locked))
 ```
 
----
-
 ## See Also
 
-- [Trust Bonding Rewards](/docs/protocol/api-reference/trust-bonding/rewards)
-- [Examples: Trust Bonding](/docs/protocol/examples/trust-bonding)
-
----
-title: "Epoch Management"
-description: "API reference for Trust Bonding epoch management functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs"
----
+- [Trust Bonding Rewards](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards)
+- [Examples: Trust Bonding](https://docs.intuition.systems/docs/protocol/examples/trust-bonding)
 
 # Epoch Management
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs
 
 Functions for managing and querying epoch information in the Trust Bonding contract.
 
@@ -30076,13 +28796,13 @@ Functions for managing and querying epoch information in the Trust Bonding contr
 
 Get the current epoch number.
 
-### Returns
+### trustBondingCurrentEpoch - Returns
 
 ```typescript
 Promise<bigint> // Current epoch number
 ```
 
-### Example
+### trustBondingCurrentEpoch - Example
 
 ```typescript
 import { trustBondingCurrentEpoch, getContractAddressFromChainId } from '@0xintuition/protocol'
@@ -30092,19 +28812,17 @@ const epoch = await trustBondingCurrentEpoch({ address: bondingAddress, publicCl
 console.log('Current epoch:', epoch)
 ```
 
----
-
 ## trustBondingPreviousEpoch
 
 Get the previous epoch number.
 
-### Returns
+### trustBondingPreviousEpoch - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingPreviousEpoch - Example
 
 ```typescript
 import { trustBondingPreviousEpoch } from '@0xintuition/protocol'
@@ -30113,26 +28831,24 @@ const prevEpoch = await trustBondingPreviousEpoch({ address: bondingAddress, pub
 console.log('Previous epoch:', prevEpoch)
 ```
 
----
-
 ## trustBondingEpochAtTimestamp
 
 Get the epoch number for a specific timestamp.
 
-### Parameters
+### trustBondingEpochAtTimestamp - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Unix timestamp | Yes |
 
-### Returns
+### trustBondingEpochAtTimestamp - Returns
 
 ```typescript
 Promise<bigint> // Epoch number at timestamp
 ```
 
-### Example
+### trustBondingEpochAtTimestamp - Example
 
 ```typescript
 import { trustBondingEpochAtTimestamp } from '@0xintuition/protocol'
@@ -30145,26 +28861,24 @@ const epoch = await trustBondingEpochAtTimestamp(
 console.log('Epoch at timestamp:', epoch)
 ```
 
----
-
 ## trustBondingEpochTimestampEnd
 
 Get the end timestamp for an epoch.
 
-### Parameters
+### trustBondingEpochTimestampEnd - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### trustBondingEpochTimestampEnd - Returns
 
 ```typescript
 Promise<bigint> // Epoch end timestamp
 ```
 
-### Example
+### trustBondingEpochTimestampEnd - Example
 
 ```typescript
 import { trustBondingEpochTimestampEnd } from '@0xintuition/protocol'
@@ -30178,19 +28892,17 @@ const endDate = new Date(Number(endTime) * 1000)
 console.log('Epoch ends:', endDate.toISOString())
 ```
 
----
-
 ## trustBondingEpochLength
 
 Get the length of an epoch in seconds.
 
-### Returns
+### trustBondingEpochLength - Returns
 
 ```typescript
 Promise<bigint> // Epoch duration in seconds
 ```
 
-### Example
+### trustBondingEpochLength - Example
 
 ```typescript
 import { trustBondingEpochLength } from '@0xintuition/protocol'
@@ -30200,19 +28912,17 @@ console.log('Epoch length:', length, 'seconds')
 console.log('In days:', Number(length) / 86400)
 ```
 
----
-
 ## trustBondingEpochsPerYear
 
 Get the number of epochs per year.
 
-### Returns
+### trustBondingEpochsPerYear - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingEpochsPerYear - Example
 
 ```typescript
 import { trustBondingEpochsPerYear } from '@0xintuition/protocol'
@@ -30221,21 +28931,14 @@ const epochsPerYear = await trustBondingEpochsPerYear({ address: bondingAddress,
 console.log('Epochs per year:', epochsPerYear)
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Epochs](/docs/protocol/core-concepts/epochs)
-- [Trust Bonding Rewards](/docs/protocol/api-reference/trust-bonding/rewards)
-
----
-title: "Lock Queries"
-description: "API reference for Trust Bonding lock query functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/lock-queries"
----
+- [Core Concepts: Epochs](https://docs.intuition.systems/docs/protocol/core-concepts/epochs)
+- [Trust Bonding Rewards](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards)
 
 # Lock Queries
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/lock-queries
 
 Functions for querying lock information in the Trust Bonding system (if applicable).
 
@@ -30306,22 +29009,15 @@ const maxShares = await multiVaultMaxRedeem(
 console.log('Max redeemable:', formatEther(maxShares))
 ```
 
----
-
 ## See Also
 
-- [Trust Bonding Balances](/docs/protocol/api-reference/trust-bonding/balances)
-- [Vault Queries](/docs/protocol/api-reference/multivault/vault-queries)
-- [Share Conversions](/docs/protocol/api-reference/multivault/conversions)
-
----
-title: "Reward Calculations"
-description: "API reference for Trust Bonding reward calculation functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards"
----
+- [Trust Bonding Balances](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/balances)
+- [Vault Queries](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vault-queries)
+- [Share Conversions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions)
 
 # Reward Calculations
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards
 
 Functions for calculating and querying bonding rewards.
 
@@ -30329,20 +29025,20 @@ Functions for calculating and querying bonding rewards.
 
 Get user's annual percentage yield (APY).
 
-### Parameters
+### trustBondingGetUserApy - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address]` | User address | Yes |
 
-### Returns
+### trustBondingGetUserApy - Returns
 
 ```typescript
 Promise<bigint> // User APY (basis points)
 ```
 
-### Example
+### trustBondingGetUserApy - Example
 
 ```typescript
 import { trustBondingGetUserApy } from '@0xintuition/protocol'
@@ -30354,19 +29050,17 @@ const userApy = await trustBondingGetUserApy(
 console.log('User APY:', Number(userApy) / 100, '%')
 ```
 
----
-
 ## trustBondingGetSystemApy
 
 Get system-wide APY.
 
-### Returns
+### trustBondingGetSystemApy - Returns
 
 ```typescript
 Promise<bigint> // System APY (basis points)
 ```
 
-### Example
+### trustBondingGetSystemApy - Example
 
 ```typescript
 import { trustBondingGetSystemApy } from '@0xintuition/protocol'
@@ -30375,26 +29069,24 @@ const systemApy = await trustBondingGetSystemApy({ address: bondingAddress, publ
 console.log('System APY:', Number(systemApy) / 100, '%')
 ```
 
----
-
 ## trustBondingGetUserCurrentClaimableRewards
 
 Get user's currently claimable rewards.
 
-### Parameters
+### trustBondingGetUserCurrentClaimableRewards - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address]` | User address | Yes |
 
-### Returns
+### trustBondingGetUserCurrentClaimableRewards - Returns
 
 ```typescript
 Promise<bigint> // Claimable rewards amount
 ```
 
-### Example
+### trustBondingGetUserCurrentClaimableRewards - Example
 
 ```typescript
 import { trustBondingGetUserCurrentClaimableRewards } from '@0xintuition/protocol'
@@ -30407,26 +29099,24 @@ const rewards = await trustBondingGetUserCurrentClaimableRewards(
 console.log('Claimable rewards:', formatEther(rewards))
 ```
 
----
-
 ## trustBondingGetUserRewardsForEpoch
 
 Get user's rewards for a specific epoch.
 
-### Parameters
+### trustBondingGetUserRewardsForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bigint]` | User address, epoch number | Yes |
 
-### Returns
+### trustBondingGetUserRewardsForEpoch - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingGetUserRewardsForEpoch - Example
 
 ```typescript
 import { trustBondingGetUserRewardsForEpoch } from '@0xintuition/protocol'
@@ -30438,26 +29128,24 @@ const epochRewards = await trustBondingGetUserRewardsForEpoch(
 console.log('Epoch rewards:', formatEther(epochRewards))
 ```
 
----
-
 ## trustBondingGetUnclaimedRewardsForEpoch
 
 Get unclaimed system rewards for an epoch.
 
-### Parameters
+### trustBondingGetUnclaimedRewardsForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### trustBondingGetUnclaimedRewardsForEpoch - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingGetUnclaimedRewardsForEpoch - Example
 
 ```typescript
 import { trustBondingGetUnclaimedRewardsForEpoch } from '@0xintuition/protocol'
@@ -30469,26 +29157,24 @@ const unclaimed = await trustBondingGetUnclaimedRewardsForEpoch(
 console.log('Unclaimed rewards:', formatEther(unclaimed))
 ```
 
----
-
 ## trustBondingUserEligibleRewardsForEpoch
 
 Get eligible rewards for a user in an epoch.
 
-### Parameters
+### trustBondingUserEligibleRewardsForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bigint]` | User address, epoch number | Yes |
 
-### Returns
+### trustBondingUserEligibleRewardsForEpoch - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingUserEligibleRewardsForEpoch - Example
 
 ```typescript
 import { trustBondingUserEligibleRewardsForEpoch } from '@0xintuition/protocol'
@@ -30500,26 +29186,24 @@ const eligible = await trustBondingUserEligibleRewardsForEpoch(
 console.log('Eligible rewards:', formatEther(eligible))
 ```
 
----
-
 ## trustBondingHasClaimedRewardsForEpoch
 
 Check if user has claimed rewards for an epoch.
 
-### Parameters
+### trustBondingHasClaimedRewardsForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address, bigint]` | User address, epoch number | Yes |
 
-### Returns
+### trustBondingHasClaimedRewardsForEpoch - Returns
 
 ```typescript
 Promise<boolean>
 ```
 
-### Example
+### trustBondingHasClaimedRewardsForEpoch - Example
 
 ```typescript
 import { trustBondingHasClaimedRewardsForEpoch } from '@0xintuition/protocol'
@@ -30536,19 +29220,17 @@ if (hasClaimed) {
 }
 ```
 
----
-
 ## trustBondingGetSystemUtilizationRatio
 
 Get system-wide utilization ratio.
 
-### Returns
+### trustBondingGetSystemUtilizationRatio - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingGetSystemUtilizationRatio - Example
 
 ```typescript
 import { trustBondingGetSystemUtilizationRatio } from '@0xintuition/protocol'
@@ -30557,26 +29239,24 @@ const ratio = await trustBondingGetSystemUtilizationRatio({ address: bondingAddr
 console.log('System utilization ratio:', ratio)
 ```
 
----
-
 ## trustBondingGetPersonalUtilizationRatio
 
 Get user's personal utilization ratio.
 
-### Parameters
+### trustBondingGetPersonalUtilizationRatio - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address]` | User address | Yes |
 
-### Returns
+### trustBondingGetPersonalUtilizationRatio - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingGetPersonalUtilizationRatio - Example
 
 ```typescript
 import { trustBondingGetPersonalUtilizationRatio } from '@0xintuition/protocol'
@@ -30588,26 +29268,24 @@ const personalRatio = await trustBondingGetPersonalUtilizationRatio(
 console.log('Personal utilization ratio:', personalRatio)
 ```
 
----
-
 ## trustBondingGetUserInfo
 
 Get comprehensive user bonding information.
 
-### Parameters
+### trustBondingGetUserInfo - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address]` | User address | Yes |
 
-### Returns
+### trustBondingGetUserInfo - Returns
 
 ```typescript
 Promise<UserInfo> // Complete user bonding data
 ```
 
-### Example
+### trustBondingGetUserInfo - Example
 
 ```typescript
 import { trustBondingGetUserInfo } from '@0xintuition/protocol'
@@ -30619,26 +29297,24 @@ const userInfo = await trustBondingGetUserInfo(
 console.log('User bonding info:', userInfo)
 ```
 
----
-
 ## trustBondingEmissionsForEpoch
 
 Get total emissions for an epoch.
 
-### Parameters
+### trustBondingEmissionsForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### trustBondingEmissionsForEpoch - Returns
 
 ```typescript
 Promise<bigint>
 ```
 
-### Example
+### trustBondingEmissionsForEpoch - Example
 
 ```typescript
 import { trustBondingEmissionsForEpoch } from '@0xintuition/protocol'
@@ -30650,21 +29326,14 @@ const emissions = await trustBondingEmissionsForEpoch(
 console.log('Epoch emissions:', formatEther(emissions))
 ```
 
----
-
 ## See Also
 
-- [Core Concepts: Epochs](/docs/protocol/core-concepts/epochs)
-- [Examples: Trust Bonding](/docs/protocol/examples/trust-bonding)
-
----
-title: "Staking Operations"
-description: "API reference for Trust Bonding staking operation functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/staking-operations"
----
+- [Core Concepts: Epochs](https://docs.intuition.systems/docs/protocol/core-concepts/epochs)
+- [Examples: Trust Bonding](https://docs.intuition.systems/docs/protocol/examples/trust-bonding)
 
 # Staking Operations
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/staking-operations
 
 Functions for Trust Bonding staking operations (if applicable based on contract implementation).
 
@@ -30676,7 +29345,7 @@ The Trust Bonding contract primarily tracks utilization and distributes rewards.
 
 Trust Bonding rewards are earned through:
 
-1. **Depositing to vaults** via [multiVaultDeposit](/docs/protocol/api-reference/multivault/vaults#multivaultdeposit)
+1. **Depositing to vaults** via [multiVaultDeposit](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults#multivaultdeposit)
 2. **Vault utilization** tracked by the protocol
 3. **Epoch-based rewards** calculated from utilization
 
@@ -30723,22 +29392,15 @@ console.log('Bonding position:', userInfo)
 console.log('Claimable rewards:', formatEther(claimable))
 ```
 
----
-
 ## See Also
 
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-- [Trust Bonding Rewards](/docs/protocol/api-reference/trust-bonding/rewards)
-- [Examples: Trust Bonding](/docs/protocol/examples/trust-bonding)
-
----
-title: "Wrapped Trust"
-description: "API reference for Wrapped Trust token functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/api-reference/wrapped-trust/overview"
----
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
+- [Trust Bonding Rewards](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards)
+- [Examples: Trust Bonding](https://docs.intuition.systems/docs/protocol/examples/trust-bonding)
 
 # Wrapped Trust
+
+Source: https://docs.intuition.systems/docs/protocol/api-reference/wrapped-trust/overview
 
 Functions for wrapping and unwrapping native TRUST tokens.
 
@@ -30746,20 +29408,20 @@ Functions for wrapping and unwrapping native TRUST tokens.
 
 Deposit native TRUST to receive wrapped TRUST.
 
-### Parameters
+### wrappedTrustDeposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `WriteConfig` | Contract address, publicClient, walletClient | Yes |
 | value | `bigint` | Amount of TRUST to wrap | Yes |
 
-### Returns
+### wrappedTrustDeposit - Returns
 
 ```typescript
 Promise<Hash> // Transaction hash
 ```
 
-### Example
+### wrappedTrustDeposit - Example
 
 ```typescript
 import { wrappedTrustDeposit, getContractAddressFromChainId } from '@0xintuition/protocol'
@@ -30775,26 +29437,24 @@ const txHash = await wrappedTrustDeposit(
 console.log('Wrapped 10 TRUST:', txHash)
 ```
 
----
-
 ## wrappedTrustWithdraw
 
 Withdraw wrapped TRUST to receive native TRUST.
 
-### Parameters
+### wrappedTrustWithdraw - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `WriteConfig` | Contract address, publicClient, walletClient | Yes |
 | args | `[bigint]` | Amount of wrapped TRUST to unwrap | Yes |
 
-### Returns
+### wrappedTrustWithdraw - Returns
 
 ```typescript
 Promise<Hash> // Transaction hash
 ```
 
-### Example
+### wrappedTrustWithdraw - Example
 
 ```typescript
 import { wrappedTrustWithdraw } from '@0xintuition/protocol'
@@ -30806,8 +29466,6 @@ const txHash = await wrappedTrustWithdraw(
 
 console.log('Unwrapped 5 TRUST:', txHash)
 ```
-
----
 
 ## Standard ERC20 Functions
 
@@ -30870,8 +29528,6 @@ const txHash = await writeContract(walletClient, {
 console.log('Approved:', txHash)
 ```
 
----
-
 ## Complete Example
 
 ```typescript
@@ -30915,20 +29571,13 @@ const unwrapTx = await wrappedTrustWithdraw(
 console.log('Unwrapped:', unwrapTx)
 ```
 
----
-
 ## See Also
 
-- [Configuration](/docs/protocol/getting-started/configuration)
-
----
-title: "Epochs & Utilization"
-description: "Understanding the epoch-based reward system and utilization tracking"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/core-concepts/epochs"
----
+- [Configuration](https://docs.intuition.systems/docs/protocol/getting-started/configuration)
 
 # Epochs & Utilization
+
+Source: https://docs.intuition.systems/docs/protocol/core-concepts/epochs
 
 The Intuition Protocol operates on an **epoch-based system** for tracking bonding rewards and vault utilization. Epochs are fixed time periods that determine reward distribution.
 
@@ -31212,24 +29861,19 @@ setInterval(async () => {
 
 ## Related Functions
 
-- [multiVaultCurrentEpoch](/docs/protocol/api-reference/multivault/epochs-utilization#multivaultcurrentepoch) - Get current epoch
-- [multiVaultGetTotalUtilizationForEpoch](/docs/protocol/api-reference/multivault/epochs-utilization#multivaultgettotalutilizationforepoch) - Get total utilization
-- [trustBondingGetUserApy](/docs/protocol/api-reference/trust-bonding/rewards#trustbondinggetuserapy) - Get user APY
-- [Trust Bonding Epochs](/docs/protocol/api-reference/trust-bonding/epochs) - Epoch management functions
+- [multiVaultCurrentEpoch](https://docs.intuition.systems/docs/protocol/api-reference/multivault/epochs-utilization#multivaultcurrentepoch) - Get current epoch
+- [multiVaultGetTotalUtilizationForEpoch](https://docs.intuition.systems/docs/protocol/api-reference/multivault/epochs-utilization#multivaultgettotalutilizationforepoch) - Get total utilization
+- [trustBondingGetUserApy](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards#trustbondinggetuserapy) - Get user APY
+- [Trust Bonding Epochs](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs) - Epoch management functions
 
 ## Next Steps
 
-- [Trust Bonding](/docs/protocol/api-reference/trust-bonding/epochs) - Explore bonding system
-- [Examples](/docs/protocol/examples/trust-bonding) - See epoch tracking examples
-
----
-title: "Vaults & Shares"
-description: "Understanding vault mechanics and share-based deposits in the Intuition Protocol"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/core-concepts/vaults"
----
+- [Trust Bonding](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs) - Explore bonding system
+- [Examples](https://docs.intuition.systems/docs/protocol/examples/trust-bonding) - See epoch tracking examples
 
 # Vaults & Shares
+
+Source: https://docs.intuition.systems/docs/protocol/core-concepts/vaults
 
 Every atom and triple has an associated **vault** that holds deposited assets. Users receive **shares** representing their ownership when they deposit, with prices determined by bonding curves.
 
@@ -31545,24 +30189,19 @@ const txHashAgainst = await multiVaultDeposit(
 
 ## Related Functions
 
-- [multiVaultDeposit](/docs/protocol/api-reference/multivault/vaults#multivaultdeposit) - Deposit to vault
-- [multiVaultRedeem](/docs/protocol/api-reference/multivault/vaults#multivaultredeem) - Redeem shares
-- [multiVaultPreviewDeposit](/docs/protocol/api-reference/multivault/vaults#multivaultpreviewdeposit) - Preview deposit
-- [multiVaultGetShares](/docs/protocol/api-reference/multivault/conversions#multivaultgetshares) - Get user shares
+- [multiVaultDeposit](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults#multivaultdeposit) - Deposit to vault
+- [multiVaultRedeem](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults#multivaultredeem) - Redeem shares
+- [multiVaultPreviewDeposit](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults#multivaultpreviewdeposit) - Preview deposit
+- [multiVaultGetShares](https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions#multivaultgetshares) - Get user shares
 
 ## Next Steps
 
-- [Bonding Curves](/docs/intuition-concepts/economics/bonding-curves) - Understand pricing mechanics
-- [Examples](/docs/protocol/examples/deposit-redeem) - See complete deposit/redeem workflows
-
----
-title: "Atom Events"
-description: "API reference for atom event parsing functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/events/atom-events"
----
+- [Bonding Curves](https://docs.intuition.systems/docs/intuition-concepts/economics/bonding-curves) - Understand pricing mechanics
+- [Examples](https://docs.intuition.systems/docs/protocol/examples/deposit-redeem) - See complete deposit/redeem workflows
 
 # Atom Events
+
+Source: https://docs.intuition.systems/docs/protocol/events/atom-events
 
 Functions for parsing atom-related events from transaction receipts.
 
@@ -31570,14 +30209,14 @@ Functions for parsing atom-related events from transaction receipts.
 
 Parse AtomCreated events from a transaction.
 
-### Parameters
+### eventParseAtomCreated - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | publicClient | `PublicClient` | Viem public client | Yes |
 | txHash | `Hash` | Transaction hash | Yes |
 
-### Returns
+### eventParseAtomCreated - Returns
 
 ```typescript
 Promise<Array<{
@@ -31591,7 +30230,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseAtomCreated - Example
 
 ```typescript
 import { eventParseAtomCreated } from '@0xintuition/protocol'
@@ -31605,13 +30244,11 @@ events.forEach((event) => {
 })
 ```
 
----
-
 ## eventParseAtomDepositCreated
 
 Parse AtomDepositCreated events (atom creation with initial deposit).
 
-### Returns
+### eventParseAtomDepositCreated - Returns
 
 ```typescript
 Promise<Array<{
@@ -31625,7 +30262,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseAtomDepositCreated - Example
 
 ```typescript
 import { eventParseAtomDepositCreated } from '@0xintuition/protocol'
@@ -31638,8 +30275,6 @@ events.forEach((event) => {
   console.log('Shares received:', formatEther(event.args.shares))
 })
 ```
-
----
 
 ## Complete Example
 
@@ -31671,22 +30306,15 @@ console.log('Created atoms:', atomEvents.map(e => e.args.termId))
 console.log('Deposits:', depositEvents.map(e => formatEther(e.args.assets)))
 ```
 
----
-
 ## See Also
 
-- [Triple Events](/docs/protocol/events/triple-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-- [Examples: Event Parsing](/docs/protocol/examples/event-parsing)
-
----
-title: "Triple Events"
-description: "API reference for triple event parsing functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/events/triple-events"
----
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
+- [Examples: Event Parsing](https://docs.intuition.systems/docs/protocol/examples/event-parsing)
 
 # Triple Events
+
+Source: https://docs.intuition.systems/docs/protocol/events/triple-events
 
 Functions for parsing triple-related events from transaction receipts.
 
@@ -31694,14 +30322,14 @@ Functions for parsing triple-related events from transaction receipts.
 
 Parse TripleCreated events from a transaction.
 
-### Parameters
+### eventParseTripleCreated - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | publicClient | `PublicClient` | Viem public client | Yes |
 | txHash | `Hash` | Transaction hash | Yes |
 
-### Returns
+### eventParseTripleCreated - Returns
 
 ```typescript
 Promise<Array<{
@@ -31716,7 +30344,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseTripleCreated - Example
 
 ```typescript
 import { eventParseTripleCreated } from '@0xintuition/protocol'
@@ -31732,13 +30360,11 @@ events.forEach((event) => {
 })
 ```
 
----
-
 ## eventParseTripleDepositCreated
 
 Parse TripleDepositCreated events.
 
-### Returns
+### eventParseTripleDepositCreated - Returns
 
 ```typescript
 Promise<Array<{
@@ -31752,7 +30378,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseTripleDepositCreated - Example
 
 ```typescript
 import { eventParseTripleDepositCreated } from '@0xintuition/protocol'
@@ -31766,21 +30392,14 @@ events.forEach((event) => {
 })
 ```
 
----
-
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-
----
-title: "Trust Bonding Events"
-description: "API reference for Trust Bonding event parsing functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/events/trust-bonding-events"
----
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
 
 # Trust Bonding Events
+
+Source: https://docs.intuition.systems/docs/protocol/events/trust-bonding-events
 
 Functions for parsing Trust Bonding events from transaction receipts.
 
@@ -31788,7 +30407,7 @@ Functions for parsing Trust Bonding events from transaction receipts.
 
 Parse RewardsClaimed events from a transaction.
 
-### Returns
+### eventParseRewardsClaimed - Returns
 
 ```typescript
 Promise<Array<{
@@ -31800,7 +30419,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseRewardsClaimed - Example
 
 ```typescript
 import { eventParseRewardsClaimed } from '@0xintuition/protocol'
@@ -31813,8 +30432,6 @@ events.forEach((event) => {
   console.log('Epoch:', event.args.epoch)
 })
 ```
-
----
 
 ## Generic Event Parser
 
@@ -31840,22 +30457,15 @@ const bondingEvents = await eventParse(
 )
 ```
 
----
-
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-- [Examples: Event Parsing](/docs/protocol/examples/event-parsing)
-
----
-title: "Vault Events"
-description: "API reference for vault event parsing functions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/events/vault-events"
----
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
+- [Examples: Event Parsing](https://docs.intuition.systems/docs/protocol/examples/event-parsing)
 
 # Vault Events
+
+Source: https://docs.intuition.systems/docs/protocol/events/vault-events
 
 Functions for parsing vault-related events from transaction receipts.
 
@@ -31863,7 +30473,7 @@ Functions for parsing vault-related events from transaction receipts.
 
 Parse Deposited events from a transaction.
 
-### Returns
+### eventParseDeposited - Returns
 
 ```typescript
 Promise<Array<{
@@ -31877,7 +30487,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseDeposited - Example
 
 ```typescript
 import { eventParseDeposited } from '@0xintuition/protocol'
@@ -31891,13 +30501,11 @@ events.forEach((event) => {
 })
 ```
 
----
-
 ## eventParseRedeemed
 
 Parse Redeemed events from a transaction.
 
-### Returns
+### eventParseRedeemed - Returns
 
 ```typescript
 Promise<Array<{
@@ -31911,7 +30519,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseRedeemed - Example
 
 ```typescript
 import { eventParseRedeemed } from '@0xintuition/protocol'
@@ -31925,13 +30533,11 @@ events.forEach((event) => {
 })
 ```
 
----
-
 ## eventParseSharePriceChanged
 
 Parse SharePriceChanged events.
 
-### Returns
+### eventParseSharePriceChanged - Returns
 
 ```typescript
 Promise<Array<{
@@ -31943,7 +30549,7 @@ Promise<Array<{
 }>>
 ```
 
-### Example
+### eventParseSharePriceChanged - Example
 
 ```typescript
 import { eventParseSharePriceChanged } from '@0xintuition/protocol'
@@ -31957,24 +30563,15 @@ events.forEach((event) => {
 })
 ```
 
----
-
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Triple Events](/docs/protocol/events/triple-events)
-- [Examples: Event Parsing](/docs/protocol/examples/event-parsing)
-
----
-title: "Batch Operations"
-description: "Complete examples for batch creation and deposit operations"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/examples/batch-operations"
----
-
-# Batch Operations
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
+- [Examples: Event Parsing](https://docs.intuition.systems/docs/protocol/examples/event-parsing)
 
 # Batch Operations Examples
+
+Source: https://docs.intuition.systems/docs/protocol/examples/batch-operations
 
 Complete workflows for performing batch operations to save gas and improve efficiency.
 
@@ -32163,18 +30760,13 @@ events.forEach((event, i) => {
 
 ## See Also
 
-- [Atom Functions](/docs/protocol/api-reference/multivault/atoms)
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-- [Triple Functions](/docs/protocol/api-reference/multivault/triples)
-
----
-title: "Creating Atoms & Triples"
-description: "Complete examples for creating atoms and triples"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples"
----
+- [Atom Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
+- [Triple Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples)
 
 # Creating Atoms & Triples
+
+Source: https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples
 
 Complete workflows for creating atoms and triples with the Protocol package.
 
@@ -32468,21 +31060,14 @@ const atomId = await createAtomIfNotExists('My Unique Atom')
 
 ## See Also
 
-- [Atom Functions](/docs/protocol/api-reference/multivault/atoms)
-- [Triple Functions](/docs/protocol/api-reference/multivault/triples)
-- [Atoms Fundamentals](/docs/intuition-concepts/primitives/Atoms/fundamentals)
-- [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
-
----
-title: "Deposit & Redeem"
-description: "Complete examples for vault deposits and redemptions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/examples/deposit-redeem"
----
-
-# Deposit & Redeem
+- [Atom Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Triple Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples)
+- [Atoms Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
+- [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 # Deposit & Redeem Examples
+
+Source: https://docs.intuition.systems/docs/protocol/examples/deposit-redeem
 
 Complete workflows for depositing to and redeeming from vaults.
 
@@ -32668,18 +31253,13 @@ await performCycle()
 
 ## See Also
 
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-- [Share Conversions](/docs/protocol/api-reference/multivault/conversions)
-- [Core Concepts: Vaults](/docs/protocol/core-concepts/vaults)
-
----
-title: "Event Parsing Examples"
-description: "Complete examples for parsing transaction events"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/examples/event-parsing"
----
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
+- [Share Conversions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions)
+- [Core Concepts: Vaults](https://docs.intuition.systems/docs/protocol/core-concepts/vaults)
 
 # Event Parsing Examples
+
+Source: https://docs.intuition.systems/docs/protocol/examples/event-parsing
 
 Complete workflows for parsing events from transaction receipts.
 
@@ -32799,20 +31379,13 @@ console.log('Recent activity:', feed)
 
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-- [Triple Events](/docs/protocol/events/triple-events)
-
----
-title: "Fee Calculations"
-description: "Complete examples for calculating and estimating fees"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/examples/fee-calculations"
----
-
-# Fee Calculations
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
 
 # Fee Calculations Examples
+
+Source: https://docs.intuition.systems/docs/protocol/examples/fee-calculations
 
 Complete workflows for calculating fees and estimating costs.
 
@@ -33000,18 +31573,13 @@ console.log('Vault fee comparison:', vaultComparison)
 
 ## See Also
 
-- [Fee Calculations API](/docs/protocol/api-reference/multivault/fees)
-- [Configuration](/docs/protocol/api-reference/multivault/configuration)
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-
----
-title: "Trust Bonding Examples"
-description: "Complete examples for Trust Bonding and rewards"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/examples/trust-bonding"
----
+- [Fee Calculations API](https://docs.intuition.systems/docs/protocol/api-reference/multivault/fees)
+- [Configuration](https://docs.intuition.systems/docs/protocol/api-reference/multivault/configuration)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
 
 # Trust Bonding Examples
+
+Source: https://docs.intuition.systems/docs/protocol/examples/trust-bonding
 
 Complete workflows for tracking rewards and utilization in the Trust Bonding system.
 
@@ -33129,18 +31697,13 @@ await monitorUtilization()
 
 ## See Also
 
-- [Trust Bonding Rewards](/docs/protocol/api-reference/trust-bonding/rewards)
-- [Epoch Management](/docs/protocol/api-reference/trust-bonding/epochs)
-- [Core Concepts: Epochs](/docs/protocol/core-concepts/epochs)
-
----
-title: "Configuration"
-description: "Configure clients, networks, and contract addresses for the Intuition Protocol"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/getting-started/configuration"
----
+- [Trust Bonding Rewards](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards)
+- [Epoch Management](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs)
+- [Core Concepts: Epochs](https://docs.intuition.systems/docs/protocol/core-concepts/epochs)
 
 # Configuration
+
+Source: https://docs.intuition.systems/docs/protocol/getting-started/configuration
 
 This guide covers how to configure the Protocol package for use with Intuition networks, including client setup, network configuration, and contract address management.
 
@@ -33536,18 +32099,13 @@ export const config = {
 
 ## Next Steps
 
-- [Core Concepts: Atoms](/docs/intuition-concepts/primitives/Atoms/fundamentals) - Learn about atoms
-- [API Reference: MultiVault](/docs/protocol/api-reference/multivault/atoms) - Explore available functions
-- [Examples](/docs/protocol/examples/creating-atoms-triples) - See complete workflows
-
----
-title: "Protocol Package Overview"
-description: "TypeScript SDK for interacting with the Intuition Protocol - atoms, triples, vaults, and bonding rewards"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/getting-started/overview"
----
+- [Core Concepts: Atoms](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals) - Learn about atoms
+- [API Reference: MultiVault](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms) - Explore available functions
+- [Examples](https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples) - See complete workflows
 
 # Protocol Package Overview
+
+Source: https://docs.intuition.systems/docs/protocol/getting-started/overview
 
 The `@0xintuition/protocol` package is a comprehensive TypeScript/JavaScript SDK for interacting with the Intuition onchain knowledge graph. It provides low-level access to build, query, and manage atoms (entities), triples (statements), vaults, and bonding rewards on the Intuition blockchain.
 
@@ -33720,13 +32278,13 @@ The Protocol package is ideal when you need:
 - **Event parsing**: Extract detailed event data from transactions
 - **Custom workflows**: Build your own higher-level abstractions
 
-For simpler, more user-friendly interactions, consider using the [SDK Package](/docs/intuition-sdk/quick-start) which provides higher-level abstractions including IPFS pinning, JSON-LD support, and simplified APIs.
+For simpler, more user-friendly interactions, consider using the [SDK Package](https://docs.intuition.systems/docs/intuition-sdk/quick-start) which provides higher-level abstractions including IPFS pinning, JSON-LD support, and simplified APIs.
 
 ## Next Steps
 
-- [Configuration Guide](/docs/protocol/getting-started/configuration) - Set up clients and networks
-- [API Reference](/docs/protocol/api-reference/multivault/atoms) - Explore all available functions
-- [Examples](/docs/protocol/examples/creating-atoms-triples) - See complete workflows
+- [Configuration Guide](https://docs.intuition.systems/docs/protocol/getting-started/configuration) - Set up clients and networks
+- [API Reference](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms) - Explore all available functions
+- [Examples](https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples) - See complete workflows
 
 ## Resources
 
@@ -33736,22 +32294,17 @@ For simpler, more user-friendly interactions, consider using the [SDK Package](/
 
 ## See Also
 
-- [SDK Package](/docs/intuition-sdk/quick-start) - Higher-level API with IPFS and JSON-LD support
-- [GraphQL API](/docs/graphql-api/overview) - Query protocol data efficiently
-- [Primitives Overview](/docs/intuition-concepts/primitives) - Understand atoms, triples, and signals
-
----
-title: "Working with Primitives"
-description: "Create and interact with atoms, triples, and vaults using the Protocol package"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/protocol/working-with-primitives"
----
+- [SDK Package](https://docs.intuition.systems/docs/intuition-sdk/quick-start) - Higher-level API with IPFS and JSON-LD support
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview) - Query protocol data efficiently
+- [Primitives Overview](https://docs.intuition.systems/docs/intuition-concepts/primitives) - Understand atoms, triples, and signals
 
 # Working with Primitives
 
+Source: https://docs.intuition.systems/docs/protocol/working-with-primitives
+
 This guide shows how to create and interact with atoms, triples, and vaults using the Protocol package (low-level contract interactions).
 
-**For conceptual understanding:** [Primitives Overview](/docs/intuition-concepts/primitives)
+**For conceptual understanding:** [Primitives Overview](https://docs.intuition.systems/docs/intuition-concepts/primitives)
 
 ## Creating Atoms
 
@@ -33787,7 +32340,7 @@ const tx = await multiVaultCreateAtoms({
 console.log('Atom created:', tx.atomIds[0])
 ```
 
-**See also:** [Atoms Concept](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+**See also:** [Atoms Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 ## Creating Triples
 
@@ -33812,7 +32365,7 @@ const tx = await multiVaultCreateTriples({
 console.log('Triple created:', tx.tripleIds[0])
 ```
 
-**See also:** [Triples Concept](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See also:** [Triples Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ## Vault Operations
 
@@ -33865,7 +32418,7 @@ console.log('Total shares:', vaultDetails.totalShares)
 console.log('Share price:', vaultDetails.currentSharePrice)
 ```
 
-**See also:** [Signals Concept](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See also:** [Signals Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 ## Batch Operations
 
@@ -33932,28 +32485,23 @@ publicClient.watchContractEvent({
 ## Examples
 
 See complete examples:
-- [Protocol Examples](/docs/protocol/examples/creating-atoms-triples)
+- [Protocol Examples](https://docs.intuition.systems/docs/protocol/examples/creating-atoms-triples)
 
 ## SDK Alternative
 
 For a higher-level API with React hooks, see:
-- [SDK Atoms Guide](/docs/intuition-sdk/atoms-guide)
-- [SDK Triples Guide](/docs/intuition-sdk/triples-guide)
-- [SDK Vaults Guide](/docs/intuition-sdk/vaults-guide)
+- [SDK Atoms Guide](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [SDK Triples Guide](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
+- [SDK Vaults Guide](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 ## API Reference
 
 Full API documentation:
-- [MultiVault API Reference](/docs/protocol/api-reference/multivault/atoms)
-
----
-title: "Contract Deployments"
-description: "The Intuition protocol contracts are deployed on both the Base Mainnet and the Intuition Layer 3 network, as well as their respective testnets. Below are the details of the deployed contracts,..."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/quick-start/deployments"
----
+- [MultiVault API Reference](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
 
 # Contract Deployments
+
+Source: https://docs.intuition.systems/docs/quick-start/deployments
 
 The Intuition protocol contracts are deployed on both the Base Mainnet and the Intuition Layer 3 network, as well as their respective testnets. Below are the details of the deployed contracts, including their addresses and network configurations.
 
@@ -34053,16 +32601,9 @@ Contract ABIs can be found in the following locations:
 - **GitHub**: [0xIntuition/intuition-contracts-v2](https://github.com/0xIntuition/intuition-contracts-v2/tree/main/abis)
 - **Block Explorer**: Available on verified contract pages
 
----
-title: "Network & Explorers"
-description: "Interacting with the Intuition protocol requires connecting to the Intuition network - an L3 network that posts to [Base](https://base.org/)."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/quick-start/network-details"
----
-
-# Network & Explorers
-
 # Intuition Network & Explorers
+
+Source: https://docs.intuition.systems/docs/quick-start/network-details
 
 Interacting with the Intuition protocol requires connecting to the Intuition network - an L3 network that posts to [Base](https://base.org/).
 
@@ -34093,7 +32634,7 @@ You can visit the [Intuition Testnet faucet](https://testnet.hub.intuition.syste
 
 - https://testnet.hub.intuition.systems/
 
-# Network Details
+## Network Details
 
 ### Intuition Mainnet Configuration
 - **Chain ID**: 1155
@@ -34121,14 +32662,9 @@ You can visit the [Intuition Testnet faucet](https://testnet.hub.intuition.syste
 - **Explorer**: `https://basescan.org`
 - **Native Token**: ETH
 
----
-title: "Intuition Testnet Faucet"
-description: "You can visit the [Intuition Testnet faucet](https://testnet.hub.intuition.systems/) to get some $tTRUST tokens for testing."
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/quick-start/testnet-faucet"
----
-
 # Intuition Testnet Faucet
+
+Source: https://docs.intuition.systems/docs/quick-start/testnet-faucet
 
 You can visit the [Intuition Testnet faucet](https://testnet.hub.intuition.systems/) to get some $tTRUST tokens for testing.
 
@@ -34140,22 +32676,17 @@ If you have any questions visit the [Intuition Discord](https://discord.gg/RgBen
 
 **https://discord.gg/RgBenkX4mx**
 
----
-title: "Using the SDK"
-description: "Get started building with Intuition in minutes."
-last_updated: "2026-06-25T17:11:24-04:00"
-source: "https://docs.intuition.systems/docs/quick-start/using-the-sdk"
----
-
 # Using the SDK
 
-# Intuition SDK Quick Start
+Source: https://docs.intuition.systems/docs/quick-start/using-the-sdk
+
+## Intuition SDK Quick Start
 
 Get started building with Intuition in minutes. 
 
 This guide provides direct code snippets to create atoms, triples, and signal on them.
 
-Before starting development, we recommend adding the Intuition Testnet and Mainnet networks to your preferred wallet. You can find the networks in the [Network Details](/docs/quick-start/network-details) page.
+Before starting development, we recommend adding the Intuition Testnet and Mainnet networks to your preferred wallet. You can find the networks in the [Network Details](https://docs.intuition.systems/docs/quick-start/network-details) page.
 
 ## Installation
 In most cases, you will only need to install the `@0xintuition/sdk` package. This package provides a high-level API for interacting with the Intuition protocol, plus exports the core `@0xintuition/protocol` and `@0xintuition/graphql` functionality.
@@ -34239,14 +32770,14 @@ export const walletClient = createWalletClient({
 })
 ```
 
-# Adding Data to the Knowledge Graph
+## Adding Data to the Knowledge Graph
 Data in the Intuition protocol is represented as atoms and triples. As a developer you will help users create atoms and triples in the protocol via onchain smart contracts, and retrieving data from the knowledge graph via offchain services.
 
 ## Create Atoms
 
 Atoms are the foundational building blocks of Intuition's knowledge graph – the words in our global dictionary. Think of Intuition as a vast, collaborative dictionary where anyone can create a new word, and each word has its own globally persistent, unique digital identifier that can be used to reference it across the entire internet!
 
-[Learn more about Atoms →](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+[Learn more about Atoms →](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 ### Create an Atom from a String
 
@@ -34375,7 +32906,7 @@ console.log('On-chain atom:', atomOnChain)
 
 If Atoms are the words in Intuition's global dictionary, Triples are the sentences we create from those words. A Triple connects three Atoms to assert a relationship or fact in the form **[Subject] – [Predicate] – [Object]**. You can string these sentences together to express any arbitrarily-complex concept, all while retaining a discrete, referenceable structure!
 
-[Learn more about Triples →](/docs/intuition-concepts/primitives/Triples/fundamentals)
+[Learn more about Triples →](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ```typescript
 import { createAtomFromString, createTripleStatement } from '@0xintuition/sdk'
@@ -34416,7 +32947,7 @@ console.log('Triple created:', triple.transactionHash)
 
 Signals represent the trust, confidence, or relevance that the community assigns to Atoms and Triples in the Intuition knowledge graph. Think of the knowledge graph as a weighted graph where Signal is the weight on each node (Atom) or edge (Triple), indicating how strongly people believe in or care about this information.
 
-[Learn more about Signals →](/docs/intuition-concepts/primitives/Signals/fundamentals)
+[Learn more about Signals →](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 ### Deposit (Signal Support)
 
@@ -34619,107 +33150,57 @@ Batch operations significantly reduce gas costs when working with multiple atoms
 
 Now that you know the basics, explore what you can build:
 
-- **[List Curation & Ranking](/docs/getting-started/use-cases#list-curation--ranking-systems)** - Create curated lists and reputation systems
-- **[Verification & Fraud Protection](/docs/getting-started/use-cases#verification-and-fraud-protection)** - Build trust and safety mechanisms
-- **[Social Platforms](/docs/getting-started/use-cases#community-owned-social-platforms)** - Portable identities and attestations
-- **[Reputation Scores](/docs/getting-started/use-cases#reputation-scores)** - Context-aware trust scoring
-- **[Q&A Platforms](/docs/getting-started/use-cases#qa-platforms)** - Knowledge sharing with proof
-- **[Oracles](/docs/getting-started/use-cases#oracles)** - Decentralized data feeds
+- **[List Curation & Ranking](https://docs.intuition.systems/docs/getting-started/use-cases#list-curation--ranking-systems)** - Create curated lists and reputation systems
+- **[Verification & Fraud Protection](https://docs.intuition.systems/docs/getting-started/use-cases#verification-and-fraud-protection)** - Build trust and safety mechanisms
+- **[Social Platforms](https://docs.intuition.systems/docs/getting-started/use-cases#community-owned-social-platforms)** - Portable identities and attestations
+- **[Reputation Scores](https://docs.intuition.systems/docs/getting-started/use-cases#reputation-scores)** - Context-aware trust scoring
+- **[Q&A Platforms](https://docs.intuition.systems/docs/getting-started/use-cases#qa-platforms)** - Knowledge sharing with proof
+- **[Oracles](https://docs.intuition.systems/docs/getting-started/use-cases#oracles)** - Decentralized data feeds
 
-[View all use cases →](/docs/getting-started/use-cases)
+[View all use cases →](https://docs.intuition.systems/docs/getting-started/use-cases)
 
 ## Next Steps
 
-- **[Build Your First App](/docs/tutorials/overview)** - Complete tutorial for a full application
-- **[Network Configuration](/docs/quick-start/network-details)** - Detailed network setup
-- **[Explore the SDK](/docs/intuition-sdk/quick-start)** - Deep dive into SDK capabilities
-- **[Smart Contracts](/docs/protocol/getting-started/overview)** - Contract architecture and ABIs
-- **[GraphQL API](/docs/graphql-api/overview)** - Query the knowledge graph
-- **[Join the Community](/docs/resources/community-and-support)** - Get help and share ideas
+- **[Build Your First App](https://docs.intuition.systems/docs/tutorials/overview)** - Complete tutorial for a full application
+- **[Network Configuration](https://docs.intuition.systems/docs/quick-start/network-details)** - Detailed network setup
+- **[Explore the SDK](https://docs.intuition.systems/docs/intuition-sdk/quick-start)** - Deep dive into SDK capabilities
+- **[Smart Contracts](https://docs.intuition.systems/docs/protocol/getting-started/overview)** - Contract architecture and ABIs
+- **[GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)** - Query the knowledge graph
+- **[Join the Community](https://docs.intuition.systems/docs/resources/community-and-support)** - Get help and share ideas
 
-Check out [Choose Your Path](/docs/getting-started/choose-your-path) to find the best starting point for your project.
-
----
-title: "Community & Support"
-description: "Connect with the Intuition community and get the support you need"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/resources/community-and-support"
----
+Check out [Choose Your Path](https://docs.intuition.systems/docs/getting-started/choose-your-path) to find the best starting point for your project.
 
 # Community & Support
+
+Source: https://docs.intuition.systems/docs/resources/community-and-support
 
 Connect with the Intuition community, get help, and stay updated with the latest developments.
 
 ## Official Channels
 
-<svg width="32" height="32" viewBox="0 0 24 24" fill="white">
-<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-</svg>
+[Follow us on X for real-time updates, announcements, and community highlights.](https://x.com/0xintuition)
 
-Follow us on X for real-time updates, announcements, and community highlights.
+[Join our Discord community for discussions, support, and real-time collaboration.](https://discord.com/invite/0xintuition)
 
-<svg width="32" height="32" viewBox="0 0 24 24" fill="white">
-<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z"/>
-</svg>
+[Watch video recordings, tutorials, and community content on our YouTube channel.](https://www.youtube.com/@0xIntuition)
 
-Join our Discord community for discussions, support, and real-time collaboration.
-
-<svg width="32" height="32" viewBox="0 0 24 24" fill="white">
-<path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
-</svg>
-
-Watch video recordings, tutorials, and community content on our YouTube channel.
-
-<svg width="32" height="32" viewBox="0 0 24 24" fill="white">
-<path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/>
-</svg>
-
-Read our latest articles, insights, and technical deep-dives on Medium.
+[Read our latest articles, insights, and technical deep-dives on Medium.](https://medium.com/0xintuition)
 
 ## Support Channels
 
-<svg width="20" height="20" viewBox="0 0 24 24" fill="white">
-<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/>
-</svg>
+[General Support Get general support and assistance for questions about Intuition.](mailto:support@intuition.systems)
 
-<h3 >General Support</h3>
-
-Get general support and assistance for questions about Intuition.
-
-<svg width="20" height="20" viewBox="0 0 24 24" fill="white">
-<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-</svg>
-
-<h3 >Website</h3>
-
-Visit our official website for the latest updates, information, and resources.
+[Website Visit our official website for the latest updates, information, and resources.](https://www.intuition.systems)
 
 ## Feedback & Improvement
 
-<svg width="20" height="20" viewBox="0 0 24 24" fill="white">
-<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-</svg>
+[GitHub Contribute to our open-source projects, report issues, and suggest improvements.](https://github.com/0xintuition)
 
-<h3 >GitHub</h3>
-
-Contribute to our open-source projects, report issues, and suggest improvements.
-
-<svg width="20" height="20" viewBox="0 0 24 24" fill="white">
-<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-</svg>
-
-<h3 >Feedback</h3>
-
-Share your feedback, suggestions, and ideas to help improve Intuition.
-
----
-title: "FAQ"
-description: "Frequently Asked Questions about Intuition"
-last_updated: "2026-02-11T09:19:02-05:00"
-source: "https://docs.intuition.systems/docs/resources/faq"
----
+[Feedback Share your feedback, suggestions, and ideas to help improve Intuition.](mailto:feedback@intuition.systems)
 
 # FAQ
+
+Source: https://docs.intuition.systems/docs/resources/faq
 
 This page is organized into expandable sections for easy navigation. Click on any section below to explore the questions within that category.
 
@@ -34736,7 +33217,7 @@ The protocol uses atomic primitives (atoms, triples, signals, and bonding curves
 ### How do I get started with Intuition?
 
 **Step 1: Read the Documentation**  
-Start with the [Getting Started](/docs/getting-started/overview) guides to understand the core concepts.
+Start with the [Getting Started](https://docs.intuition.systems/docs/getting-started/overview) guides to understand the core concepts.
 
 **Step 2: Connect to Testnet**  
 Visit the [Intuition Hub](https://intuition-testnet.hub.caldera.xyz/) to access the testnet and get your development environment set up.
@@ -34905,7 +33386,7 @@ Common causes of transaction failures:
 
 **Community Support**: Join our [Discord](https://discord.com/invite/0xintuition) for real-time help from the community.
 
-**Documentation**: Check our comprehensive [documentation](/docs) for detailed guides and tutorials.
+**Documentation**: Check our comprehensive [documentation](https://docs.intuition.systems/docs) for detailed guides and tutorials.
 
 **GitHub**: Report issues and contribute to the project on [GitHub](https://github.com/0xintuition).
 
@@ -34943,22 +33424,16 @@ Use Cases & Contributing - Applications and ecosystem participation
 
 ## Need More Help?
 
-<h3 >Can't find what you're looking for?</h3>
+### Can't find what you're looking for?
 
 We're here to help! Reach out to our community or support team for assistance.
 
-Join Community
-
-Contact Support
-
----
-title: "Glossary"
-description: "Key terms and definitions for Intuition"
-last_updated: "2026-02-11T09:19:02-05:00"
-source: "https://docs.intuition.systems/docs/resources/glossary"
----
+[Join Community](https://docs.intuition.systems/docs/resources/community-and-support)
+[Contact Support](mailto:support@intuition.systems)
 
 # Glossary
+
+Source: https://docs.intuition.systems/docs/resources/glossary
 
 Comprehensive glossary of key terms used in Intuition documentation.
 
@@ -34968,7 +33443,7 @@ Comprehensive glossary of key terms used in Intuition documentation.
 
 A unique decentralized identifier for any entity, concept, or piece of data. Atoms are the fundamental building blocks of the knowledge graph.
 
-**See:** [Atoms Fundamentals](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+**See:** [Atoms Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 **Example:** An atom representing "TypeScript" or an Ethereum address "0x742d35..."
 
@@ -34976,7 +33451,7 @@ A unique decentralized identifier for any entity, concept, or piece of data. Ato
 
 A verifiable claim or statement made on-chain using triples. Attestations can be supported or opposed through signals (staking).
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 **Example:** `[Alice] [endorses] [Bob]` is an attestation that Alice endorses Bob.
 
@@ -34984,7 +33459,7 @@ A verifiable claim or statement made on-chain using triples. Attestations can be
 
 Arbitrum's data availability solution that provides a trust-minimized alternative to standard rollup data availability. Uses a committee of trusted parties.
 
-**See:** [Network Architecture](/docs/intuition-network)
+**See:** [Network Architecture](https://docs.intuition.systems/docs/intuition-network)
 
 ## B
 
@@ -34992,7 +33467,7 @@ Arbitrum's data availability solution that provides a trust-minimized alternativ
 
 A mathematical function that determines the price of vault shares based on supply. As more people stake, the price increases proportionally.
 
-**See:** [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See:** [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 **Formula:** `price = k * supply^n` (where k and n are constants)
 
@@ -35000,7 +33475,7 @@ A mathematical function that determines the price of vault shares based on suppl
 
 A smart contract system that allows transferring assets between different blockchain networks. Intuition uses a bridge to connect testnet to Base Sepolia.
 
-**See:** [Network Overview](/docs/intuition-network)
+**See:** [Network Overview](https://docs.intuition.systems/docs/intuition-network)
 
 ## C
 
@@ -35012,13 +33487,13 @@ A triple that opposes or contradicts another triple. Used for expressing disagre
 - Triple: `[Contract A] [is safe] [true]`
 - Counter: `[Contract A] [is safe] [false]`
 
-**See:** [Triple Operations](/docs/intuition-sdk/triples-guide)
+**See:** [Triple Operations](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
 
 ### Creator Fee
 
 A fee paid to the creator of an atom or triple when others interact with it. Incentivizes quality contributions.
 
-**See:** [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See:** [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 ## D
 
@@ -35026,7 +33501,7 @@ A fee paid to the creator of an atom or triple when others interact with it. Inc
 
 A W3C standard for decentralized, self-sovereign identities. Intuition atoms can serve as DIDs for entities.
 
-**See:** [Core Concepts](/docs/intuition-concepts/primitives)
+**See:** [Core Concepts](https://docs.intuition.systems/docs/intuition-concepts/primitives)
 
 **Format:** `did:intuition:<vault-id>`
 
@@ -35034,7 +33509,7 @@ A W3C standard for decentralized, self-sovereign identities. Intuition atoms can
 
 The act of staking assets into a vault to signal support for an atom or triple. Returns vault shares representing ownership.
 
-**See:** [Vaults Guide](/docs/intuition-sdk/vaults-guide)
+**See:** [Vaults Guide](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 ## E
 
@@ -35042,7 +33517,7 @@ The act of staking assets into a vault to signal support for an atom or triple. 
 
 A time period used for calculating rewards and fees. Epochs help coordinate economic activity and batch operations.
 
-**See:** [Protocol Documentation](/docs/protocol/getting-started/overview)
+**See:** [Protocol Documentation](https://docs.intuition.systems/docs/protocol/getting-started/overview)
 
 **Duration:** Configurable by protocol (e.g., 1 day, 1 week)
 
@@ -35050,7 +33525,7 @@ A time period used for calculating rewards and fees. Epochs help coordinate econ
 
 The runtime environment for smart contracts on Ethereum and compatible chains. Intuition is EVM-compatible.
 
-**See:** [Network Architecture](/docs/intuition-network)
+**See:** [Network Architecture](https://docs.intuition.systems/docs/intuition-network)
 
 ## F
 
@@ -35058,7 +33533,7 @@ The runtime environment for smart contracts on Ethereum and compatible chains. I
 
 The system of fees charged for creating atoms, triples, and vault operations. Fees are distributed to various stakeholders including creators, protocol, and stakers.
 
-**See:** [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See:** [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 **Fee types:**
 - Entry fees (when staking)
@@ -35072,7 +33547,7 @@ The system of fees charged for creating atoms, triples, and vault operations. Fe
 
 A query language for APIs that allows clients to request exactly the data they need. Intuition provides a GraphQL API for querying the knowledge graph.
 
-**See:** [GraphQL API](/docs/graphql-api/overview)
+**See:** [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)
 
 ## I
 
@@ -35080,7 +33555,7 @@ A query language for APIs that allows clients to request exactly the data they n
 
 Decentralized storage protocol for content-addressed data. Atoms can reference IPFS content by CID (Content Identifier).
 
-**See:** [Atoms Guide](/docs/intuition-sdk/atoms-guide)
+**See:** [Atoms Guide](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 **Example CID:** `QmXnnyufdzAWL5CqZ2RnSNgPbvCc1ALT73s6epPrRnZ1Xy`
 
@@ -35090,7 +33565,7 @@ Decentralized storage protocol for content-addressed data. Atoms can reference I
 
 The interconnected network of atoms (nodes) and triples (edges) forming Intuition's decentralized data layer. Represents structured knowledge and relationships.
 
-**See:** [Primitives Overview](/docs/intuition-concepts/primitives)
+**See:** [Primitives Overview](https://docs.intuition.systems/docs/intuition-concepts/primitives)
 
 ## L
 
@@ -35098,7 +33573,7 @@ The interconnected network of atoms (nodes) and triples (edges) forming Intuitio
 
 A blockchain built on top of a Layer 2 solution. Intuition is an L3 built on Base using Arbitrum Orbit technology.
 
-**See:** [Network Architecture](/docs/intuition-network)
+**See:** [Network Architecture](https://docs.intuition.systems/docs/intuition-network)
 
 ## M
 
@@ -35106,7 +33581,7 @@ A blockchain built on top of a Layer 2 solution. Intuition is an L3 built on Bas
 
 The core smart contract that manages all atoms, triples, and vaults in Intuition. Acts as the central registry and vault factory.
 
-**See:** [MultiVault API](/docs/protocol/api-reference/multivault/atoms)
+**See:** [MultiVault API](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
 
 **Functions:**
 - Create atoms and triples
@@ -35119,7 +33594,7 @@ The core smart contract that manages all atoms, triples, and vaults in Intuition
 
 A triple that uses another triple as one of its components (subject, predicate, or object), enabling complex, multi-layered expressions.
 
-**See:** [Triples](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 **Example:** `[Alice] [endorses] [[Bob has skill TypeScript]]`
 
@@ -35129,7 +33604,7 @@ This states "Alice endorses the claim that Bob has skill TypeScript"
 
 A server that runs the Intuition indexing software, providing local access to the knowledge graph database and GraphQL API.
 
-**See:** [Network Overview](/docs/intuition-network)
+**See:** [Network Overview](https://docs.intuition.systems/docs/intuition-network)
 
 ## O
 
@@ -35139,7 +33614,7 @@ The third component of a triple—what is being claimed about the subject. Can b
 
 **Example:** In `[Alice] [knows] [Bob]`, "Bob" is the object.
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ## P
 
@@ -35149,13 +33624,13 @@ The middle component of a triple that defines the relationship between subject a
 
 **Examples:** "knows", "has skill", "is member of", "endorses"
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ### Protocol Fee
 
 A fee collected by the Intuition protocol on various operations, used for protocol development and sustainability.
 
-**See:** [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See:** [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 ## R
 
@@ -35163,13 +33638,13 @@ A fee collected by the Intuition protocol on various operations, used for protoc
 
 A W3C standard for describing resources and their relationships. Intuition's triple format is compatible with RDF principles.
 
-**See:** [Triples](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ### Redemption
 
 The act of withdrawing staked assets from a vault by burning vault shares. Subject to exit fees.
 
-**See:** [Vaults Guide](/docs/intuition-sdk/vaults-guide)
+**See:** [Vaults Guide](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 ## S
 
@@ -35177,7 +33652,7 @@ The act of withdrawing staked assets from a vault by burning vault shares. Subje
 
 The weight of trust or conviction expressed through staking on atoms or triples. Higher signals indicate stronger community support.
 
-**See:** [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See:** [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 **Measured by:** Total value staked in vault
 
@@ -35185,7 +33660,7 @@ The weight of trust or conviction expressed through staking on atoms or triples.
 
 A structured claim in [Subject]-[Predicate]-[Object] format, following RDF/semantic web standards.
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 **Standard form:** `[Subject Atom] [Predicate Atom] [Object Atom]`
 
@@ -35195,7 +33670,7 @@ The first component of a triple—the entity being described or making a claim.
 
 **Example:** In `[Alice] [knows] [Bob]`, "Alice" is the subject.
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ## T
 
@@ -35203,13 +33678,13 @@ The first component of a triple—the entity being described or making a claim.
 
 Intuition's economic model where token staking curates and validates knowledge. Economic incentives align with truth and quality.
 
-**See:** [Signals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See:** [Signals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 ### Triple
 
 A structured statement connecting three atoms in Subject-Predicate-Object format. The fundamental unit of claims in Intuition.
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 **Format:** `[Subject] [Predicate] [Object]`
 
@@ -35217,7 +33692,7 @@ A structured statement connecting three atoms in Subject-Predicate-Object format
 
 The native token of Intuition Network, used for staking, governance, and paying gas fees.
 
-**See:** [Network Overview](/docs/intuition-network)
+**See:** [Network Overview](https://docs.intuition.systems/docs/intuition-network)
 
 **Symbol:** $TRUST (mainnet), $tTRUST (testnet)
 
@@ -35227,7 +33702,7 @@ The native token of Intuition Network, used for staking, governance, and paying 
 
 An on-chain smart contract holding staked assets for a specific atom or triple. Each atom/triple has its own isolated vault.
 
-**See:** [Vaults Guide](/docs/intuition-sdk/vaults-guide)
+**See:** [Vaults Guide](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 **Functions:**
 - Hold staked assets
@@ -35239,13 +33714,13 @@ An on-chain smart contract holding staked assets for a specific atom or triple. 
 
 The unique identifier for a vault, derived from the corresponding atom or triple ID. Used to reference vaults in contracts and APIs.
 
-**See:** [MultiVault API](/docs/protocol/api-reference/multivault/atoms)
+**See:** [MultiVault API](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
 
 ### Vault Shares
 
 Tokens representing ownership in a vault's assets. Issued when depositing, burned when redeeming. Value increases as fees accumulate.
 
-**See:** [Vaults Guide](/docs/intuition-sdk/vaults-guide)
+**See:** [Vaults Guide](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 ## W
 
@@ -35253,81 +33728,54 @@ Tokens representing ownership in a vault's assets. Issued when depositing, burne
 
 A tokenized representation of staked TRUST in a vault, making staked positions transferable as ERC-20 tokens.
 
-**See:** [Protocol API Reference](/docs/protocol/api-reference/wrapped-trust/overview)
+**See:** [Protocol API Reference](https://docs.intuition.systems/docs/protocol/api-reference/wrapped-trust/overview)
 
 **Use cases:**
 - Transfer staked positions
 - Use as collateral
 - Trade on DEXs
 
----
-
 ## Not Finding a Term?
 
 Check these resources:
-- **[FAQ](/docs/resources/faq)** - Common questions
-- **[Community Support](/docs/resources/community-and-support)** - Ask the community
-- **[Core Concepts](/docs/intuition-concepts/primitives)** - In-depth explanations
+- **[FAQ](https://docs.intuition.systems/docs/resources/faq)** - Common questions
+- **[Community Support](https://docs.intuition.systems/docs/resources/community-and-support)** - Ask the community
+- **[Core Concepts](https://docs.intuition.systems/docs/intuition-concepts/primitives)** - In-depth explanations
 - **[Discord](https://discord.gg/RgBenkX4mx)** - Real-time help
 
----
-title: "Resources"
-description: "Additional resources and community support"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/resources"
----
-
 # Resources
+
+Source: https://docs.intuition.systems/docs/resources
 
 Find additional resources, support, and tools for building with Intuition.
 
 ## Documentation Resources
 
-<h3>FAQ</h3>
+[FAQ Frequently asked questions about Intuition. From basic concepts to advanced implementation details, get quick answers to common questions.](https://docs.intuition.systems/docs/resources/faq)
 
-Frequently asked questions about Intuition. From basic concepts to advanced implementation details, get quick answers to common questions.
+[Glossary Comprehensive glossary of key terms and definitions. Master the essential terminology for working with Intuition.](https://docs.intuition.systems/docs/resources/glossary)
 
-<h3>Glossary</h3>
-
-Comprehensive glossary of key terms and definitions. Master the essential terminology for working with Intuition.
-
-<h3>Tutorials</h3>
-
-Step-by-step guides for building with Intuition. Learn by doing with hands-on tutorials covering common use cases.
+[Tutorials Step-by-step guides for building with Intuition. Learn by doing with hands-on tutorials covering common use cases.](https://docs.intuition.systems/docs/tutorials/overview)
 
 ## Community & Support
 
-<h3>Community Channels</h3>
+[Community Channels Connect with the Intuition community. Join Discord, Forum discussions, and follow us on Twitter for updates.](https://docs.intuition.systems/docs/resources/community-and-support)
 
-Connect with the Intuition community. Join Discord, Forum discussions, and follow us on Twitter for updates.
+[Contributing Help improve Intuition. Learn how to contribute to the protocol, documentation, and ecosystem.](https://docs.intuition.systems/docs/contribution-guidelines)
 
-<h3>Contributing</h3>
-
-Help improve Intuition. Learn how to contribute to the protocol, documentation, and ecosystem.
-
-<h3>GitHub</h3>
-
-Open source repositories for the Intuition protocol, SDK, and tools. Contribute code or report issues.
+[GitHub Open source repositories for the Intuition protocol, SDK, and tools. Contribute code or report issues.](https://github.com/0xIntuition)
 
 ## Security
 
-<h3>Audit Reports</h3>
+[Audit Reports Third-party security audits of Intuition smart contracts. Review audit findings and security best practices.](https://docs.intuition.systems/docs/intuition-smart-contracts/audit-reports)
 
-Third-party security audits of Intuition smart contracts. Review audit findings and security best practices.
-
-<h3>Bug Bounty</h3>
-
-Report security vulnerabilities and earn rewards. Help keep Intuition secure through our bug bounty program.
+[Bug Bounty Report security vulnerabilities and earn rewards. Help keep Intuition secure through our bug bounty program.](https://immunefi.com/bounty/intuition/)
 
 ## AI Agent Integration
 
-<h3>llms.txt</h3>
+[llms.txt Concise documentation index optimized for LLM consumption. Quick reference for AI agents integrating with Intuition.](https://docs.intuition.systems/llms.txt)
 
-Concise documentation index optimized for LLM consumption. Quick reference for AI agents integrating with Intuition.
-
-<h3>llms-full.txt</h3>
-
-Complete documentation in LLM-friendly format. Full protocol reference for advanced AI agent integration.
+[llms-full.txt Complete documentation in LLM-friendly format. Full protocol reference for advanced AI agent integration.](https://docs.intuition.systems/llms-full.txt)
 
 ## External Links
 
@@ -35343,26 +33791,26 @@ Complete documentation in LLM-friendly format. Full protocol reference for advan
 - **[Status Page](https://status.intuition.systems)** - Network status monitoring
 
 ### Network Monitoring
-- **[Network Health](/docs/intuition-network)** - Real-time status
+- **[Network Health](https://docs.intuition.systems/docs/intuition-network)** - Real-time status
 - **[Testnet Explorer](https://testnet.explorer.intuition.systems)** - Blockchain explorer
 - **[GraphQL Playground](https://mainnet.intuition.sh/v1/graphql)** - Query interface
 
 ## Learning Resources
 
 ### Core Concepts
-- **[Primitives Overview](/docs/intuition-concepts/primitives)** - Understanding atoms, triples, and signals
-- **[Economics](/docs/intuition-concepts/economics)** - Tokenomics and incentive design
-- **[Architecture](/docs/intuition-concepts/architecture)** - System design and architecture
+- **[Primitives Overview](https://docs.intuition.systems/docs/intuition-concepts/primitives)** - Understanding atoms, triples, and signals
+- **[Economics](https://docs.intuition.systems/docs/intuition-concepts/economics)** - Tokenomics and incentive design
+- **[Architecture](https://docs.intuition.systems/docs/intuition-concepts/architecture)** - System design and architecture
 
 ### Developer Guides
-- **[SDK Documentation](/docs/intuition-sdk/installation-and-setup)** - TypeScript SDK
-- **[Protocol API](/docs/protocol/api-reference/multivault/atoms)** - Smart contract API
-- **[GraphQL API](/docs/graphql-api/getting-started/introduction)** - Query language
+- **[SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)** - TypeScript SDK
+- **[Protocol API](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)** - Smart contract API
+- **[GraphQL API](https://docs.intuition.systems/docs/graphql-api/getting-started/introduction)** - Query language
 
 ### Tutorials
-- **[Create Your First Atom](/docs/tutorials/overview)** - Getting started
-- **[Build a Reputation System](/docs/tutorials/reputation-system)** - Intermediate tutorial
-- **[Custom Indexing](/docs/tutorials/advanced/batch-operations)** - Advanced topics
+- **[Create Your First Atom](https://docs.intuition.systems/docs/tutorials/overview)** - Getting started
+- **[Build a Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)** - Intermediate tutorial
+- **[Custom Indexing](https://docs.intuition.systems/docs/tutorials/advanced/batch-operations)** - Advanced topics
 
 ## Stay Updated
 
@@ -35378,18 +33826,11 @@ Complete documentation in LLM-friendly format. Full protocol reference for advan
 
 ## Additional Tools
 
-<h3>Network Health</h3>
-
-Monitor real-time network status and uptime statistics. Stay informed about maintenance and incidents.
-
----
-title: "Key Terms"
-description: "Essential terminology and concepts for the Intuition ecosystem"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/resources/key-terms"
----
+[Network Health Monitor real-time network status and uptime statistics. Stay informed about maintenance and incidents.](https://docs.intuition.systems/docs/intuition-network)
 
 # Key Terms
+
+Source: https://docs.intuition.systems/docs/resources/key-terms
 
 This page defines the essential terminology and concepts you need to understand the Intuition protocol. Terms are organized by category to help you quickly find what you're looking for.
 
@@ -35397,9 +33838,6 @@ This page defines the essential terminology and concepts you need to understand 
 
 This page is organized into expandable sections for easy navigation. Click on any section below to explore the terms within that category.
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Core Primitives - Fundamental building blocks of the Intuition protocol
 
 ## Core Primitives
@@ -35457,9 +33895,6 @@ This creates the statement: "Alice works for Intuition Systems"
 - **Negative Signals**: Disagreements or refutations
 - **Neutral Signals**: Acknowledgment without taking a position
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Economic Components - Financial and incentive mechanisms
 
 ## Economic Components
@@ -35504,9 +33939,6 @@ Economic Components - Financial and incentive mechanisms
 - **Market Cap Aggregation**: Combines value across all associated vaults
 - **Universal Reference**: Provides a stable identifier for the concept
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Network Components - Protocol infrastructure and governance
 
 ## Network Components
@@ -35541,9 +33973,6 @@ The **Knowledge Graph** is the collective network of atoms, triples, and signals
 - **Endorsements**: Support for existing information
 - **Refutations**: Disagreements with existing information
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Technical Components - Developer tools and APIs
 
 ## Technical Components
@@ -35578,9 +34007,6 @@ The **GraphQL API** provides a unified interface for querying and interacting wi
 - **BondingCurveRegistry**: Manages different curve implementations
 - **TrustBonding**: Implements trust-based economic mechanisms
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 User Roles - Different ways to participate in the ecosystem
 
 ## User Roles
@@ -35615,9 +34041,6 @@ User Roles - Different ways to participate in the ecosystem
 - **Integration Services**: APIs and services that connect to Intuition
 - **Mobile Applications**: Native mobile experiences
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Economic Terms - Financial metrics and market concepts
 
 ## Economic Terms
@@ -35657,9 +34080,6 @@ Market Cap = Total Shares × Current Share Price
 - **Price Stability**: How much price changes with large trades
 - **Accessibility**: How easy it is for users to participate
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Governance Terms - Protocol governance and decision-making
 
 ## Governance Terms
@@ -35684,18 +34104,11 @@ Governance Terms - Protocol governance and decision-making
 - **Multi-Sig**: Critical decisions require multiple approvals
 - **Emergency Powers**: Special procedures for urgent situations
 
----
-
-> **Ready to dive deeper?** Explore our [Architecture Guide](/docs/getting-started/architecture) to understand how these components work together, or check out our [Quick Start Guide](/docs/quick-start/using-the-sdk) to begin building with Intuition.
-
----
-title: "Optimizing Batch Operations"
-description: "Efficiently create multiple atoms and triples"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/tutorials/advanced/batch-operations"
----
+> **Ready to dive deeper?** Explore our [Architecture Guide](https://docs.intuition.systems/docs/getting-started/architecture) to understand how these components work together, or check out our [Quick Start Guide](https://docs.intuition.systems/docs/quick-start/using-the-sdk) to begin building with Intuition.
 
 # Optimizing Batch Operations
+
+Source: https://docs.intuition.systems/docs/tutorials/advanced/batch-operations
 
 > Coming soon! This tutorial will show how to efficiently create and manage multiple atoms and triples in batches.
 
@@ -35715,9 +34128,9 @@ This tutorial will cover:
 
 See these resources:
 
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
-- [Protocol API Reference](/docs/protocol/api-reference/multivault/atoms)
-- [Performance Best Practices](/docs/intuition-sdk/quick-start)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
+- [Protocol API Reference](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Performance Best Practices](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ## Quick Example
 
@@ -35747,14 +34160,9 @@ console.log(`Created ${atomIds.length} atoms in one transaction`)
 
 Want to be notified when this tutorial is ready? Join our [Discord](https://discord.gg/RgBenkX4mx).
 
----
-title: "Working with Nested Triples"
-description: "Use triples as atoms for complex expressions"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/tutorials/advanced/nested-triples"
----
-
 # Working with Nested Triples
+
+Source: https://docs.intuition.systems/docs/tutorials/advanced/nested-triples
 
 > Coming soon! This tutorial will show how to create complex, multi-layered claims.
 
@@ -35773,9 +34181,9 @@ This tutorial will cover:
 
 See these resources to learn about nested triples:
 
-- [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
-- [Nested Triples Concept](/docs/intuition-concepts/primitives/Triples/nested-triples)
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
+- [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
+- [Nested Triples Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
 
 ## Simple Example
 
@@ -35808,14 +34216,9 @@ const metaTriple = await multivault.createTriple({
 
 Want to be notified when this tutorial is ready? Join our [Discord](https://discord.gg/RgBenkX4mx) or follow us on [Twitter](https://twitter.com/0xIntuition).
 
----
-title: "Oracle Integration"
-description: "Use Intuition claims in smart contracts"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/tutorials/advanced/oracle-integration"
----
-
 # Oracle Integration
+
+Source: https://docs.intuition.systems/docs/tutorials/advanced/oracle-integration
 
 > Coming soon! This tutorial will show how to use Intuition as an oracle for your smart contracts.
 
@@ -35843,9 +34246,9 @@ This tutorial will cover:
 
 See these resources:
 
-- [Protocol Smart Contracts](/docs/protocol/getting-started/overview)
-- [Multivault Contract API](/docs/protocol/api-reference/multivault/atoms)
-- [Solidity Integration Guide](/docs/protocol/getting-started/overview)
+- [Protocol Smart Contracts](https://docs.intuition.systems/docs/protocol/getting-started/overview)
+- [Multivault Contract API](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Solidity Integration Guide](https://docs.intuition.systems/docs/protocol/getting-started/overview)
 
 ## Quick Example
 
@@ -35880,14 +34283,9 @@ contract ReputationGatedDAO {
 
 Want to be notified when this tutorial is ready? Join our [Discord](https://discord.gg/RgBenkX4mx).
 
----
-title: "Building Curated Lists with Community Ranking"
-description: "Create token-curated registries with signal-based ranking"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/curated-lists"
----
-
 # Building Curated Lists with Community Ranking
+
+Source: https://docs.intuition.systems/docs/tutorials/curated-lists
 
 Build a community-curated list where ranking is determined by stake. Perfect for token-curated registries (TCRs), trusted contract lists, or any ranked collection.
 
@@ -36925,9 +35323,9 @@ console.log('Rankings:', rankings)
 
 You've built a complete curated list system! Explore:
 
-1. **[Reputation System](/docs/tutorials/reputation-system)** - Combine with reputation
-2. **[Fraud Detection](/docs/tutorials/fraud-detection)** - Use for safety lists
-3. **[Nested Triples](/docs/tutorials/advanced/nested-triples)** - Advanced list logic
+1. **[Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)** - Combine with reputation
+2. **[Fraud Detection](https://docs.intuition.systems/docs/tutorials/fraud-detection)** - Use for safety lists
+3. **[Nested Triples](https://docs.intuition.systems/docs/tutorials/advanced/nested-triples)** - Advanced list logic
 
 ## Example Repository
 
@@ -36940,22 +35338,15 @@ npm run dev
 
 ## Resources
 
-- [SDK Overview](/docs/intuition-sdk/quick-start)
-- [GraphQL API](/docs/graphql-api/overview)
+- [SDK Overview](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)
 - [Community Discord](https://discord.gg/RgBenkX4mx)
-
----
 
 Built with Intuition - The Universal Reputation Protocol
 
----
-title: "Building a Fraud Detection System"
-description: "Community-driven scam flagging with weighted voting"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/fraud-detection"
----
-
 # Building a Fraud Detection System
+
+Source: https://docs.intuition.systems/docs/tutorials/fraud-detection
 
 Create a community-driven fraud detection system where users flag malicious contracts, scam tokens, and phishing sites, with expert signals weighted more heavily.
 
@@ -37846,9 +36237,9 @@ console.log('Safety:', safety.status)
 
 Explore more:
 
-1. **[Curated Lists](/docs/tutorials/curated-lists)** - Trusted contract registries
-2. **[Reputation System](/docs/tutorials/reputation-system)** - Expert reputation
-3. **[Oracle Integration](/docs/tutorials/advanced/oracle-integration)** - Use in smart contracts
+1. **[Curated Lists](https://docs.intuition.systems/docs/tutorials/curated-lists)** - Trusted contract registries
+2. **[Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)** - Expert reputation
+3. **[Oracle Integration](https://docs.intuition.systems/docs/tutorials/advanced/oracle-integration)** - Use in smart contracts
 
 ## Example Repository
 
@@ -37858,28 +36249,21 @@ git clone https://github.com/0xIntuition/fraud-detection-example
 
 ## Resources
 
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
-- [GraphQL API](/docs/graphql-api/overview)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)
 - [Discord Community](https://discord.gg/RgBenkX4mx)
-
----
 
 Built with Intuition - The Universal Reputation Protocol
 
----
-title: "Tutorials"
-description: "Learn by building real applications with Intuition"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/tutorials/overview"
----
-
 # Tutorials
+
+Source: https://docs.intuition.systems/docs/tutorials/overview
 
 Learn by building real applications with Intuition. Each tutorial is a complete, end-to-end guide with working code.
 
 ## Building Applications
 
-### [Reputation System](/docs/tutorials/reputation-system)
+### [Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)
 
 Build a developer reputation platform with skills, endorsements, and verifiable credentials.
 
@@ -37891,9 +36275,7 @@ Build a developer reputation platform with skills, endorsements, and verifiable 
 
 **Time:** 2-3 hours | **Level:** Intermediate
 
----
-
-### [Curated Lists](/docs/tutorials/curated-lists)
+### [Curated Lists](https://docs.intuition.systems/docs/tutorials/curated-lists)
 
 Create community-curated, ranked lists where stake determines ranking.
 
@@ -37905,9 +36287,7 @@ Create community-curated, ranked lists where stake determines ranking.
 
 **Time:** 2 hours | **Level:** Intermediate
 
----
-
-### [Social Attestations](/docs/tutorials/social-attestations)
+### [Social Attestations](https://docs.intuition.systems/docs/tutorials/social-attestations)
 
 Build a decentralized professional network with portable identity.
 
@@ -37919,9 +36299,7 @@ Build a decentralized professional network with portable identity.
 
 **Time:** 2-3 hours | **Level:** Intermediate
 
----
-
-### [Fraud Detection](/docs/tutorials/fraud-detection)
+### [Fraud Detection](https://docs.intuition.systems/docs/tutorials/fraud-detection)
 
 Create a community-driven scam flagging system.
 
@@ -37933,9 +36311,7 @@ Create a community-driven scam flagging system.
 
 **Time:** 2 hours | **Level:** Advanced
 
----
-
-### [Prediction Market](/docs/tutorials/prediction-market)
+### [Prediction Market](https://docs.intuition.systems/docs/tutorials/prediction-market)
 
 Build a non-resolving forecasting platform.
 
@@ -37947,8 +36323,6 @@ Build a non-resolving forecasting platform.
 
 **Time:** 2 hours | **Level:** Advanced
 
----
-
 ## Data Queries
 
 GraphQL-focused tutorials for querying the knowledge graph (Coming Soon).
@@ -37957,12 +36331,10 @@ GraphQL-focused tutorials for querying the knowledge graph (Coming Soon).
 
 Advanced tutorials coming soon including nested triples, batch operations, and oracle integration.
 
----
-
 ## Need Help?
 
-- [Community Support](/docs/resources/community-and-support)
-- [FAQ](/docs/resources/faq)
+- [Community Support](https://docs.intuition.systems/docs/resources/community-and-support)
+- [FAQ](https://docs.intuition.systems/docs/resources/faq)
 - [Discord](https://discord.gg/RgBenkX4mx)
 
 ## Prerequisites for Tutorials
@@ -37984,16 +36356,11 @@ Before starting these tutorials, make sure you have:
    - Code editor (VS Code recommended)
    - Git for cloning example repos
 
-See [Getting Started](/docs/quick-start/using-the-sdk) for setup instructions.
-
----
-title: "Building a Non-Resolving Prediction Market"
-description: "Create a forecasting platform with track records"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/prediction-market"
----
+See [Getting Started](https://docs.intuition.systems/docs/quick-start/using-the-sdk) for setup instructions.
 
 # Building a Non-Resolving Prediction Market
+
+Source: https://docs.intuition.systems/docs/tutorials/prediction-market
 
 Create a prediction market where forecasts don't need formal resolution. Instead, track record and reputation emerge from the accuracy of past predictions.
 
@@ -39015,9 +37382,9 @@ console.log('Accuracy:', record.accuracy)
 
 Explore more:
 
-1. **[Reputation System](/docs/tutorials/reputation-system)** - Track forecaster expertise
-2. **[Curated Lists](/docs/tutorials/curated-lists)** - Top forecasters
-3. **[Fraud Detection](/docs/tutorials/fraud-detection)** - Verify event outcomes
+1. **[Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)** - Track forecaster expertise
+2. **[Curated Lists](https://docs.intuition.systems/docs/tutorials/curated-lists)** - Top forecasters
+3. **[Fraud Detection](https://docs.intuition.systems/docs/tutorials/fraud-detection)** - Verify event outcomes
 
 ## Example Repository
 
@@ -39027,22 +37394,15 @@ git clone https://github.com/0xIntuition/prediction-market-example
 
 ## Resources
 
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
-- [GraphQL API](/docs/graphql-api/overview)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)
 - [Discord Community](https://discord.gg/RgBenkX4mx)
-
----
 
 Built with Intuition - The Universal Reputation Protocol
 
----
-title: "Building User Activity Feeds"
-description: "Step-by-step guide to create user-specific activity streams"
-last_updated: "2026-01-05T17:16:01-08:00"
-source: "https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds"
----
-
 # Building User Activity Feeds
+
+Source: https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds
 
 Learn how to create personalized, real-time activity feeds that track user interactions across the Intuition ecosystem using the GraphQL API.
 
@@ -39176,14 +37536,9 @@ Learn how to create personalized, real-time activity feeds that track user inter
 
 ];
 
----
-title: "Finding Related Claims"
-description: "A step-by-step guide to discover related triples and relationship patterns"
-last_updated: "2026-06-22T14:26:07-04:00"
-source: "https://docs.intuition.systems/docs/tutorials/queries/finding-related-claims"
----
-
 # Finding Related Claims
+
+Source: https://docs.intuition.systems/docs/tutorials/queries/finding-related-claims
 
 Learn how to find and navigate related claims in the Intuition knowledge graph by exploring triples, their relationships, and semantic connections.
 
@@ -39351,16 +37706,11 @@ Learn how to find and navigate related claims in the Intuition knowledge graph b
 
 ];
 
----
-title: "Finding Top Dapps on Coinbase"
-description: "Step-by-step guide to query and rank top decentralized applications"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/queries/finding-top-dapps-on-coinbase"
----
-
 # Finding Top Dapps on Coinbase
 
-# Finding the Top dApps on Coinbase
+Source: https://docs.intuition.systems/docs/tutorials/queries/finding-top-dapps-on-coinbase
+
+## Finding the Top dApps on Coinbase
 
 **Time to complete:** 30 minutes
 **Difficulty:** Beginner
@@ -39680,26 +38030,21 @@ async function getTrendingDapps(): Promise<DappMetrics[]> {
 
 ## Next Steps
 
-- [Discovering Trusted Accounts](/docs/tutorials/queries/discovering-most-trusted-accounts) - Find reliable users
-- [Building Activity Feeds](/docs/tutorials/queries/building-user-activity-feeds) - Track user actions
-- [Curated Lists Tutorial](/docs/tutorials/curated-lists) - Create ranked registries
+- [Discovering Trusted Accounts](https://docs.intuition.systems/docs/tutorials/queries/discovering-most-trusted-accounts) - Find reliable users
+- [Building Activity Feeds](https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds) - Track user actions
+- [Curated Lists Tutorial](https://docs.intuition.systems/docs/tutorials/curated-lists) - Create ranked registries
 
 ## Resources
 
-- [GraphQL API Reference](/docs/graphql-api/overview)
-- [Schema Explorer](/docs/graphql-api/getting-started/schema-reference)
+- [GraphQL API Reference](https://docs.intuition.systems/docs/graphql-api/overview)
+- [Schema Explorer](https://docs.intuition.systems/docs/graphql-api/getting-started/schema-reference)
 - [GraphQL Playground](https://mainnet.intuition.sh/v1/graphql)
-
----
-title: "Discovering Most Trusted Accounts"
-description: "Find and rank the ecosystem's most trusted accounts based on stake and activity"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/queries/discovering-most-trusted-accounts"
----
 
 # Discovering Most Trusted Accounts
 
-# Discovering the Most Trusted Accounts
+Source: https://docs.intuition.systems/docs/tutorials/queries/discovering-most-trusted-accounts
+
+## Discovering the Most Trusted Accounts
 
 **Time to complete:** 45 minutes
 **Difficulty:** Intermediate
@@ -39922,23 +38267,18 @@ export function TrustedAccountsWidget() {
 
 ## Next Steps
 
-- [Building Activity Feeds](/docs/tutorials/queries/building-user-activity-feeds) - Track user actions
-- [Finding Related Claims](/docs/tutorials/queries/finding-related-claims) - Explore connections
-- [Reputation System Tutorial](/docs/tutorials/reputation-system) - Build reputation scoring
+- [Building Activity Feeds](https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds) - Track user actions
+- [Finding Related Claims](https://docs.intuition.systems/docs/tutorials/queries/finding-related-claims) - Explore connections
+- [Reputation System Tutorial](https://docs.intuition.systems/docs/tutorials/reputation-system) - Build reputation scoring
 
 ## Resources
 
-- [GraphQL API Reference](/docs/graphql-api/overview)
-- [Accounts Schema](/docs/graphql-api/getting-started/schema-reference)
-
----
-title: "Building a Reputation System"
-description: "Build a developer reputation platform with skills, endorsements, and verifiable credentials"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/reputation-system"
----
+- [GraphQL API Reference](https://docs.intuition.systems/docs/graphql-api/overview)
+- [Accounts Schema](https://docs.intuition.systems/docs/graphql-api/getting-started/schema-reference)
 
 # Building a Reputation System
+
+Source: https://docs.intuition.systems/docs/tutorials/reputation-system
 
 Learn how to build a complete reputation system using Intuition's primitives. We'll create a developer reputation platform where users can claim skills, receive endorsements, and build verifiable credentials.
 
@@ -41094,9 +39434,9 @@ Congratulations! You've built a complete reputation system. Here's what to explo
    - Add search functionality
 
 3. **Explore Related Patterns**
-   - [Curated Lists](/docs/tutorials/curated-lists) - Rank items by community stake
-   - [Social Attestations](/docs/tutorials/social-attestations) - Professional networks
-   - [Nested Triples](/docs/tutorials/advanced/nested-triples) - Complex claims
+   - [Curated Lists](https://docs.intuition.systems/docs/tutorials/curated-lists) - Rank items by community stake
+   - [Social Attestations](https://docs.intuition.systems/docs/tutorials/social-attestations) - Professional networks
+   - [Nested Triples](https://docs.intuition.systems/docs/tutorials/advanced/nested-triples) - Complex claims
 
 ## Example Repository
 
@@ -41111,27 +39451,20 @@ npm run dev
 
 ## Resources
 
-- [SDK Overview](/docs/intuition-sdk/quick-start)
-- [GraphQL API Reference](/docs/graphql-api/overview)
-- [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+- [SDK Overview](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
+- [GraphQL API Reference](https://docs.intuition.systems/docs/graphql-api/overview)
+- [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 - [Community Discord](https://discord.gg/RgBenkX4mx)
 
 ## Get Help
 
 Questions? Join our [Discord](https://discord.gg/RgBenkX4mx) or [open an issue](https://github.com/0xIntuition/sdk/issues).
 
----
-
 Built with Intuition - The Universal Reputation Protocol
 
----
-title: "Building a Social Attestation Platform"
-description: "Create a decentralized LinkedIn with portable identity"
-last_updated: "2026-02-19T15:00:01-05:00"
-source: "https://docs.intuition.systems/docs/tutorials/social-attestations"
----
-
 # Building a Social Attestation Platform
+
+Source: https://docs.intuition.systems/docs/tutorials/social-attestations
 
 Build a decentralized professional network where connections, recommendations, and work history are portable across platforms and verifiable on-chain.
 
@@ -42141,9 +40474,9 @@ await platform.recommendSkill('0xBob...', '0xAlice...', 'Solidity', BigInt('1e18
 
 Explore related tutorials:
 
-1. **[Reputation System](/docs/tutorials/reputation-system)** - Deeper skill reputation
-2. **[Fraud Detection](/docs/tutorials/fraud-detection)** - Verify claims
-3. **[Curated Lists](/docs/tutorials/curated-lists)** - Professional registries
+1. **[Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)** - Deeper skill reputation
+2. **[Fraud Detection](https://docs.intuition.systems/docs/tutorials/fraud-detection)** - Verify claims
+3. **[Curated Lists](https://docs.intuition.systems/docs/tutorials/curated-lists)** - Professional registries
 
 ## Example Repository
 
@@ -42153,10 +40486,8 @@ git clone https://github.com/0xIntuition/social-attestations-example
 
 ## Resources
 
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
-- [GraphQL API](/docs/graphql-api/overview)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
+- [GraphQL API](https://docs.intuition.systems/docs/graphql-api/overview)
 - [Discord Community](https://discord.gg/RgBenkX4mx)
-
----
 
 Built with Intuition - The Universal Reputation Protocol

--- a/static/llms-medium.txt
+++ b/static/llms-medium.txt
@@ -33,8 +33,6 @@ source: "https://docs.intuition.systems/docs/experimental-applications/data-popu
 
 # Data Populator (Deprecated)
 
-# Data Populator
-
 The **Intuition Data Populator** is a specialized tool designed to help users and developers efficiently populate the Intuition knowledge graph with high-quality, structured data. This application streamlines the process of creating atoms, triples, and establishing meaningful relationships within the decentralized knowledge network.
 
 ## Why did we create the Data Populator?
@@ -64,13 +62,11 @@ Farcaster Frames provide an interactive way for users to engage with Intuition's
 [... see full docs for complete content]
 
 ---
-title: "MCP Server"
+title: "Intuition MCP Server"
 description: "Documentation for the Intuition MCP Server"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/experimental-applications/mcp-server"
 ---
-
-# MCP Server
 
 # Intuition MCP Server
 
@@ -84,6 +80,7 @@ The Intuition MCP Server acts as a bridge between AI applications and the Intuit
 - **Comprehensive search** for entities (atoms), accounts, and concepts
 - **Social graph exploration** with followers and following relationships
 - **Account information** retrieval with detailed connection data
+- **List management** for curated entity collections
 
 [... see full docs for complete content]
 
@@ -135,13 +132,11 @@ The skills provide verified references so the agent can reason from canonical pr
 [... see full docs for complete content]
 
 ---
-title: "Architecture"
+title: "Technical Architecture"
 description: "Technical architecture of Intuition's three-layer system - Network, Protocol, and Subnet"
 last_updated: "2026-02-19T15:00:01-05:00"
 source: "https://docs.intuition.systems/docs/getting-started/architecture"
 ---
-
-# Architecture
 
 # Technical Architecture
 
@@ -149,13 +144,15 @@ Intuition's architecture consists of three tightly integrated layers that work t
 
 ## Architecture Overview
 
-![Intuition System Overview](/img/intuition-intro.png)
+![Intuition System Overview](https://docs.intuition.systems/img/intuition-intro.png)
 
 Intuition's architecture is designed for **speed**, **scale**, and **interoperability**. By separating concerns across three specialized layers, we achieve optimal performance while maintaining decentralization and cross-chain compatibility.
 
 ## Layer 1: Intuition Network (Base L3)
 
 ### Overview
+
+The Intuition Network is an **EVM-compatible Layer 3** built on Base using the Orbit stack. This provides the ultra-fast, low-cost transaction environment essential for high-frequency knowledge graph operations.
 
 [... see full docs for complete content]
 
@@ -179,7 +176,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Best for: Web apps, dashboards, social platforms
 - Abstracts complexity
 - React integration ready
-- **Start here:** [SDK Quick Start](/docs/intuition-sdk/quick-start)
+- **Start here:** [SDK Quick Start](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ### Query Data Only (No Writes)
 
@@ -188,7 +185,7 @@ Not sure where to start? Pick the path that matches your goal.
 - Best for: Analytics, dashboards, data visualization
 - No wallet needed for reads
 - Powerful filtering and aggregation
-- **Start here:** [GraphQL Setup](/docs/graphql-api/getting-started/client-setup)
+- **Start here:** [GraphQL Setup](https://docs.intuition.systems/docs/graphql-api/getting-started/client-setup)
 
 ### Build Smart Contract Integration
 
@@ -209,8 +206,8 @@ Use these official resources when you want to learn the protocol, start from a w
 
 | Resource | Use When | Link |
 | --- | --- | --- |
-| Learn Intuition | You want a guided course through atoms, triples, signals, reads, writes, and app building. | [Learn Intuition](/docs/getting-started/learn-intuition) |
-| Templates | You want to fork a working Intuition app instead of starting from a blank repository. | [Templates](/docs/getting-started/templates) |
+| Learn Intuition | You want a guided course through atoms, triples, signals, reads, writes, and app building. | [Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition) |
+| Templates | You want to fork a working Intuition app instead of starting from a blank repository. | [Templates](https://docs.intuition.systems/docs/getting-started/templates) |
 
 [... see full docs for complete content]
 
@@ -223,7 +220,7 @@ source: "https://docs.intuition.systems/docs/getting-started/developer-stack"
 
 # Developer Stack
 
-# Developer Tools
+## Developer Tools
 
 Choose the right tool for your use case.
 
@@ -240,7 +237,7 @@ Interactive course that teaches atoms, triples, signals, protocol reads, protoco
 - You are onboarding yourself or an AI-assisted workflow.
 - You want a course that ends with a template-based capstone.
 
-**[Learn Intuition](/docs/getting-started/learn-intuition)**
+**[Learn Intuition](https://docs.intuition.systems/docs/getting-started/learn-intuition)**
 
 ### Templates
 
@@ -261,9 +258,9 @@ Intuition integrates with various platforms and tools to extend its capabilities
 
 Use Intuition's knowledge graph with AI systems and agents to create persistent, verifiable memory and context.
 
-- **[AI Skills](/docs/getting-started/ai-skills)** - Agent-facing protocol context for Claude Code, Codex, and compatible AI coding agents.
-- **[MCP Server](/docs/experimental-applications/mcp-server)** - Model Context Protocol tools for querying atoms, accounts, lists, and graph data.
-- **[Templates](/docs/getting-started/templates)** - Agent-ready starter apps with file maps, protocol paths, and `.agents/INSTRUCTIONS.md` guidance.
+- **[AI Skills](https://docs.intuition.systems/docs/getting-started/ai-skills)** - Agent-facing protocol context for Claude Code, Codex, and compatible AI coding agents.
+- **[MCP Server](https://docs.intuition.systems/docs/experimental-applications/mcp-server)** - Model Context Protocol tools for querying atoms, accounts, lists, and graph data.
+- **[Templates](https://docs.intuition.systems/docs/getting-started/templates)** - Agent-ready starter apps with file maps, protocol paths, and `.agents/INSTRUCTIONS.md` guidance.
 
 **Use cases:**
 - **AI agents with persistent memory** - Store and retrieve agent knowledge on-chain
@@ -308,8 +305,6 @@ Instead of information living as unstructured, siloed, minimally-attributable da
 
 The result is a Semantic Web of Trust, powered the world's first token-curated knowledge graph — a network where information isn't just stored, but structured, incentivized, and made usable for developers and AI systems alike — all while maintaining verifiable provenance and attribution.
 
----
-
 [... see full docs for complete content]
 
 ---
@@ -343,7 +338,7 @@ source: "https://docs.intuition.systems/docs/getting-started/use-cases"
 
 # Use Cases
 
-![Use Cases](/img/use-cases.png)
+![Use Cases](https://docs.intuition.systems/img/use-cases.png)
 
 This article outlines use cases that take advantage of Intuition's unique knowledge graph and claim infrastructure. There are many more ways to use Intuition (and we would love to see what you come up with!), but here are some ideas to get you started.
 
@@ -711,13 +706,11 @@ Query triples with Hasura's `where` filtering:
 [... see full docs for complete content]
 
 ---
-title: "Activity Feed"
+title: "Example: Activity Feed"
 description: "Build real-time activity feed"
 last_updated: "2026-02-28T21:52:51-05:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/activity-feed"
 ---
-
-# Activity Feed
 
 # Example: Activity Feed
 
@@ -756,13 +749,11 @@ Build an activity feed showing recent protocol activity.
 ];
 
 ---
-title: "Atom with Vault"
+title: "Example: Atom with Vault"
 description: "Fetch atom details with vault statistics"
 last_updated: "2026-06-22T14:26:07-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/atom-with-vault"
 ---
-
-# Atom with Vault
 
 # Example: Atom with Vault
 
@@ -806,13 +797,11 @@ Display atom information with market data on a detail page.
 ## Implementation
 
 ---
-title: "Complex Filtering"
+title: "Example: Complex Filtering"
 description: "Multi-criteria search and filtering"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/complex-filtering"
 ---
-
-# Complex Filtering
 
 # Example: Complex Filtering
 
@@ -871,13 +860,11 @@ Use the Intuition GraphQL API across different programming languages.
 ## Rust
 
 ---
-title: "Price History"
+title: "Example: Price History"
 description: "Analyze price trends over time"
 last_updated: "2026-06-22T14:26:07-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/price-history"
 ---
-
-# Price History
 
 # Example: Price History
 
@@ -911,13 +898,11 @@ Analyze share price trends using time-series data.
 ];
 
 ---
-title: "Social Graph"
+title: "Example: Social Graph"
 description: "Build social feed from followed accounts"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/social-graph"
 ---
-
-# Social Graph
 
 # Example: Social Graph
 
@@ -958,13 +943,11 @@ Build a social activity feed from followed accounts.
 ];
 
 ---
-title: "Real-Time Subscriptions"
+title: "Example: Real-Time Subscriptions"
 description: "Implement real-time updates with subscriptions"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/subscriptions"
 ---
-
-# Real-Time Subscriptions
 
 # Example: Real-Time Subscriptions
 
@@ -1007,13 +990,11 @@ Implement real-time position monitoring with subscriptions.
 ## Implementation
 
 ---
-title: "Trending Atoms"
+title: "Example: Trending Atoms"
 description: "Find top atoms by market cap and activity"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/trending-atoms"
 ---
-
-# Trending Atoms
 
 # Example: Trending Atoms
 
@@ -1048,13 +1029,11 @@ Find top atoms ranked by vault market cap.
 ];
 
 ---
-title: "Triples Pagination"
+title: "Example: Triples Pagination"
 description: "Paginate through triples with total count"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/triples-pagination"
 ---
-
-# Triples Pagination
 
 # Example: Triples Pagination
 
@@ -1088,13 +1067,11 @@ Paginate through triples with total count for UI.
 ];
 
 ---
-title: "User Positions"
+title: "Example: User Positions"
 description: "Fetch all positions for a user with aggregates"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/examples/user-positions"
 ---
-
-# User Positions
 
 # Example: User Positions
 
@@ -1193,13 +1170,11 @@ Simple and lightweight GraphQL client:
 [... see full docs for complete content]
 
 ---
-title: "Introduction"
+title: "GraphQL API Introduction"
 description: "Introduction to the Intuition GraphQL API and its capabilities"
 last_updated: "2026-06-25T17:11:24-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/getting-started/introduction"
 ---
-
-# Introduction
 
 # GraphQL API Introduction
 
@@ -1294,7 +1269,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/migration-guide"
 
 # Migration Guide
 
-# Migrating GraphQL from v1.5 to v2.0
+## Migrating GraphQL from v1.5 to v2.0
 
 ## Overview
 
@@ -1335,8 +1310,8 @@ Image and JSON upload mutations use the public gated pinning endpoint, `https://
 
 | Operation                                       | Description                           |
 | ----------------------------------------------- | ------------------------------------- |
-| [`uploadImage`](./upload-image)                 | Upload a base64-encoded image to IPFS |
-| [`uploadImageFromUrl`](./upload-image-from-url) | Upload an image from a URL to IPFS    |
+| [`uploadImage`](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image)                 | Upload a base64-encoded image to IPFS |
+| [`uploadImageFromUrl`](https://docs.intuition.systems/docs/graphql-api/mutations/images/upload-image-from-url) | Upload an image from a URL to IPFS    |
 
 [... see full docs for complete content]
 
@@ -1427,13 +1402,11 @@ Use the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, with 
 [... see full docs for complete content]
 
 ---
-title: "Pin Organization"
+title: "Pin Organization Mutation"
 description: "Pin Organization metadata to IPFS"
 last_updated: "2026-06-25T17:24:12-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/mutations/pin-organization"
 ---
-
-# Pin Organization
 
 # Pin Organization Mutation
 
@@ -1459,13 +1432,11 @@ Create an authenticated client before sending the mutation:
 4. **Include contact email** if available
 
 ---
-title: "Pin Person"
+title: "Pin Person Mutation"
 description: "Pin Person metadata to IPFS"
 last_updated: "2026-06-25T17:24:12-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/mutations/pin-person"
 ---
-
-# Pin Person
 
 # Pin Person Mutation
 
@@ -1491,13 +1462,11 @@ Create an authenticated client before sending the mutation:
 4. **Use person-specific fields** for rich metadata
 
 ---
-title: "Pin Thing"
+title: "Pin Thing Mutation"
 description: "Pin Thing metadata to IPFS"
 last_updated: "2026-06-25T17:24:12-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/mutations/pin-thing"
 ---
-
-# Pin Thing
 
 # Pin Thing Mutation
 
@@ -1522,6 +1491,7 @@ Create an authenticated client before sending the mutation:
 1. **Pin metadata** using `pinThing` mutation
 2. **Get IPFS URI** from response
 3. **Create atom on-chain** using the URI
+4. **Query the atom** via GraphQL API
 
 [... see full docs for complete content]
 
@@ -1563,13 +1533,11 @@ Configure the GraphQL client at the root of your application:
 [... see full docs for complete content]
 
 ---
-title: "Overview"
+title: "GraphQL API Overview"
 description: "Introduction to the Intuition GraphQL API and its main features"
 last_updated: "2026-02-11T14:23:51-05:00"
 source: "https://docs.intuition.systems/docs/graphql-api/overview"
 ---
-
-# Overview
 
 # GraphQL API Overview
 
@@ -1577,31 +1545,13 @@ Intuition provides GraphQL APIs for querying its knowledge graph in a convenient
 
 **Available endpoints**
 
-    <h3>
-      Intuition mainnet
-    </h3>
+### Intuition mainnet
 
-      ```text
-      https://mainnet.intuition.sh/v1/graphql
-      ```
+      [Try on GraphQL Explorer](https://studio.apollographql.com/sandbox/explorer?endpoint=https://mainnet.intuition.sh/v1/graphql)
 
-        target="_blank"
-        rel="noreferrer"
+### Intuition testnet
 
-        Try on GraphQL Explorer
-
-    <h3>
-      Intuition testnet
-    </h3>
-
-      ```text
-      https://testnet.intuition.sh/v1/graphql
-      ```
-
-        target="_blank"
-        rel="noreferrer"
-
-        Try on GraphQL Explorer
+      [Try on GraphQL Explorer](https://studio.apollographql.com/sandbox/explorer?endpoint=https://testnet.intuition.sh/v1/graphql)
 
 Alternatively, you can import these URLs from the GraphQL package:
 
@@ -1609,9 +1559,9 @@ If this is your first time using GraphQL, you can learn more at [graphql.org](ht
 
 There are a few ways to get started with this GraphQL API, depending on the level of abstraction and customization you require : 
 
-    <h3>
-      SDK
-    </h3>
+  [SDK Integrate with Intuition smart contracts using our TypeScript SDK.](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
+
+  [Custom Queries Create bespoke GraphQL queries for your specific use case.](https://docs.intuition.systems/docs/graphql-api/custom-queries)
 
 [... see full docs for complete content]
 
@@ -1626,7 +1576,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/follow
 
 Query the social graph to find who an account follows and who follows them.
 
-## Query Structure
+## Following Query - Query Structure
 
 ## Variables
 
@@ -1653,8 +1603,6 @@ Query the social graph to find who an account follows and who follows them.
     label
     image
 
-  following_aggregate(where: { follower_id: { _eq: $account_id } }) {
-
 [... see full docs for complete content]
 
 ---
@@ -1668,7 +1616,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-a
 
 Query multiple accounts with filtering, sorting, and pagination.
 
-## Query Structure
+## List Accounts - Query Structure
 
 ## Variables
 
@@ -1700,8 +1648,6 @@ Query multiple accounts with filtering, sorting, and pagination.
 
     id: 'atom-wallets',
     title: 'Accounts with Linked Atoms',
-    query: `query GetAtomWallets($limit: Int!) {
-  accounts(
 
 [... see full docs for complete content]
 
@@ -1720,10 +1666,10 @@ Query account information including profile data, social relationships (followin
 
 | Query | Description |
 |-------|-------------|
-| [`account`](./single-account) | Query a single account by address |
-| [`accounts`](./list-accounts) | Query multiple accounts with filtering |
-| [`following`](./following) | Query following relationships |
-| [`positions_from_following`](./positions-from-following) | Query positions from followed accounts |
+| [`account`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/single-account) | Query a single account by address |
+| [`accounts`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/list-accounts) | Query multiple accounts with filtering |
+| [`following`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) | Query following relationships |
+| [`positions_from_following`](https://docs.intuition.systems/docs/graphql-api/queries/accounts/positions-from-following) | Query positions from followed accounts |
 
 ## What Are Accounts?
 
@@ -1746,7 +1692,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/positi
 
 Query positions (stakes) held by accounts that a user follows. This enables building social portfolio views and discovering popular investments within your network.
 
-## Query Structure
+## Positions from Following - Query Structure
 
 ## Variables
 
@@ -1765,7 +1711,6 @@ Query positions (stakes) held by accounts that a user follows. This enables buil
 ## Interactive Example
 
     id: 'following-positions',
-    title: 'Positions from Following',
 
 [... see full docs for complete content]
 
@@ -1780,7 +1725,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/accounts/single
 
 Fetch detailed information about a specific account using its Ethereum address.
 
-## Query Structure
+## Single Account Query - Query Structure
 
 ## Variables
 
@@ -1799,8 +1744,6 @@ Fetch detailed information about a specific account using its Ethereum address.
 
 ## Interactive Example
 
-    id: 'basic-account',
-
 [... see full docs for complete content]
 
 ---
@@ -1814,7 +1757,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/aggreg
 
 Compute statistical aggregations without fetching all nodes.
 
-## Query Structure
+## Aggregations - Query Structure
 
 ## Available Functions
 
@@ -1883,7 +1826,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/pagina
 
 Implement efficient offset-based pagination with total counts.
 
-## Query Structure
+## Pagination - Query Structure
 
 ## Variables
 
@@ -1907,7 +1850,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/advanced/predic
 
 Use the denormalized `predicate_objects` table for efficient collection queries.
 
-## Query Structure
+## Predicate-Object Aggregations - Query Structure
 
 ## Best Practices
 
@@ -1954,7 +1897,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/list-filt
 
 Query multiple atoms with filtering, sorting, and pagination to find specific entities in the knowledge graph.
 
-## Query Structure
+## List and Filter Atoms - Query Structure
 
 ## Variables
 
@@ -1987,9 +1930,6 @@ Query multiple atoms with filtering, sorting, and pagination to find specific en
   atoms(
     where: { creator_id: { _eq: $creatorId } }
     order_by: { created_at: desc }
-    limit: $limit
-  ) {
-    term_id
 
 [... see full docs for complete content]
 
@@ -2004,7 +1944,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/search"
 
 Search atoms using pattern matching and full-text query patterns.
 
-## Query Structure
+## Atom Search - Query Structure
 
 ### Pattern Matching Search
 
@@ -2064,7 +2004,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/single-at
 
 Fetch detailed information about a specific atom using its term ID. This is the most efficient way to retrieve atom data using a primary key lookup.
 
-## Query Structure
+## Single Atom Query - Query Structure
 
 ## Variables
 
@@ -2109,10 +2049,6 @@ Fetch detailed information about a specific atom using its term ID. This is the 
     created_at
     transaction_hash
     creator {
-      id
-      label
-      image
-      type
 
 [... see full docs for complete content]
 
@@ -2127,7 +2063,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-trip
 
 Discover relationships by finding all triples where an atom appears as subject, predicate, or object.
 
-## Query Structure
+## Atom with Related Triples - Query Structure
 
 ## Interactive Examples
 
@@ -2157,8 +2093,6 @@ Discover relationships by finding all triples where an atom appears as subject, 
 
     id: 'filtered-relationships',
     title: 'Filter by Predicate',
-    query: `query GetSpecificRelationships(
-  $atomId: String!
 
 [... see full docs for complete content]
 
@@ -2173,7 +2107,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/atoms/with-vaul
 
 Fetch atom data along with associated vault statistics, including total shares, current share price, market cap, and position count.
 
-## Query Structure
+## Atom with Vault Details - Query Structure
 
 ## Variables
 
@@ -2221,7 +2155,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-js
 
 Retrieve chart data in structured JSON format for use with charting libraries.
 
-## Query Structure
+## Get Chart JSON - Query Structure
 
 ## Variables
 
@@ -2247,11 +2181,11 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-ra
 
 Retrieve raw chart data in JSON format. Uses the same input and output types as `getChartJson`.
 
-## Query Structure
+## Get Chart Raw JSON - Query Structure
 
 ## Variables
 
-Same as [`getChartJson`](./chart-json) -- takes `GetChartJsonInput`:
+Same as [`getChartJson`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) -- takes `GetChartJsonInput`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -2273,11 +2207,11 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-ra
 
 Retrieve a minimal SVG chart, suitable for custom post-processing or styling. Uses the same input type as `getChartSvg`.
 
-## Query Structure
+## Get Chart Raw SVG - Query Structure
 
 ## Variables
 
-Same as [`getChartSvg`](./chart-svg) -- takes `GetChartSvgInput`:
+Same as [`getChartSvg`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) -- takes `GetChartSvgInput`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -2299,7 +2233,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-sv
 
 Retrieve a pre-rendered chart as an SVG image, ready for embedding in HTML or documents.
 
-## Query Structure
+## Get Chart SVG - Query Structure
 
 ## Variables
 
@@ -2329,10 +2263,10 @@ The Intuition GraphQL API provides chart generation operations to create visuali
 
 | Operation | Description |
 |-----------|-------------|
-| [`getChartJson`](./chart-json) | Get chart data as structured JSON |
-| [`getChartRawJson`](./chart-raw-json) | Get raw chart JSON data |
-| [`getChartSvg`](./chart-svg) | Get chart rendered as SVG |
-| [`getChartRawSvg`](./chart-raw-svg) | Get raw SVG chart data |
+| [`getChartJson`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-json) | Get chart data as structured JSON |
+| [`getChartRawJson`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-json) | Get raw chart JSON data |
+| [`getChartSvg`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-svg) | Get chart rendered as SVG |
+| [`getChartRawSvg`](https://docs.intuition.systems/docs/graphql-api/queries/charts/chart-raw-svg) | Get raw SVG chart data |
 
 ## Use Cases
 
@@ -2355,7 +2289,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/events/aggregat
 
 Query aggregate statistics for blockchain events.
 
-## Query Structure
+## Aggregate Events - Query Structure
 
 ## Variables
 
@@ -2367,8 +2301,8 @@ Query aggregate statistics for blockchain events.
 
 ## Related
 
-- [List Events](./list-events) - Individual events
-- [Protocol Stats](/docs/graphql-api/queries/stats/protocol-stats) - Higher-level statistics
+- [List Events](https://docs.intuition.systems/docs/graphql-api/queries/events/list-events) - Individual events
+- [Protocol Stats](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) - Higher-level statistics
 
 ---
 title: "List Events"
@@ -2381,7 +2315,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/events/list-eve
 
 Query raw blockchain events with filtering, sorting, and pagination.
 
-## Query Structure
+## List Events - Query Structure
 
 ## Variables
 
@@ -2419,8 +2353,8 @@ Query raw blockchain events emitted by the Intuition protocol contracts. Events 
 
 | Query | Description |
 |-------|-------------|
-| [`events`](./list-events) | Query events with filtering and pagination |
-| [`events_aggregate`](./aggregate-events) | Aggregate statistics for events |
+| [`events`](https://docs.intuition.systems/docs/graphql-api/queries/events/list-events) | Query events with filtering and pagination |
+| [`events_aggregate`](https://docs.intuition.systems/docs/graphql-api/queries/events/aggregate-events) | Aggregate statistics for events |
 
 ## What Are Events?
 
@@ -2451,7 +2385,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/acc
 
 Look up a single account's leaderboard rank and percentile using `get_account_pnl_rank`. Returns `account_pnl_rank` rows.
 
-## Query Structure
+## Account PnL Rank - Query Structure
 
 ## Function Arguments
 
@@ -2467,7 +2401,6 @@ Look up a single account's leaderboard rank and percentile using `get_account_pn
 | Field | Type | Description |
 |-------|------|-------------|
 | `account_id` | `String` | Account address |
-| `account_label` | `String` | Display name |
 
 [... see full docs for complete content]
 
@@ -2482,7 +2415,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/lea
 
 Get aggregate protocol-level statistics using `get_pnl_leaderboard_stats`. Returns `pnl_leaderboard_stats` rows with metrics like total traders, average PnL, and profitability rates.
 
-## Query Structure
+## Leaderboard Stats - Query Structure
 
 ## Function Arguments
 
@@ -2509,8 +2442,6 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/ove
 
 # Leaderboard Queries Overview
 
-# Leaderboard Queries
-
 The Intuition GraphQL API provides leaderboard queries for ranking accounts and vaults by PnL performance. These are exposed as Hasura SQL functions that return `pnl_leaderboard_entry` rows.
 
 ## Available Leaderboard Operations
@@ -2519,15 +2450,17 @@ The Intuition GraphQL API provides leaderboard queries for ranking accounts and 
 
 | Operation | Description |
 |-----------|-------------|
-| [`get_pnl_leaderboard`](./pnl-leaderboard) | Full PnL leaderboard with filtering and sorting |
-| [`get_pnl_leaderboard_period`](./pnl-leaderboard#period-scoped) | Period-scoped PnL leaderboard with date range |
+| [`get_pnl_leaderboard`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard) | Full PnL leaderboard with filtering and sorting |
+| [`get_pnl_leaderboard_period`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard#period-scoped) | Period-scoped PnL leaderboard with date range |
 
 ### Vault Leaderboard
 
 | Operation | Description |
 |-----------|-------------|
-| [`get_vault_leaderboard`](./vault-leaderboard) | Vault-level leaderboard filtered by term and curve |
-| [`get_pnl_leaderboard_period`](./vault-leaderboard#period-scoped) | Period-scoped leaderboard with date range (use `p_term_id`/`p_curve_id` for vault scoping) |
+| [`get_vault_leaderboard`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard) | Vault-level leaderboard filtered by term and curve |
+| [`get_pnl_leaderboard_period`](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vault-leaderboard#period-scoped) | Period-scoped leaderboard with date range (use `p_term_id`/`p_curve_id` for vault scoping) |
+
+### Account Rank & Stats
 
 [... see full docs for complete content]
 
@@ -2542,7 +2475,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl
 
 Rank accounts by PnL performance using `get_pnl_leaderboard` and `get_pnl_leaderboard_period`. Both return `pnl_leaderboard_entry` rows.
 
-## Query Structure
+## PnL Leaderboard - Query Structure
 
 ## Function Arguments
 
@@ -2566,9 +2499,9 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/vau
 
 # Vault Leaderboard
 
-Rank accounts within specific vaults using `get_vault_leaderboard` and `get_pnl_leaderboard_period`. Both return `pnl_leaderboard_entry` rows (same schema as the [PnL Leaderboard](./pnl-leaderboard)).
+Rank accounts within specific vaults using `get_vault_leaderboard` and `get_pnl_leaderboard_period`. Both return `pnl_leaderboard_entry` rows (same schema as the [PnL Leaderboard](https://docs.intuition.systems/docs/graphql-api/queries/leaderboard/pnl-leaderboard)).
 
-## Query Structure
+## Vault Leaderboard - Query Structure
 
 ## Function Arguments
 
@@ -2579,7 +2512,6 @@ Rank accounts within specific vaults using `get_vault_leaderboard` and `get_pnl_
 | `p_limit` | `Int` | Number of results to return |
 | `p_offset` | `Int` | Offset for pagination |
 | `p_sort_by` | `String` | Field to sort by |
-| `p_sort_order` | `String` | Sort direction: `"asc"` or `"desc"` |
 
 [... see full docs for complete content]
 
@@ -2594,7 +2526,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl
 
 Get historical Profit and Loss (PnL) time-series data for an account, suitable for charting portfolio performance over configurable intervals.
 
-## Query Structure
+## Account PnL Chart - Query Structure
 
 ## Variables
 
@@ -2619,7 +2551,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl
 
 Get the current Profit and Loss (PnL) snapshot for an account, including equity value, net invested amount, and unrealized gains.
 
-## Query Structure
+## Account PnL Current - Query Structure
 
 ## Variables
 
@@ -2649,7 +2581,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl
 
 Get realized Profit and Loss (PnL) data for an account over a specified time range.
 
-## Query Structure
+## Account PnL Realized - Query Structure
 
 ## Variables
 
@@ -2677,7 +2609,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/overview"
 
 # PnL Queries Overview
 
-# Profit & Loss (PnL) Queries
+## Profit & Loss (PnL) Queries
 
 The Intuition GraphQL API provides Profit and Loss (PnL) queries to track portfolio performance, analyze realized gains, and visualize value changes over time. These queries are powered by the chart-api service and exposed through Hasura as GraphQL actions.
 
@@ -2685,9 +2617,9 @@ The Intuition GraphQL API provides Profit and Loss (PnL) queries to track portfo
 
 | Operation | Description |
 |-----------|-------------|
-| [`getAccountPnlCurrent`](./account-pnl-current) | Current account PnL snapshot with equity value, net invested, and unrealized gains |
-| [`getAccountPnlChart`](./account-pnl-chart) | Account PnL time-series data with configurable intervals |
-| [`getAccountPnlRealized`](./account-pnl-realized) | Realized PnL data for an account over a time range |
+| [`getAccountPnlCurrent`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-current) | Current account PnL snapshot with equity value, net invested, and unrealized gains |
+| [`getAccountPnlChart`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-chart) | Account PnL time-series data with configurable intervals |
+| [`getAccountPnlRealized`](https://docs.intuition.systems/docs/graphql-api/queries/pnl/account-pnl-realized) | Realized PnL data for an account over a time range |
 
 [... see full docs for complete content]
 
@@ -2702,7 +2634,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/pnl/position-pn
 
 Get historical Profit and Loss (PnL) time-series data for a specific position, identified by account, term, and curve.
 
-## Query Structure
+## Position PnL Chart - Query Structure
 
 ## Variables
 
@@ -2731,9 +2663,9 @@ Search the Intuition knowledge graph for atoms, terms, and positions using text-
 
 | Query | Description |
 |-------|-------------|
-| [`search_term`](./search-term) | Search atoms and terms by text |
-| [`search_term_from_following`](./search-from-following) | Search within followed accounts' activity |
-| [`search_positions_on_subject`](./search-positions) | Find positions related to a subject |
+| [`search_term`](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) | Search atoms and terms by text |
+| [`search_term_from_following`](https://docs.intuition.systems/docs/graphql-api/queries/search/search-from-following) | Search within followed accounts' activity |
+| [`search_positions_on_subject`](https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions) | Find positions related to a subject |
 
 ## Quick Start
 
@@ -2746,7 +2678,7 @@ Search the Intuition knowledge graph for atoms, terms, and positions using text-
 
 ## Related Documentation
 
-- [Search Term](./search-term) - Basic search
+- [Search Term](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) - Basic search
 
 [... see full docs for complete content]
 
@@ -2761,7 +2693,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/search/search-f
 
 Search for terms within the context of accounts you follow, prioritizing results from your social network.
 
-## Query Structure
+## Search from Following - Query Structure
 
 ## Variables
 
@@ -2781,23 +2713,21 @@ Search prioritizing content from your network:
 
 ## Related
 
-- [Search Term](./search-term) - Global search
-- [Following](/docs/graphql-api/queries/accounts/following) - Following relationships
+- [Search Term](https://docs.intuition.systems/docs/graphql-api/queries/search/search-term) - Global search
+- [Following](https://docs.intuition.systems/docs/graphql-api/queries/accounts/following) - Following relationships
 
 ---
-title: "Search Positions"
+title: "Search Positions on Subject"
 description: "Search positions on a specific subject"
 last_updated: "2026-04-01T11:08:48-04:00"
 source: "https://docs.intuition.systems/docs/graphql-api/queries/search/search-positions"
 ---
 
-# Search Positions
-
 # Search Positions on Subject
 
 Search for positions (stakes) related to a specific subject. This function takes an array of addresses and a JSONB search fields object to filter positions.
 
-## Query Structure
+## Search Positions on Subject - Query Structure
 
 ## Variables
 
@@ -2820,7 +2750,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/search/search-t
 
 Search for atoms by their label or data content.
 
-## Query Structure
+## Search Term - Query Structure
 
 ## Variables
 
@@ -2851,7 +2781,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/aggrega
 
 Query aggregate statistics for signals including counts, sums, and averages.
 
-## Query Structure
+## Aggregate Signals - Query Structure
 
 ## Variables
 
@@ -2872,7 +2802,6 @@ Query aggregate statistics for signals including counts, sums, and averages.
 ## Interactive Example
 
     id: 'total-stats',
-    title: 'Total Signal Statistics',
 
 [... see full docs for complete content]
 
@@ -2887,7 +2816,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/list-si
 
 Query deposit and redemption signals with rich filtering, sorting, and pagination capabilities.
 
-## Query Structure
+## List Signals - Query Structure
 
 ## Variables
 
@@ -2923,9 +2852,9 @@ Signals represent deposit and redemption events in the Intuition protocol. Unlik
 
 | Query | Description |
 |-------|-------------|
-| [`signals`](./list-signals) | Query signals with filtering and pagination |
-| [`signals_aggregate`](./aggregate-signals) | Aggregate statistics for signals |
-| [`signals_from_following`](./signals-from-following) | Query signals from followed accounts |
+| [`signals`](https://docs.intuition.systems/docs/graphql-api/queries/signals/list-signals) | Query signals with filtering and pagination |
+| [`signals_aggregate`](https://docs.intuition.systems/docs/graphql-api/queries/signals/aggregate-signals) | Aggregate statistics for signals |
+| [`signals_from_following`](https://docs.intuition.systems/docs/graphql-api/queries/signals/signals-from-following) | Query signals from followed accounts |
 
 ## What Are Signals?
 
@@ -2949,7 +2878,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/signals/signals
 
 Query signals (deposits and redemptions) from accounts that a specific user follows. This enables building personalized social activity feeds.
 
-## Query Structure
+## Signals from Following - Query Structure
 
 ## Variables
 
@@ -2964,7 +2893,6 @@ Query signals (deposits and redemptions) from accounts that a specific user foll
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | `String` | Signal identifier |
 
 [... see full docs for complete content]
 
@@ -2979,7 +2907,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accru
 
 Query protocol fee accrual records. Fee accruals track protocol fees accumulated per epoch, including the sender and transaction details.
 
-## Query Structure
+## Fee Accruals - Query Structure
 
 ## Response Fields
 
@@ -3004,7 +2932,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-trans
 
 Query protocol fee transfers - the fees collected by the protocol on each transaction.
 
-## Query Structure
+## Fee Transfers - Query Structure
 
 ## Variables
 
@@ -3037,9 +2965,9 @@ Query protocol-wide statistics including total value locked (TVL), fee transfers
 
 | Query | Description |
 |-------|-------------|
-| [`stats`](./protocol-stats) | Protocol-wide statistics and metrics |
-| [`fee_transfers`](./fee-transfers) | Protocol fee transfer events |
-| [`protocol_fee_accruals`](./fee-accruals) | Protocol fee accruals by epoch |
+| [`stats`](https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-stats) | Protocol-wide statistics and metrics |
+| [`fee_transfers`](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-transfers) | Protocol fee transfer events |
+| [`protocol_fee_accruals`](https://docs.intuition.systems/docs/graphql-api/queries/stats/fee-accruals) | Protocol fee accruals by epoch |
 
 ## Quick Start
 
@@ -3066,7 +2994,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/stats/protocol-
 
 Query aggregate statistics for the entire Intuition protocol.
 
-## Query Structure
+## Protocol Statistics - Query Structure
 
 ## Response Fields
 
@@ -3093,7 +3021,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/counter
 
 Query triples along with their counter (opposing) triples to see both sides of a claim.
 
-## Query Structure
+## Counter Triples - Query Structure
 
 ## Interactive Example
 
@@ -3142,7 +3070,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-
 
 Use the denormalized `predicate_objects` table to efficiently query pre-aggregated collections.
 
-## Query Structure
+## Filter by Predicate-Object - Query Structure
 
 ## Interactive Example
 
@@ -3170,7 +3098,8 @@ Use the denormalized `predicate_objects` table to efficiently query pre-aggregat
 1. **Use for aggregations** instead of manually counting triples
 2. **Order by triple_count** for popular collections
 3. **Filter by predicate** to find specific relationship types
-4. **More efficient** than aggregating raw triples
+
+[... see full docs for complete content]
 
 ---
 title: "Filter Triples by Subject"
@@ -3183,7 +3112,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/filter-
 
 Query all triples where a specific atom is the subject.
 
-## Query Structure
+## Filter Triples by Subject - Query Structure
 
 ## Interactive Example
 
@@ -3212,7 +3141,8 @@ Query all triples where a specific atom is the subject.
 1. **Use indexed subject_id field** for performance
 2. **Order by created_at** for chronological results
 3. **Include limit** to prevent over-fetching
-4. **Filter by predicate** to narrow relationship types
+
+[... see full docs for complete content]
 
 ---
 title: "Nested Triple Queries"
@@ -3225,7 +3155,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/nested-
 
 Query triples with nested relationships to explore the knowledge graph.
 
-## Query Structure
+## Nested Triple Queries - Query Structure
 
 ## Best Practices
 
@@ -3245,7 +3175,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/single-
 
 Fetch detailed information about a specific triple using its term ID.
 
-## Query Structure
+## Single Triple Query - Query Structure
 
 ## Interactive Example
 
@@ -3274,10 +3204,6 @@ Fetch detailed information about a specific triple using its term ID.
     predicate { label }
     object { label }
     term {
-      vaults(where: { curve_id: { _eq: $curveId } }) {
-        total_shares
-        market_cap
-        position_count
 
 [... see full docs for complete content]
 
@@ -3292,7 +3218,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/subject
 
 Query aggregated subject-predicate pairs across the knowledge graph. Each record represents a unique (subject, predicate) combination with aggregate stats across all triples sharing that pair.
 
-## Query Structure
+## Subject Predicates - Query Structure
 
 ## Response Fields
 
@@ -3316,7 +3242,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-
 
 Query the `triple_term` view to get aggregate statistics for triple-term pairs. Each record links a triple's term to its counter-term with position and market cap data.
 
-## Query Structure
+## Triple Terms - Query Structure
 
 ## Response Fields
 
@@ -3341,7 +3267,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/triples/triple-
 
 Query the `triple_vault` view to get vault-level data for triples, including market cap, position counts, shares, and asset totals per curve.
 
-## Query Structure
+## Triple Vaults - Query Structure
 
 ## Response Fields
 
@@ -3366,7 +3292,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/deposits
 
 Query transaction history for deposits and redemptions.
 
-## Query Structure
+## Deposits & Redemptions - Query Structure
 
 ## Best Practices
 
@@ -3388,7 +3314,7 @@ Track individual position changes and view pre-aggregated daily/hourly summaries
 
 ## Individual Changes
 
-### Query Structure
+### Individual Changes - Query Structure
 
 ### Response Fields (`position_changes`)
 
@@ -3413,7 +3339,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/position
 
 Query positions enriched with computed value fields including PnL, redeemable assets, and theoretical value. This is a view that extends the base `positions` table with real-time calculations.
 
-## Query Structure
+## Positions with Value - Query Structure
 
 ## Response Fields
 
@@ -3424,7 +3350,6 @@ Query positions enriched with computed value fields including PnL, redeemable as
 | `term_id` | `String` | Term ID for the vault |
 | `curve_id` | `numeric` | Bonding curve ID |
 | `shares` | `numeric` | Number of shares held |
-| `redeemable_assets` | `numeric` | Current redeemable value in assets |
 
 [... see full docs for complete content]
 
@@ -3439,7 +3364,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/share-pr
 
 Track how share prices change over time.
 
-## Query Structure
+## Share Price Changes - Query Structure
 
 ## Best Practices
 
@@ -3459,7 +3384,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/top-vaul
 
 Query top vaults ranked by market cap, position count, or other metrics.
 
-## Query Structure
+## Top Vaults - Query Structure
 
 ## Interactive Example
 
@@ -3489,7 +3414,8 @@ Query top vaults ranked by market cap, position count, or other metrics.
 1. **Order by market_cap** for TVL ranking
 2. **Filter by curve_id** for specific bonding curve
 3. **Include term data** for display
-4. **Use limit** to show top N vaults
+
+[... see full docs for complete content]
 
 ---
 title: "User Positions"
@@ -3502,7 +3428,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/user-pos
 
 Query all positions held by a specific account.
 
-## Query Structure
+## User Positions - Query Structure
 
 ## Interactive Example
 
@@ -3546,7 +3472,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/queries/vaults/vault-de
 
 Fetch comprehensive vault statistics including shares, assets, price, and positions.
 
-## Query Structure
+## Vault Details - Query Structure
 
 ## Interactive Example
 
@@ -3648,7 +3574,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/subscriptions/price-upd
 
 # Price Updates
 
-# Price Update Subscriptions
+## Price Update Subscriptions
 
 Subscribe to real-time share price changes.
 
@@ -3670,7 +3596,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/subscriptions/real-time
 
 # Real-Time Positions
 
-# Real-Time Position Updates
+## Real-Time Position Updates
 
 Subscribe to position changes for live portfolio tracking.
 
@@ -3684,13 +3610,11 @@ Subscribe to position changes for live portfolio tracking.
 4. **Resume from last cursor** after disconnection
 
 ---
-title: "Use Cases"
+title: "GraphQL API Use Cases"
 description: "Real-world examples and step-by-step tutorials to use the Intuition GraphQL API"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/graphql-api/use-cases/overview"
 ---
-
-# Use Cases
 
 # GraphQL API Use Cases
 
@@ -3700,29 +3624,13 @@ This section contains practical, step-by-step tutorials for common use cases whe
 
 Select a use case above to see detailed step-by-step implementation guides.
 
-    <h3>
-      Finding the Top dApps on Coinbase
-    </h3>
+  [Finding the Top dApps on Coinbase Query and rank decentralized applications based on market data.](https://docs.intuition.systems/docs/tutorials/queries/finding-top-dapps-on-coinbase)
 
-      Query and rank decentralized applications based on market data.
+  [Discovering the Most Trusted Accounts Find highly trusted accounts based on stake and activity.](https://docs.intuition.systems/docs/tutorials/queries/discovering-most-trusted-accounts)
 
-    <h3>
-      Discovering the Most Trusted Accounts
-    </h3>
+  [Building User Activity Feeds Create personalized activity streams for users.](https://docs.intuition.systems/docs/tutorials/queries/building-user-activity-feeds)
 
-      Find highly trusted accounts based on stake and activity.
-
-    <h3>
-      Building User Activity Feeds
-    </h3>
-
-      Create personalized activity streams for users.
-
-    <h3>
-      Finding Related Claims
-    </h3>
-
-[... see full docs for complete content]
+  [Finding Related Claims Discover linked triples and relationship patterns.](https://docs.intuition.systems/docs/tutorials/queries/finding-related-claims)
 
 ---
 title: "Writes"
@@ -3735,7 +3643,7 @@ source: "https://docs.intuition.systems/docs/graphql-api/writes"
 
 ## Understanding Mutations vs Smart Contract Operations
 
-The Intuition GraphQL API provides mutations for **off-chain operations** like uploading metadata to IPFS. For **on-chain operations** like creating atoms, triples, and positions, you must use the [Intuition SDK](/docs/intuition-sdk/installation-and-setup) or interact directly with the smart contracts.
+The Intuition GraphQL API provides mutations for **off-chain operations** like uploading metadata to IPFS. For **on-chain operations** like creating atoms, triples, and positions, you must use the [Intuition SDK](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup) or interact directly with the smart contracts.
 
 Pinning mutations are served from the public gated endpoint, `https://pin.intuition.systems/v1/graphql`, not the read endpoint. Send your Intuition pin API key in an `apikey` request header from a trusted server runtime.
 
@@ -3780,13 +3688,13 @@ Creating atoms in the Intuition protocol involves interacting with the EthMultiV
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
+This implementation guide assumes that you've completed the setup steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
 
 ## Implementation
 
 We recommend creating a `multivault.ts` that includes the following atom creation functionality:
 
-<h3 >Core Atom Creation Pattern</h3>
+### Core Atom Creation Pattern
 
 {`// Create atom with initial deposit
 const createAtomConfig = {
@@ -3808,13 +3716,13 @@ Creating triples in the Intuition protocol involves establishing relationships b
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide and have existing atoms to work with.
+This implementation guide assumes that you've completed the setup steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide and have existing atoms to work with.
 
 ## Implementation
 
 We recommend creating a `multivault.ts` that includes the following triple creation functionality:
 
-<h3 >Core Triple Creation Pattern</h3>
+### Core Triple Creation Pattern
 
 {`// Create triple with initial deposit
 const createTripleConfig = {
@@ -3840,13 +3748,13 @@ Managing deposits and withdrawals from vaults in the Intuition protocol involves
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
+This implementation guide assumes that you've completed the setup steps in the [Overview](https://docs.intuition.systems/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
 
 ## Implementation
 
 We recommend creating a `multivault.ts` that includes the following deposit and withdrawal functionality:
 
-<h3 >Core Deposit Pattern</h3>
+### Core Deposit Pattern
 
 {`// Deposit into vault
 const depositConfig = {
@@ -3857,13 +3765,11 @@ const depositConfig = {
 [... see full docs for complete content]
 
 ---
-title: "Overview"
+title: "Contract Interactions Overview"
 description: "Introduction to Intuition contract interactions and smart contract operations"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/interaction-guide/overview"
 ---
-
-# Overview
 
 # Contract Interactions Overview
 
@@ -3871,15 +3777,15 @@ The Intuition protocol's smart contracts manage complex state involving Atoms, T
 
 ## Key Concepts
 
-<h4 >Multicall Operations</h4>
+#### Multicall Operations
 
 Batch multiple read-only contract calls into a single request to reduce RPC calls and improve performance.
 
-<h4 >State Management</h4>
+#### State Management
 
 Retrieve comprehensive vault information including assets, share prices, and user positions.
 
-<h4 >Configuration Access</h4>
+#### Configuration Access
 
 Access global protocol configuration including fee structures and minimum deposits.
 
@@ -3973,7 +3879,7 @@ source: "https://docs.intuition.systems/docs/intuition-concepts/economics/fees-a
 
 # Fees and Rewards
 
-# Fees & Rewards
+## Fees & Rewards
 
 In the Intuition system, interactions incur fees similar to gas costs in blockchain transactions. These fees serve critical roles in maintaining system integrity, incentivizing contributions, and fostering high-quality data.
 
@@ -4011,13 +3917,11 @@ In many systems, user-generated tags and classifications, known as **folksonomie
 [... see full docs for complete content]
 
 ---
-title: "Economics"
+title: "Economics Overview"
 description: "Understanding Intuition's token-curated knowledge graph economics"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/intuition-concepts/economics"
 ---
-
-# Economics
 
 # Economics Overview
 
@@ -4104,7 +4008,7 @@ Atoms are the foundational building blocks of Intuition's knowledge graph – th
 
 A system facilitating the arrival at social consensus around globally persistent canonical identifiers for all things demands that these identifiers possess a few key attributes.
 
-<h3 >Decentralized Identifiers</h3>
+### Decentralized Identifiers
 
 [... see full docs for complete content]
 
@@ -4234,13 +4138,11 @@ A Triple is a fundamental data structure that expresses relationships between At
 [... see full docs for complete content]
 
 ---
-title: "Nested Triples"
+title: "Nested Triples: Meta-Claims & Context"
 description: "Creating meta-claims and context through nested Triple structures"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples"
 ---
-
-# Nested Triples
 
 # Nested Triples: Meta-Claims & Context
 
@@ -4293,23 +4195,21 @@ Establish hierarchical or categorical relationships.
 [... see full docs for complete content]
 
 ---
-title: "Primitives"
+title: "Primitives Overview"
 description: "Understanding Intuition's core primitives - Atoms, Triples, and Signals - the building blocks of a decentralized knowledge graph"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/intuition-concepts/primitives"
 ---
 
-# Primitives
-
 # Primitives Overview
 
 Intuition's data model is built on three fundamental primitives that work together to create a rich, self-regulating knowledge graph. These primitives form the foundation of the ecosystem and enable the creation of a structured, semantic web of trust.
 
-<h2>Atoms</h2>
+## Atoms
 
 The basic entities or identifiers - unique decentralized identifiers for everything in existence. Think of them as the nodes in the knowledge graph, or the words in the dictionary. Atoms are Intuition's atomic unit of knowledge, enabling unique, persistent, canonical identifiers for all things - not just people.
 
-<h2>Triples</h2>
+## Triples
 
 [... see full docs for complete content]
 
@@ -4464,8 +4364,6 @@ Using the `ethers` library:
 ## Authentication
 
 RPC access requires authentication for production use:
-
-[... see full docs for complete content]
 
 ---
 title: "Intuition Testnet"
@@ -4650,21 +4548,19 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/atoms-guide"
 
 # Working with Atoms
 
-**Conceptual overview:** [Atoms Fundamentals](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+**Conceptual overview:** [Atoms Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 Atoms are unique identifiers for any entity—people, concepts, smart contracts, or data. This guide covers all ways to create and query atoms using the SDK.
 
 ## Table of Contents
 
-- [Creating from Strings](#creating-from-strings)
-- [Creating from Thing (JSON-LD)](#creating-from-thing)
-- [Creating from Ethereum Accounts](#creating-from-ethereum-accounts)
-- [Creating from Smart Contracts](#creating-from-smart-contracts)
-- [Creating from IPFS](#creating-from-ipfs)
-- [Batch Creation](#batch-creation)
-- [Querying Atoms](#querying-atoms)
-
----
+- [Creating from Strings](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-strings)
+- [Creating from Thing (JSON-LD)](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-thing)
+- [Creating from Ethereum Accounts](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-ethereum-accounts)
+- [Creating from Smart Contracts](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-smart-contracts)
+- [Creating from IPFS](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-ipfs)
+- [Batch Creation](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#batch-creation)
+- [Querying Atoms](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#querying-atoms)
 
 ## Creating from Strings
 
@@ -4672,7 +4568,7 @@ The simplest way to create an atom is from a plain string.
 
 ### Function Signature
 
-### Parameters
+### Creating from Strings - Parameters
 
 | Parameter | Type          | Description                                                           | Required |
 
@@ -4687,7 +4583,7 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/examples/batch-ethere
 
 # Example: Batch Create Ethereum Accounts
 
-# Example: Batch Create Ethereum Account Atoms
+## Example: Batch Create Ethereum Account Atoms
 
 This example demonstrates creating multiple identity atoms from Ethereum addresses in a single transaction.
 
@@ -4695,8 +4591,8 @@ This example demonstrates creating multiple identity atoms from Ethereum address
 
 ## See Also
 
-- [batchCreateAtomsFromEthereumAccounts](../atoms/batch-creation.md)
-- [Batch Creation Guide](../atoms/batch-creation.md)
+- [batchCreateAtomsFromEthereumAccounts](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [Batch Creation Guide](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 ---
 title: "Example: Bulk Sync with Cost Estimation"
@@ -4716,7 +4612,7 @@ This example demonstrates using the experimental `sync` function to estimate cos
 ## See Also
 
 - sync Function (Experimental)
-- [Batch Creation](../atoms/batch-creation.md)
+- [Batch Creation](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 ---
 title: "Example: Create Atom from String"
@@ -4737,9 +4633,9 @@ This example demonstrates creating an atom from a plain text string, including s
 
 ## See Also
 
-- [createAtomFromString](../atoms/create-from-string.md)
-- [getAtomDetails](../atoms/querying.md)
-- [Quick Start Guide](../getting-started/quick-start.md)
+- [createAtomFromString](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [getAtomDetails](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [Quick Start Guide](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ---
 title: "Example: Create Triple Statement"
@@ -4756,8 +4652,8 @@ This example demonstrates creating a complete triple (subject-predicate-object s
 
 ## See Also
 
-- [createTripleStatement](../triples/create-triple.md)
-- [Create Atom Example](./create-atom-from-string.md)
+- [createTripleStatement](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
+- [Create Atom Example](https://docs.intuition.systems/docs/intuition-sdk/examples/create-atom-from-string)
 
 ---
 title: "Example: Deposit into Vault"
@@ -4774,9 +4670,9 @@ This example demonstrates depositing assets into a vault and tracking share bala
 
 ## See Also
 
-- [deposit](../vaults/deposits.md)
-- [Vault Queries](../vaults/queries.md)
-- [Vault Previews](../vaults/previews.md)
+- [deposit](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
+- [Vault Queries](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
+- [Vault Previews](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide)
 
 ---
 title: "Example: Find Existing Entities"
@@ -4793,10 +4689,10 @@ This example demonstrates how to find existing atoms and triples to avoid creati
 
 ## See Also
 
-- [findAtomIds](../search/advanced-queries.md#findatomids)
-- [findTripleIds](../search/advanced-queries.md#findtripleids)
-- [calculateAtomId](../atoms/querying.md#calculateatomid)
-- [calculateTripleId](../triples/querying.md#calculatetripleid)
+- [findAtomIds](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
+- [findTripleIds](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
+- [calculateAtomId](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
+- [calculateTripleId](https://docs.intuition.systems/docs/intuition-sdk/triples-guide)
 
 ---
 title: "Example: Global Search"
@@ -4813,8 +4709,8 @@ This example demonstrates using global search to find entities across the Intuit
 
 ## See Also
 
-- [globalSearch](../search/global-search.md)
-- [getAtomDetails](../atoms/querying.md)
+- [globalSearch](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
+- [getAtomDetails](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide)
 
 ---
 title: "Example: Thing IPFS Pinning"
@@ -4831,9 +4727,9 @@ This example demonstrates creating a rich entity (Thing) with automatic IPFS pin
 
 ## See Also
 
-- [createAtomFromThing](../atoms-guide.md#creating-from-thing)
-- [pinThing](../integrations/pinata-ipfs.md)
-- [IPFS Integration](../integrations/pinata-ipfs.md)
+- [createAtomFromThing](https://docs.intuition.systems/docs/intuition-sdk/atoms-guide#creating-from-thing)
+- [pinThing](https://docs.intuition.systems/docs/intuition-sdk/integrations/pinata-ipfs)
+- [IPFS Integration](https://docs.intuition.systems/docs/intuition-sdk/integrations/pinata-ipfs)
 
 ---
 title: "Installation & Setup"
@@ -4925,9 +4821,9 @@ Full-featured React component:
 
 ## Related Resources
 
-- [TanStack Query Integration](./tanstack-query.md)
+- [TanStack Query Integration](https://docs.intuition.systems/docs/intuition-sdk/integrations/tanstack-query)
 - [Wagmi Documentation](https://wagmi.sh)
-- [SDK Quick Start](../getting-started/quick-start.md)
+- [SDK Quick Start](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ## See Also
 
@@ -4975,13 +4871,13 @@ Full React component with TanStack Query:
 
 ## Related Resources
 
-- [React Integration](./react.md)
+- [React Integration](https://docs.intuition.systems/docs/intuition-sdk/integrations/react)
 - [TanStack Query Documentation](https://tanstack.com/query)
 
 ## See Also
 
 - [Wagmi Hooks](https://wagmi.sh)
-- [SDK Query Functions](../search/global-search.md)
+- [SDK Query Functions](https://docs.intuition.systems/docs/intuition-sdk/search-guide)
 
 ---
 title: "SDK Migration V1 to V2"
@@ -4992,7 +4888,7 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/migration-guide"
 
 # SDK Migration V1 to V2
 
-# Migrating SDK from v1.5 to v2.0
+## Migrating SDK from v1.5 to v2.0
 
 This guide helps you migrate your code from v1.x to v2.0.0-alpha of the Intuition TypeScript packages. This is a **major version update** with significant breaking changes due to the underlying contract migration from `EthMultiVault` to `MultiVault`.
 
@@ -5058,12 +4954,10 @@ Discover atoms, triples, accounts, and collections using search, filters, and ba
 
 ## Table of Contents
 
-- [Global Search](#global-search)
-- [Searching Atoms](#searching-atoms)
-- [Searching Triples](#searching-triples)
-- [Advanced Queries](#advanced-queries)
-
----
+- [Global Search](https://docs.intuition.systems/docs/intuition-sdk/search-guide#global-search)
+- [Searching Atoms](https://docs.intuition.systems/docs/intuition-sdk/search-guide#searching-atoms)
+- [Searching Triples](https://docs.intuition.systems/docs/intuition-sdk/search-guide#searching-triples)
+- [Advanced Queries](https://docs.intuition.systems/docs/intuition-sdk/search-guide#advanced-queries)
 
 ## Global Search
 
@@ -5071,7 +4965,7 @@ Search across all entity types (atoms, accounts, triples, collections) with a si
 
 ### Function Signature
 
-### Parameters
+### Global Search - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5086,8 +4980,6 @@ Search across all entity types (atoms, accounts, triples, collections) with a si
 
 Search with custom limits:
 
-### Common Use Cases
-
 [... see full docs for complete content]
 
 ---
@@ -5099,18 +4991,16 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/triples-guide"
 
 # Working with Triples
 
-**Conceptual overview:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**Conceptual overview:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 Triples are subject-predicate-object statements that connect three atoms to form relationships in the knowledge graph. This guide covers all ways to create and query triples using the SDK.
 
 ## Table of Contents
 
-- [Creating Triples](#creating-triples)
-- [Batch Creation](#batch-creation)
-- [Querying Triples](#querying-triples)
-- [Counter-Triples](#counter-triples)
-
----
+- [Creating Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#creating-triples)
+- [Batch Creation](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#batch-creation)
+- [Querying Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#querying-triples)
+- [Counter-Triples](https://docs.intuition.systems/docs/intuition-sdk/triples-guide#counter-triples)
 
 ## Creating Triples
 
@@ -5118,7 +5008,7 @@ Create a triple (subject-predicate-object statement) connecting three atoms in a
 
 ### Function Signature
 
-### Parameters
+### Creating Triples - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5136,18 +5026,16 @@ source: "https://docs.intuition.systems/docs/intuition-sdk/vaults-guide"
 
 # Working with Vaults
 
-**Conceptual overview:** [Signals Fundamentals](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**Conceptual overview:** [Signals Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 Vaults enable staking on atoms and triples through bonding curve-based share pricing. This guide covers deposits, redemptions, queries, and preview operations.
 
 ## Table of Contents
 
-- [Deposits](#deposits)
-- [Redemptions](#redemptions)
-- [Vault Queries](#vault-queries)
-- [Preview Operations](#preview-operations)
-
----
+- [Deposits](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#deposits)
+- [Redemptions](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#redemptions)
+- [Vault Queries](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#vault-queries)
+- [Preview Operations](https://docs.intuition.systems/docs/intuition-sdk/vaults-guide#preview-operations)
 
 ## Deposits
 
@@ -5159,7 +5047,7 @@ Deposit assets into a single vault.
 
 #### Function Signature
 
-#### Parameters
+#### deposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5217,13 +5105,11 @@ The following fixed fees are applied when creating atoms and triples within the 
 [... see full docs for complete content]
 
 ---
-title: "Deployments"
+title: "Contract Deployments"
 description: "The Intuition protocol contracts are deployed on both the Base Mainnet and the Intuition Layer 3 network, as well as their respective testnets. Below are the details of the deployed contracts,..."
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/intuition-smart-contracts/deployments"
 ---
-
-# Deployments
 
 # Contract Deployments
 
@@ -5251,24 +5137,23 @@ The Intuition protocol contracts are deployed on both the Base Mainnet and the I
 [... see full docs for complete content]
 
 ---
-title: "Overview"
+title: "Contract Architecture Overview"
 description: "Overview of Intuition's smart contract architecture and design patterns"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/intuition-smart-contracts"
 ---
 
-# Overview
-
 # Contract Architecture Overview
 
 Intuition's smart contracts are central to the user experience, handling critical onchain activities such as the creation of Atoms (also known as Identities) and Triples (also known as Claims), as well as the staking and rewards.
 
-# MultiVault
+## MultiVault
 
 The MultiVault contract is the core component of Intuition's architecture, responsible for managing the creation of Atoms/Triples and handling deposits, redemptions, and share distributions. It supports multiple bonding curve implementations through a registry system.
 
 - **Creation**: Users can create Atoms and Triples
 - **Deposits**: Users can deposit ETH to receive shares in atoms/triples
+- **Redemptions**: Users can redeem shares for ETH
 
 [... see full docs for complete content]
 
@@ -5322,7 +5207,7 @@ source: "https://docs.intuition.systems/docs/portal"
 
 # Portal (Explorer) Guide
 
-# The Intuition Portal
+## The Intuition Portal
 
 The Portal is Intuition's first Explorer (akin to a block explorer), which provides users with easy access to the social and knowledge graph. Positioned at the application layer, the Portal offers an intuitive interface for users to create, manage, and interact with Identities (Atoms) and Claims (Triples). It serves as the gateway for creating decentralized identities, making claims, and managing your stake, transforming the exploration of the knowledge graph into an accessible and user-friendly experience.
 
@@ -5343,7 +5228,7 @@ Functions for creating and querying atoms in the MultiVault contract.
 
 Create one or more atoms with optional initial deposits.
 
-### Parameters
+### multiVaultCreateAtoms - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5351,7 +5236,7 @@ Create one or more atoms with optional initial deposits.
 | args | `[bytes[], bigint[]]` | Array of atom URIs (hex) and deposit amounts | Yes |
 | value | `bigint` | Total ETH to send (sum of deposits) | Yes |
 
-### Returns
+### multiVaultCreateAtoms - Returns
 
 ### Basic Example
 
@@ -5359,7 +5244,7 @@ Create one or more atoms with optional initial deposits.
 
 ### Related Functions
 
-- [multiVaultGetAtomCost](#multivaultgetatomcost) - Get atom creation cost
+- [multiVaultGetAtomCost](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms#multivaultgetatomcost) - Get atom creation cost
 
 [... see full docs for complete content]
 
@@ -5378,68 +5263,57 @@ Functions for querying protocol configuration settings.
 
 Get general protocol configuration.
 
-### Returns
+### multiVaultGetGeneralConfig - Returns
 
-### Example
-
----
+### multiVaultGetGeneralConfig - Example
 
 ## multiVaultGetAtomConfig
 
 Get atom-specific configuration.
 
-### Returns
+### multiVaultGetAtomConfig - Returns
 
-### Example
-
----
+### multiVaultGetAtomConfig - Example
 
 ## multiVaultGetTripleConfig
 
 Get triple-specific configuration.
 
-### Returns
+### multiVaultGetTripleConfig - Returns
 
-### Example
-
----
+### multiVaultGetTripleConfig - Example
 
 ## multiVaultGetBondingCurveConfig
 
 Get bonding curve configuration.
 
-### Returns
+### multiVaultGetBondingCurveConfig - Returns
 
-### Example
-
----
+### multiVaultGetBondingCurveConfig - Example
 
 ## multiVaultGetWalletConfig
 
 Get wallet configuration.
 
-### Returns
+### multiVaultGetWalletConfig - Returns
 
-### Example
-
----
+### multiVaultGetWalletConfig - Example
 
 ## multiVaultMultiCallIntuitionConfigs
 
 Get all configurations in a single multicall.
 
-### Returns
+### multiVaultMultiCallIntuitionConfigs - Returns
 
-### Example
+### multiVaultMultiCallIntuitionConfigs - Example
 
 ### Advanced Example
 
----
-
 ## See Also
 
-- [Configuration Guide](/docs/protocol/getting-started/configuration)
-- [Fee Calculations](/docs/protocol/api-reference/multivault/fees)
+- [Configuration Guide](https://docs.intuition.systems/docs/protocol/getting-started/configuration)
+
+[... see full docs for complete content]
 
 ---
 title: "Share & Asset Conversions"
@@ -5456,28 +5330,25 @@ Functions for converting between shares and assets, and querying share balances 
 
 Convert asset amount to expected shares.
 
-### Parameters
+### multiVaultConvertToShares - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint, bigint]` | VaultId, curveId, assets | Yes |
 
-### Returns
+### multiVaultConvertToShares - Returns
 
-### Example
-
----
+### multiVaultConvertToShares - Example
 
 ## multiVaultConvertToAssets
 
 Convert shares to expected assets.
 
-### Parameters
+### multiVaultConvertToAssets - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| config | `ReadConfig` | Contract address and publicClient | Yes |
 
 [... see full docs for complete content]
 
@@ -5496,34 +5367,30 @@ Functions for querying epoch information and utilization metrics.
 
 Get the current epoch number.
 
-### Returns
+### multiVaultCurrentEpoch - Returns
 
-### Example
-
----
+### multiVaultCurrentEpoch - Example
 
 ## multiVaultGetTotalUtilizationForEpoch
 
 Get total protocol utilization for an epoch.
 
-### Parameters
+### multiVaultGetTotalUtilizationForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### multiVaultGetTotalUtilizationForEpoch - Returns
 
-### Example
-
----
+### multiVaultGetTotalUtilizationForEpoch - Example
 
 ## multiVaultGetUserUtilizationForEpoch
 
 Get user's total utilization for an epoch.
 
-### Parameters
+### multiVaultGetUserUtilizationForEpoch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5545,29 +5412,26 @@ Functions for calculating various fees in the protocol.
 
 Calculate entry fee for a deposit.
 
-### Parameters
+### multiVaultEntryFeeAmount - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32, bigint]` | VaultId, assets | Yes |
 
-### Returns
+### multiVaultEntryFeeAmount - Returns
 
-### Example
-
----
+### multiVaultEntryFeeAmount - Example
 
 ## multiVaultExitFeeAmount
 
 Calculate exit fee for a redemption.
 
-### Parameters
+### multiVaultExitFeeAmount - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
-| args | `[bytes32, bigint]` | VaultId, assets | Yes |
 
 [... see full docs for complete content]
 
@@ -5586,7 +5450,7 @@ Functions for creating and managing triples (statements) in the MultiVault contr
 
 Create one or more triples (subject-predicate-object statements).
 
-### Parameters
+### multiVaultCreateTriples - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5594,7 +5458,7 @@ Create one or more triples (subject-predicate-object statements).
 | args | `[bytes32[], bytes32[], bytes32[], bigint[]]` | Subject IDs, predicate IDs, object IDs, deposit amounts | Yes |
 | value | `bigint` | Total ETH to send | Yes |
 
-### Returns
+### multiVaultCreateTriples - Returns
 
 ### Basic Example
 
@@ -5602,10 +5466,7 @@ Create one or more triples (subject-predicate-object statements).
 
 ### Related Functions
 
-- [multiVaultGetTriple](#multivaultgettriple) - Query triple details
-- [multiVaultGetTripleCost](#multivaultgettriplecost) - Get creation cost
-
----
+- [multiVaultGetTriple](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples#multivaultgettriple) - Query triple details
 
 [... see full docs for complete content]
 
@@ -5624,37 +5485,27 @@ Functions for querying vault information and state.
 
 Get vault details.
 
-### Parameters
+### multiVaultGetVault - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Vault ID | Yes |
 
-### Returns
+### multiVaultGetVault - Returns
 
-### Example
-
----
+### multiVaultGetVault - Example
 
 ## multiVaultGetVaultType
 
 Get vault type (atom or triple).
 
-### Parameters
+### multiVaultGetVaultType - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bytes32]` | Vault ID | Yes |
-
-### Returns
-
-### Example
-
----
-
-## multiVaultIsTermCreated
 
 [... see full docs for complete content]
 
@@ -5673,7 +5524,7 @@ Functions for depositing to and redeeming from vaults.
 
 Deposit assets into a vault to receive shares.
 
-### Parameters
+### multiVaultDeposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5681,15 +5532,13 @@ Deposit assets into a vault to receive shares.
 | args | `[Address, bytes32, bigint, bigint]` | Receiver, vaultId, curveId, minShares | Yes |
 | value | `bigint` | Deposit amount in wei | Yes |
 
-### Example
-
----
+### multiVaultDeposit - Example
 
 ## multiVaultDepositBatch
 
 Deposit to multiple vaults in a single transaction.
 
-### Parameters
+### multiVaultDepositBatch - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -5711,37 +5560,30 @@ Functions for querying bonded balances and locked amounts.
 
 Get the total bonded balance across all users.
 
-### Returns
+### trustBondingTotalBondedBalance - Returns
 
-### Example
-
----
+### trustBondingTotalBondedBalance - Example
 
 ## trustBondingTotalBondedBalanceAtEpochEnd
 
 Get total bonded balance at the end of an epoch.
 
-### Parameters
+### trustBondingTotalBondedBalanceAtEpochEnd - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Epoch number | Yes |
 
-### Returns
+### trustBondingTotalBondedBalanceAtEpochEnd - Returns
 
-### Example
-
----
+### trustBondingTotalBondedBalanceAtEpochEnd - Example
 
 ## trustBondingUserBondedBalanceAtEpochEnd
 
 Get user's bonded balance at the end of an epoch.
 
-### Parameters
-
-| Parameter | Type | Description | Required |
-|-----------|------|-------------|----------|
+### trustBondingUserBondedBalanceAtEpochEnd - Parameters
 
 [... see full docs for complete content]
 
@@ -5760,44 +5602,34 @@ Functions for managing and querying epoch information in the Trust Bonding contr
 
 Get the current epoch number.
 
-### Returns
+### trustBondingCurrentEpoch - Returns
 
-### Example
-
----
+### trustBondingCurrentEpoch - Example
 
 ## trustBondingPreviousEpoch
 
 Get the previous epoch number.
 
-### Returns
+### trustBondingPreviousEpoch - Returns
 
-### Example
-
----
+### trustBondingPreviousEpoch - Example
 
 ## trustBondingEpochAtTimestamp
 
 Get the epoch number for a specific timestamp.
 
-### Parameters
+### trustBondingEpochAtTimestamp - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[bigint]` | Unix timestamp | Yes |
 
-### Returns
+### trustBondingEpochAtTimestamp - Returns
 
-### Example
-
----
+### trustBondingEpochAtTimestamp - Example
 
 ## trustBondingEpochTimestampEnd
-
-Get the end timestamp for an epoch.
-
-### Parameters
 
 [... see full docs for complete content]
 
@@ -5822,13 +5654,11 @@ Lock functionality may be implemented through the broader bonding mechanism. Use
 
 ## Maximum Redeemable Amount
 
----
-
 ## See Also
 
-- [Trust Bonding Balances](/docs/protocol/api-reference/trust-bonding/balances)
-- [Vault Queries](/docs/protocol/api-reference/multivault/vault-queries)
-- [Share Conversions](/docs/protocol/api-reference/multivault/conversions)
+- [Trust Bonding Balances](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/balances)
+- [Vault Queries](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vault-queries)
+- [Share Conversions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions)
 
 ---
 title: "Reward Calculations"
@@ -5845,38 +5675,33 @@ Functions for calculating and querying bonding rewards.
 
 Get user's annual percentage yield (APY).
 
-### Parameters
+### trustBondingGetUserApy - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `ReadConfig` | Contract address and publicClient | Yes |
 | args | `[Address]` | User address | Yes |
 
-### Returns
+### trustBondingGetUserApy - Returns
 
-### Example
-
----
+### trustBondingGetUserApy - Example
 
 ## trustBondingGetSystemApy
 
 Get system-wide APY.
 
-### Returns
+### trustBondingGetSystemApy - Returns
 
-### Example
-
----
+### trustBondingGetSystemApy - Example
 
 ## trustBondingGetUserCurrentClaimableRewards
 
 Get user's currently claimable rewards.
 
-### Parameters
+### trustBondingGetUserCurrentClaimableRewards - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| config | `ReadConfig` | Contract address and publicClient | Yes |
 
 [... see full docs for complete content]
 
@@ -5899,7 +5724,7 @@ The Trust Bonding contract primarily tracks utilization and distributes rewards.
 
 Trust Bonding rewards are earned through:
 
-1. **Depositing to vaults** via [multiVaultDeposit](/docs/protocol/api-reference/multivault/vaults#multivaultdeposit)
+1. **Depositing to vaults** via [multiVaultDeposit](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults#multivaultdeposit)
 2. **Vault utilization** tracked by the protocol
 3. **Epoch-based rewards** calculated from utilization
 
@@ -5907,13 +5732,11 @@ Trust Bonding rewards are earned through:
 
 ### Check Your Bonding Position
 
----
-
 ## See Also
 
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-- [Trust Bonding Rewards](/docs/protocol/api-reference/trust-bonding/rewards)
-- [Examples: Trust Bonding](/docs/protocol/examples/trust-bonding)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
+- [Trust Bonding Rewards](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards)
+- [Examples: Trust Bonding](https://docs.intuition.systems/docs/protocol/examples/trust-bonding)
 
 ---
 title: "Wrapped Trust"
@@ -5930,24 +5753,22 @@ Functions for wrapping and unwrapping native TRUST tokens.
 
 Deposit native TRUST to receive wrapped TRUST.
 
-### Parameters
+### wrappedTrustDeposit - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | config | `WriteConfig` | Contract address, publicClient, walletClient | Yes |
 | value | `bigint` | Amount of TRUST to wrap | Yes |
 
-### Returns
+### wrappedTrustDeposit - Returns
 
-### Example
-
----
+### wrappedTrustDeposit - Example
 
 ## wrappedTrustWithdraw
 
 Withdraw wrapped TRUST to receive native TRUST.
 
-### Parameters
+### wrappedTrustWithdraw - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
@@ -6041,38 +5862,32 @@ Functions for parsing atom-related events from transaction receipts.
 
 Parse AtomCreated events from a transaction.
 
-### Parameters
+### eventParseAtomCreated - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | publicClient | `PublicClient` | Viem public client | Yes |
 | txHash | `Hash` | Transaction hash | Yes |
 
-### Returns
+### eventParseAtomCreated - Returns
 
-### Example
-
----
+### eventParseAtomCreated - Example
 
 ## eventParseAtomDepositCreated
 
 Parse AtomDepositCreated events (atom creation with initial deposit).
 
-### Returns
+### eventParseAtomDepositCreated - Returns
 
-### Example
-
----
+### eventParseAtomDepositCreated - Example
 
 ## Complete Example
 
----
-
 ## See Also
 
-- [Triple Events](/docs/protocol/events/triple-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-- [Examples: Event Parsing](/docs/protocol/examples/event-parsing)
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
+- [Examples: Event Parsing](https://docs.intuition.systems/docs/protocol/examples/event-parsing)
 
 ---
 title: "Triple Events"
@@ -6089,33 +5904,29 @@ Functions for parsing triple-related events from transaction receipts.
 
 Parse TripleCreated events from a transaction.
 
-### Parameters
+### eventParseTripleCreated - Parameters
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | publicClient | `PublicClient` | Viem public client | Yes |
 | txHash | `Hash` | Transaction hash | Yes |
 
-### Returns
+### eventParseTripleCreated - Returns
 
-### Example
-
----
+### eventParseTripleCreated - Example
 
 ## eventParseTripleDepositCreated
 
 Parse TripleDepositCreated events.
 
-### Returns
+### eventParseTripleDepositCreated - Returns
 
-### Example
-
----
+### eventParseTripleDepositCreated - Example
 
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Vault Events](/docs/protocol/events/vault-events)
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
 
 ---
 title: "Trust Bonding Events"
@@ -6132,23 +5943,19 @@ Functions for parsing Trust Bonding events from transaction receipts.
 
 Parse RewardsClaimed events from a transaction.
 
-### Returns
+### eventParseRewardsClaimed - Returns
 
-### Example
-
----
+### eventParseRewardsClaimed - Example
 
 ## Generic Event Parser
 
 For parsing any event from protocol contracts:
 
----
-
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-- [Examples: Event Parsing](/docs/protocol/examples/event-parsing)
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
+- [Examples: Event Parsing](https://docs.intuition.systems/docs/protocol/examples/event-parsing)
 
 ---
 title: "Vault Events"
@@ -6165,46 +5972,38 @@ Functions for parsing vault-related events from transaction receipts.
 
 Parse Deposited events from a transaction.
 
-### Returns
+### eventParseDeposited - Returns
 
-### Example
-
----
+### eventParseDeposited - Example
 
 ## eventParseRedeemed
 
 Parse Redeemed events from a transaction.
 
-### Returns
+### eventParseRedeemed - Returns
 
-### Example
-
----
+### eventParseRedeemed - Example
 
 ## eventParseSharePriceChanged
 
 Parse SharePriceChanged events.
 
-### Returns
+### eventParseSharePriceChanged - Returns
 
-### Example
-
----
+### eventParseSharePriceChanged - Example
 
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Triple Events](/docs/protocol/events/triple-events)
-- [Examples: Event Parsing](/docs/protocol/examples/event-parsing)
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
+- [Examples: Event Parsing](https://docs.intuition.systems/docs/protocol/examples/event-parsing)
 
 ---
-title: "Batch Operations"
+title: "Batch Operations Examples"
 description: "Complete examples for batch creation and deposit operations"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/protocol/examples/batch-operations"
 ---
-
-# Batch Operations
 
 # Batch Operations Examples
 
@@ -6220,9 +6019,9 @@ Complete workflows for performing batch operations to save gas and improve effic
 
 ## See Also
 
-- [Atom Functions](/docs/protocol/api-reference/multivault/atoms)
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-- [Triple Functions](/docs/protocol/api-reference/multivault/triples)
+- [Atom Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
+- [Triple Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples)
 
 ---
 title: "Creating Atoms & Triples"
@@ -6249,19 +6048,17 @@ Complete workflows for creating atoms and triples with the Protocol package.
 
 ## See Also
 
-- [Atom Functions](/docs/protocol/api-reference/multivault/atoms)
-- [Triple Functions](/docs/protocol/api-reference/multivault/triples)
-- [Atoms Fundamentals](/docs/intuition-concepts/primitives/Atoms/fundamentals)
-- [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+- [Atom Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Triple Functions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/triples)
+- [Atoms Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
+- [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ---
-title: "Deposit & Redeem"
+title: "Deposit & Redeem Examples"
 description: "Complete examples for vault deposits and redemptions"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/protocol/examples/deposit-redeem"
 ---
-
-# Deposit & Redeem
 
 # Deposit & Redeem Examples
 
@@ -6277,9 +6074,9 @@ Complete workflows for depositing to and redeeming from vaults.
 
 ## See Also
 
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
-- [Share Conversions](/docs/protocol/api-reference/multivault/conversions)
-- [Core Concepts: Vaults](/docs/protocol/core-concepts/vaults)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
+- [Share Conversions](https://docs.intuition.systems/docs/protocol/api-reference/multivault/conversions)
+- [Core Concepts: Vaults](https://docs.intuition.systems/docs/protocol/core-concepts/vaults)
 
 ---
 title: "Event Parsing Examples"
@@ -6300,18 +6097,16 @@ Complete workflows for parsing events from transaction receipts.
 
 ## See Also
 
-- [Atom Events](/docs/protocol/events/atom-events)
-- [Vault Events](/docs/protocol/events/vault-events)
-- [Triple Events](/docs/protocol/events/triple-events)
+- [Atom Events](https://docs.intuition.systems/docs/protocol/events/atom-events)
+- [Vault Events](https://docs.intuition.systems/docs/protocol/events/vault-events)
+- [Triple Events](https://docs.intuition.systems/docs/protocol/events/triple-events)
 
 ---
-title: "Fee Calculations"
+title: "Fee Calculations Examples"
 description: "Complete examples for calculating and estimating fees"
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/protocol/examples/fee-calculations"
 ---
-
-# Fee Calculations
 
 # Fee Calculations Examples
 
@@ -6329,9 +6124,9 @@ Complete workflows for calculating fees and estimating costs.
 
 ## See Also
 
-- [Fee Calculations API](/docs/protocol/api-reference/multivault/fees)
-- [Configuration](/docs/protocol/api-reference/multivault/configuration)
-- [Vault Operations](/docs/protocol/api-reference/multivault/vaults)
+- [Fee Calculations API](https://docs.intuition.systems/docs/protocol/api-reference/multivault/fees)
+- [Configuration](https://docs.intuition.systems/docs/protocol/api-reference/multivault/configuration)
+- [Vault Operations](https://docs.intuition.systems/docs/protocol/api-reference/multivault/vaults)
 
 ---
 title: "Trust Bonding Examples"
@@ -6352,9 +6147,9 @@ Complete workflows for tracking rewards and utilization in the Trust Bonding sys
 
 ## See Also
 
-- [Trust Bonding Rewards](/docs/protocol/api-reference/trust-bonding/rewards)
-- [Epoch Management](/docs/protocol/api-reference/trust-bonding/epochs)
-- [Core Concepts: Epochs](/docs/protocol/core-concepts/epochs)
+- [Trust Bonding Rewards](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/rewards)
+- [Epoch Management](https://docs.intuition.systems/docs/protocol/api-reference/trust-bonding/epochs)
+- [Core Concepts: Epochs](https://docs.intuition.systems/docs/protocol/core-concepts/epochs)
 
 ---
 title: "Configuration"
@@ -6432,19 +6227,19 @@ source: "https://docs.intuition.systems/docs/protocol/working-with-primitives"
 
 This guide shows how to create and interact with atoms, triples, and vaults using the Protocol package (low-level contract interactions).
 
-**For conceptual understanding:** [Primitives Overview](/docs/intuition-concepts/primitives)
+**For conceptual understanding:** [Primitives Overview](https://docs.intuition.systems/docs/intuition-concepts/primitives)
 
 ## Creating Atoms
 
 Atoms are unique identifiers for any entity. Here's how to create them with the Protocol package:
 
-**See also:** [Atoms Concept](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+**See also:** [Atoms Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 ## Creating Triples
 
 Triples connect three atoms to create structured claims:
 
-**See also:** [Triples Concept](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See also:** [Triples Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 ## Vault Operations
 
@@ -6456,7 +6251,7 @@ Every atom and triple has an associated vault for staking:
 
 ### Querying Vault Details
 
-**See also:** [Signals Concept](/docs/intuition-concepts/primitives/Signals/fundamentals)
+**See also:** [Signals Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Signals/fundamentals)
 
 ## Batch Operations
 
@@ -6495,13 +6290,11 @@ The Intuition protocol contracts are deployed on both the Base Mainnet and the I
 [... see full docs for complete content]
 
 ---
-title: "Network & Explorers"
+title: "Intuition Network & Explorers"
 description: "Interacting with the Intuition protocol requires connecting to the Intuition network - an L3 network that posts to [Base](https://base.org/)."
 last_updated: "2026-01-05T17:16:01-08:00"
 source: "https://docs.intuition.systems/docs/quick-start/network-details"
 ---
-
-# Network & Explorers
 
 # Intuition Network & Explorers
 
@@ -6534,10 +6327,12 @@ You can visit the [Intuition Testnet faucet](https://testnet.hub.intuition.syste
 
 - https://testnet.hub.intuition.systems/
 
-# Network Details
+## Network Details
 
 ### Intuition Mainnet Configuration
 - **Chain ID**: 1155
+- **RPC URL**: `https://rpc.intuition.systems`
+- **WebSocket**: `wss://rpc.intuition.systems`
 
 [... see full docs for complete content]
 
@@ -6569,13 +6364,13 @@ source: "https://docs.intuition.systems/docs/quick-start/using-the-sdk"
 
 # Using the SDK
 
-# Intuition SDK Quick Start
+## Intuition SDK Quick Start
 
 Get started building with Intuition in minutes. 
 
 This guide provides direct code snippets to create atoms, triples, and signal on them.
 
-Before starting development, we recommend adding the Intuition Testnet and Mainnet networks to your preferred wallet. You can find the networks in the [Network Details](/docs/quick-start/network-details) page.
+Before starting development, we recommend adding the Intuition Testnet and Mainnet networks to your preferred wallet. You can find the networks in the [Network Details](https://docs.intuition.systems/docs/quick-start/network-details) page.
 
 ## Installation
 In most cases, you will only need to install the `@0xintuition/sdk` package. This package provides a high-level API for interacting with the Intuition protocol, plus exports the core `@0xintuition/protocol` and `@0xintuition/graphql` functionality.
@@ -6599,13 +6394,23 @@ Connect with the Intuition community, get help, and stay updated with the latest
 
 ## Official Channels
 
-<svg width="32" height="32" viewBox="0 0 24 24" fill="white">
-<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-</svg>
+[Follow us on X for real-time updates, announcements, and community highlights.](https://x.com/0xintuition)
 
-Follow us on X for real-time updates, announcements, and community highlights.
+[Join our Discord community for discussions, support, and real-time collaboration.](https://discord.com/invite/0xintuition)
 
-<svg width="32" height="32" viewBox="0 0 24 24" fill="white">
+[Watch video recordings, tutorials, and community content on our YouTube channel.](https://www.youtube.com/@0xIntuition)
+
+[Read our latest articles, insights, and technical deep-dives on Medium.](https://medium.com/0xintuition)
+
+## Support Channels
+
+[General Support Get general support and assistance for questions about Intuition.](mailto:support@intuition.systems)
+
+[Website Visit our official website for the latest updates, information, and resources.](https://www.intuition.systems)
+
+## Feedback & Improvement
+
+[GitHub Contribute to our open-source projects, report issues, and suggest improvements.](https://github.com/0xintuition)
 
 [... see full docs for complete content]
 
@@ -6647,7 +6452,7 @@ Comprehensive glossary of key terms used in Intuition documentation.
 
 A unique decentralized identifier for any entity, concept, or piece of data. Atoms are the fundamental building blocks of the knowledge graph.
 
-**See:** [Atoms Fundamentals](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+**See:** [Atoms Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Atoms/fundamentals)
 
 **Example:** An atom representing "TypeScript" or an Ethereum address "0x742d35..."
 
@@ -6655,7 +6460,7 @@ A unique decentralized identifier for any entity, concept, or piece of data. Ato
 
 A verifiable claim or statement made on-chain using triples. Attestations can be supported or opposed through signals (staking).
 
-**See:** [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
+**See:** [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
 
 **Example:** `[Alice] [endorses] [Bob]` is an attestation that Alice endorses Bob.
 
@@ -6676,25 +6481,15 @@ Find additional resources, support, and tools for building with Intuition.
 
 ## Documentation Resources
 
-<h3>FAQ</h3>
+[FAQ Frequently asked questions about Intuition. From basic concepts to advanced implementation details, get quick answers to common questions.](https://docs.intuition.systems/docs/resources/faq)
 
-Frequently asked questions about Intuition. From basic concepts to advanced implementation details, get quick answers to common questions.
+[Glossary Comprehensive glossary of key terms and definitions. Master the essential terminology for working with Intuition.](https://docs.intuition.systems/docs/resources/glossary)
 
-<h3>Glossary</h3>
-
-Comprehensive glossary of key terms and definitions. Master the essential terminology for working with Intuition.
-
-<h3>Tutorials</h3>
-
-Step-by-step guides for building with Intuition. Learn by doing with hands-on tutorials covering common use cases.
+[Tutorials Step-by-step guides for building with Intuition. Learn by doing with hands-on tutorials covering common use cases.](https://docs.intuition.systems/docs/tutorials/overview)
 
 ## Community & Support
 
-<h3>Community Channels</h3>
-
-Connect with the Intuition community. Join Discord, Forum discussions, and follow us on Twitter for updates.
-
-<h3>Contributing</h3>
+[Community Channels Connect with the Intuition community. Join Discord, Forum discussions, and follow us on Twitter for updates.](https://docs.intuition.systems/docs/resources/community-and-support)
 
 [... see full docs for complete content]
 
@@ -6713,14 +6508,15 @@ This page defines the essential terminology and concepts you need to understand 
 
 This page is organized into expandable sections for easy navigation. Click on any section below to explore the terms within that category.
 
-<svg width="12" height="12" viewBox="0 0 24 24" fill="#3B82F6" >
-<path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
-</svg>
 Core Primitives - Fundamental building blocks of the Intuition protocol
 
 ## Core Primitives
 
 ### **Atoms**
+
+**Atoms** are the fundamental building blocks of the Intuition knowledge graph. Each atom represents a unique entity or concept and points to arbitrary data via a URI.
+
+**Key Characteristics:**
 
 [... see full docs for complete content]
 
@@ -6751,9 +6547,9 @@ This tutorial will cover:
 
 See these resources:
 
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
-- [Protocol API Reference](/docs/protocol/api-reference/multivault/atoms)
-- [Performance Best Practices](/docs/intuition-sdk/quick-start)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
+- [Protocol API Reference](https://docs.intuition.systems/docs/protocol/api-reference/multivault/atoms)
+- [Performance Best Practices](https://docs.intuition.systems/docs/intuition-sdk/quick-start)
 
 ## Quick Example
 
@@ -6787,9 +6583,9 @@ This tutorial will cover:
 
 See these resources to learn about nested triples:
 
-- [Triples Fundamentals](/docs/intuition-concepts/primitives/Triples/fundamentals)
-- [Nested Triples Concept](/docs/intuition-concepts/primitives/Triples/nested-triples)
-- [SDK Documentation](/docs/intuition-sdk/installation-and-setup)
+- [Triples Fundamentals](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/fundamentals)
+- [Nested Triples Concept](https://docs.intuition.systems/docs/intuition-concepts/primitives/Triples/nested-triples)
+- [SDK Documentation](https://docs.intuition.systems/docs/intuition-sdk/installation-and-setup)
 
 ## Simple Example
 
@@ -6906,7 +6702,7 @@ Learn by building real applications with Intuition. Each tutorial is a complete,
 
 ## Building Applications
 
-### [Reputation System](/docs/tutorials/reputation-system)
+### [Reputation System](https://docs.intuition.systems/docs/tutorials/reputation-system)
 
 Build a developer reputation platform with skills, endorsements, and verifiable credentials.
 
@@ -6918,9 +6714,7 @@ Build a developer reputation platform with skills, endorsements, and verifiable 
 
 **Time:** 2-3 hours | **Level:** Intermediate
 
----
-
-### [Curated Lists](/docs/tutorials/curated-lists)
+### [Curated Lists](https://docs.intuition.systems/docs/tutorials/curated-lists)
 
 Create community-curated, ranked lists where stake determines ranking.
 
@@ -7020,7 +6814,7 @@ source: "https://docs.intuition.systems/docs/tutorials/queries/finding-top-dapps
 
 # Finding Top Dapps on Coinbase
 
-# Finding the Top dApps on Coinbase
+## Finding the Top dApps on Coinbase
 
 **Time to complete:** 30 minutes
 **Difficulty:** Beginner
@@ -7050,7 +6844,7 @@ source: "https://docs.intuition.systems/docs/tutorials/queries/discovering-most-
 
 # Discovering Most Trusted Accounts
 
-# Discovering the Most Trusted Accounts
+## Discovering the Most Trusted Accounts
 
 **Time to complete:** 45 minutes
 **Difficulty:** Intermediate


### PR DESCRIPTION
## Summary
- Clean `llms-full.txt` generation so page sections use a single `# Title` plus `Source: https://docs.intuition.systems/...` delimiter instead of per-page YAML metadata.
- Absolutize and canonicalize exported links, strip presentation-only MDX/HTML artifacts outside code fences, preserve fenced code including indented fences, and qualify generic reference headings.
- Fix stale source-doc links that were producing dead generated references, then regenerate `llms-full.txt` and `llms-medium.txt`.

## Validation
- `npm run generate-llms`
- `node --check scripts/generate-llms-full.js`
- generated-file spot check: `llms-full.txt` has `0` YAML metadata lines, `227` `Source:` lines, `0` relative links outside code, `0` raw artifact tags outside code, `0` heading-marker link labels, `0` body horizontal-rule delimiters, and `228` H1s including the preamble
- `npm run validate-links`
- `npm run validate-queries`
- `git diff --check`
- `npm run build` passes; Docusaurus still emits non-blocking HTML minifier/browser data warnings