### PR TITLE
docs: correct staking currency from ETH to TRUST

### DIFF
--- a/docs/_data/experimental-applications/metamask-snap.md
+++ b/docs/_data/experimental-applications/metamask-snap.md
@@ -81,7 +81,7 @@ The MetaMask Snap serves as a bridge between traditional Web3 wallet functionali
 
 ### 💰 **Staking Operations**
 
-- Deposit ETH into atom and triple vaults
+- Deposit TRUST into atom and triple vaults
 - Withdraw staked amounts and earned fees
 - View staking history and performance metrics
 - Monitor vault share prices and market dynamics
@@ -150,7 +150,7 @@ The MetaMask Snap serves as a bridge between traditional Web3 wallet functionali
 
 1. **Create Your First Identity** - Use the Snap to create your first atom (identity)
 2. **Make Your First Claim** - Create a triple to make an assertion about something
-3. **Stake on Content** - Deposit ETH to signal agreement with existing claims
+3. **Stake on Content** - Deposit TRUST to signal agreement with existing claims
 4. **Build Your Network** - Follow other users and build your trust network
 
 ### Basic Workflow

--- a/docs/_data/graphql-api/queries/events/overview.md
+++ b/docs/_data/graphql-api/queries/events/overview.md
@@ -23,8 +23,8 @@ Events are blockchain log entries emitted by smart contracts. The Intuition inde
 
 - **AtomCreated**: New atoms minted
 - **TripleCreated**: New triples created
-- **Deposited**: ETH staked on positions
-- **Redeemed**: ETH withdrawn from positions
+- **Deposited**: TRUST staked on positions
+- **Redeemed**: TRUST withdrawn from positions
 - **FeesTransferred**: Protocol fees collected
 
 ## Quick Start

--- a/docs/_data/graphql-api/queries/signals/overview.md
+++ b/docs/_data/graphql-api/queries/signals/overview.md
@@ -22,7 +22,7 @@ Signals represent deposit and redemption events in the Intuition protocol. Unlik
 
 Signals are contextual representations of position changes:
 
-- **Deposits**: When an account stakes ETH on an atom or triple
+- **Deposits**: When an account stakes TRUST on an atom or triple
 - **Redemptions**: When an account withdraws from a position
 
 Each signal includes:
@@ -71,7 +71,7 @@ Signals don't have an explicit `type` field. Instead, distinguish deposits from 
 
 | Condition | Meaning |
 |-----------|---------|
-| `deposit_id` is not null | Deposit — staking ETH on a position |
+| `deposit_id` is not null | Deposit — staking TRUST on a position |
 | `redemption_id` is not null | Redemption — withdrawing from a position |
 
 ## Common Filters

--- a/docs/_data/intuition-concepts/primitives/index.md
+++ b/docs/_data/intuition-concepts/primitives/index.md
@@ -32,7 +32,7 @@ Structured relationships or claims linking entities together in Subject-Predicat
 <div className="uniform-card">
 <h2 className="uniform-card-title">Signals</h2>
 <p className="uniform-card-content">
-The weight of Atoms and Triples, derived from the total amount of ETH deposited in Atom and Triple Vaults. These represent the <strong>edge weights</strong> in the graph, or 'who is saying what about what, with what level of conviction'. The weight of trust or consensus behind each entity or claim, determined by community staking.
+The weight of Atoms and Triples, derived from the total amount of TRUST deposited in Atom and Triple Vaults. These represent the <strong>edge weights</strong> in the graph, or 'who is saying what about what, with what level of conviction'. The weight of trust or consensus behind each entity or claim, determined by community staking.
 </p>
 </div>
 

--- a/docs/_data/intuition-smart-contracts/index.md
+++ b/docs/_data/intuition-smart-contracts/index.md
@@ -15,8 +15,8 @@ Intuition's smart contracts are central to the user experience, handling critica
 The MultiVault contract is the core component of Intuition's architecture, responsible for managing the creation of Atoms/Triples and handling deposits, redemptions, and share distributions. It supports multiple bonding curve implementations through a registry system.
 
 - **Creation**: Users can create Atoms and Triples
-- **Deposits**: Users can deposit ETH to receive shares in atoms/triples
-- **Redemptions**: Users can redeem shares for ETH
+- **Deposits**: Users can deposit TRUST to receive shares in atoms/triples
+- **Redemptions**: Users can redeem shares for TRUST
 - **Multi-Vault**: Supports multiple bonding curve implementations
 - **Share Distribution**: Manages the minting and burning of shares
 - **Fee Collection**: Collects small fees to maintain the system

--- a/docs/_data/portal.md
+++ b/docs/_data/portal.md
@@ -60,7 +60,7 @@ Identities, also known as **Atoms**, are the fundamental building blocks in the 
 1. **Click the "Create" action button** in the bottom left section of the menu panel
 2. **Select "Create Identity"** from the dropdown menu
 3. **Input data** to describe the Identity you are creating
-4. **Optionally deposit ETH** to stake on your newly created Identity
+4. **Optionally deposit TRUST** to stake on your newly created Identity
 
 </div>
 
@@ -125,7 +125,7 @@ When you create an Identity, the data is uploaded to IPFS, generating an IPFS CI
   margin: '1.5rem 0'
 }}>
 
-**What is Staking?** Staking in Intuition allows you to signal what is important or what you believe to be true by staking ETH on Identities (Atoms) or Claims (Triples). This process contributes to a **Token Curated Registry (TCR)**, where the most relevant information rises to the top.
+**What is Staking?** Staking in Intuition allows you to signal what is important or what you believe to be true by staking TRUST on Identities (Atoms) or Claims (Triples). This process contributes to a **Token Curated Registry (TCR)**, where the most relevant information rises to the top.
 
 ### **Staking on an Identity:**
 
@@ -159,7 +159,7 @@ When you create an Identity, the data is uploaded to IPFS, generating an IPFS CI
 
 ### **Unstaking:**
 
-You can unstake your ETH at any time to retrieve your deposit (minus fees).
+You can unstake your TRUST at any time to retrieve your deposit (minus fees).
 
 ### **Staking Economics:**
 
@@ -236,7 +236,7 @@ Staking grants you shares that provide a proportionate amount of fee revenue acc
 }}>
 
 - Use the **"Add to list"** and **"Save list"** buttons to manage your Lists
-- Lists are **Token Curated Registries (TCR)**, where you can stake ETH to order entries within a List
+- Lists are **Token Curated Registries (TCR)**, where you can stake TRUST to order entries within a List
 
 </div>
 
@@ -264,8 +264,8 @@ Staking grants you shares that provide a proportionate amount of fee revenue acc
   margin: '1rem 0'
 }}>
 
-- **To follow**: Click on a user's profile and select "Follow," then optionally stake ETH
-- **To unfollow**: Click "Following" on the user's profile and select "Unfollow." Unfollowing also redeems your staked ETH
+- **To follow**: Click on a user's profile and select "Follow," then optionally stake TRUST
+- **To unfollow**: Click "Following" on the user's profile and select "Unfollow." Unfollowing also redeems your staked TRUST
 
 </div>
 

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -357,7 +357,7 @@ const triple = await createTripleStatement(
       predicate.state.termId,
       object.state.termId
     ],
-    value: 1000000000000000000n, // 1 ETH deposit in wei
+    value: 1000000000000000000n, // 1 TRUST deposit in wei
   }
 )
 
@@ -456,7 +456,7 @@ function IntuitionQuickstart() {
   const signalAtom = async () => {
     if (!atomId) return
 
-    const depositAmount = 100000000000000000n // 0.1 ETH
+    const depositAmount = 100000000000000000n // 0.1 TRUST
     await deposit(
       { walletClient, publicClient, address },
       {
@@ -513,7 +513,7 @@ const atomData = [
 const result = await batchCreateAtomsFromThings(
   { walletClient, publicClient, address },
   atomData,
-  1000000000000000000n // Optional: 1 ETH deposit per atom
+  1000000000000000000n // Optional: 1 TRUST deposit per atom
 )
 
 console.log('Created atoms:', result.state)
@@ -537,7 +537,7 @@ const tripleData = [
 const result = await batchCreateTripleStatements(
   { walletClient, publicClient, address },
   tripleData,
-  1000000000000000000n // Optional: 1 ETH deposit
+  1000000000000000000n // Optional: 1 TRUST deposit
 )
 
 console.log('Created triples:', result.state)


### PR DESCRIPTION
## Summary

Corrects staking and deposit documentation to identify TRUST—not ETH—as the native currency used by the current Intuition Network and MultiVault deployment.

## Why This Changed

The protocol migrated in August 2025 from the Base-based `EthMultiVault`, where deposits were denominated in ETH, to the current Intuition Network `MultiVault`, where payable deposits use the network's native TRUST currency. Several current and general documentation pages retained terminology from the earlier deployment.

## Changes

- Replaced 19 staking- and deposit-specific references to ETH with TRUST across seven current documentation pages.
- Updated deposit, redemption, signal, Portal, contract overview, and SDK example wording.
- Preserved unrelated Ethereum references and legacy or deployment-ambiguous pages.

## Testing

- [x] Ran `npm run validate-links` successfully; all 275 documentation files passed.
- [x] Ran `npm run build` successfully.
- [x] Confirmed the commit contains exactly 19 replacements across seven files.


