### PR TITLE
fix(docs): correct browser extension links

### DIFF
--- a/docs/_data/experimental-applications/farcaster-frames.md
+++ b/docs/_data/experimental-applications/farcaster-frames.md
@@ -308,7 +308,7 @@ const claimFrame = {
 
 - [Portal](/docs/portal) - Main web interface for Intuition
 - [MetaMask Snap](/docs/experimental-applications/metamask-snap) - MetaMask integration
-- [Browser Extension](/docs/experimental-applications/metamask-snap) - Chrome extension
+- [Browser Extension](https://github.com/0xIntuition/chrome-extension) - Chrome extension
 - [Developer Tools](/docs/getting-started/developer-stack) - Programmatic access
 - [API Documentation](/docs/graphql-api/overview) - Technical guides
 - [Community](https://discord.gg/0xintuition) - Join the Intuition community

--- a/docs/_data/experimental-applications/metamask-snap.md
+++ b/docs/_data/experimental-applications/metamask-snap.md
@@ -288,7 +288,7 @@ The MetaMask Snap is open source and welcomes contributions:
 ## Related Resources
 
 - [Portal](/docs/portal) - Main web interface for Intuition
-- [Browser Extension](/docs/experimental-applications/metamask-snap) - Chrome extension for web browsing
+- [Browser Extension](https://github.com/0xIntuition/chrome-extension) - Chrome extension for web browsing
 - [Developer Tools](/docs/getting-started/developer-stack) - Programmatic access and integration
 - [API Documentation](/docs/graphql-api/overview) - Technical integration guides
 - [Community](https://discord.gg/0xintuition) - Join the Intuition community


### PR DESCRIPTION

# fix(docs): correct browser extension links

## Summary

Corrects the Browser Extension links in the experimental application documentation so they point to the extension's GitHub repository.

## Changes

- Updated the Browser Extension link in the MetaMask Snap documentation.
- Updated the Browser Extension link in the Farcaster Frames documentation.
- Replaced the incorrect MetaMask Snap route with `https://github.com/0xIntuition/chrome-extension`.

## Testing

- [x] Verified both Browser Extension links use the correct GitHub URL.
- [x] Ran `npm run validate-links` successfully; all 275 documentation files passed.
- [x] Ran `npm run build` successfully.