### PR TITLE
fix(docs): correct protocol package name

### DIFF
--- a/src/faq.yaml
+++ b/src/faq.yaml
@@ -8,7 +8,7 @@
   answer: |
     1. Install the Protocol Package using npm:
        ```bash
-       npm install @intuition/protocol
+       npm install @0xintuition/protocol
        ```
     2. Create an account
     3. Start building with our guides and documentation


### PR DESCRIPTION
# fix(docs): correct protocol package name in FAQ

## Summary

Corrects the Protocol Package installation command in the FAQ.

## Changes

- Replaced `@intuition/protocol` with the correct package name, `@0xintuition/protocol`.

## Testing
- [x] Verified the FAQ contains the corrected npm command.
- [x] Ran `npm run validate-links` successfully; all 275 documentation files passed.
- [x] Ran `npm run build` successfully.
