### PR TITLE
docs: use verified /ws WebSocket endpoints in network tables

### DIFF
--- a/docs/_data/intuition-smart-contracts/deployments.md
+++ b/docs/_data/intuition-smart-contracts/deployments.md
@@ -69,14 +69,14 @@ The Intuition protocol contracts are deployed on both the Base Mainnet and the I
 ### Intuition Mainnet Configuration
 - **Chain ID**: 1155
 - **RPC URL**: `https://rpc.intuition.systems`
-- **WebSocket**: `wss://rpc.intuition.systems`
+- **WebSocket**: `wss://rpc.intuition.systems/ws`
 - **Explorer**: `https://explorer.intuition.systems/`
 - **Native Token**: $TRUST
 
 ### Intuition Testnet Configuration
 - **Chain ID**: 13579
 - **RPC URL**: `https://testnet.rpc.intuition.systems`
-- **WebSocket**: `wss://testnet.rpc.intuition.systems`
+- **WebSocket**: `wss://testnet.rpc.intuition.systems/ws`
 - **Explorer**: `https://testnet.explorer.intuition.systems/`
 - **Native Token**: $tTRUST
 

--- a/docs/_data/quick-start/deployments.md
+++ b/docs/_data/quick-start/deployments.md
@@ -69,14 +69,14 @@ The Intuition protocol contracts are deployed on both the Base Mainnet and the I
 ### Intuition Mainnet Configuration
 - **Chain ID**: 1155
 - **RPC URL**: `https://rpc.intuition.systems`
-- **WebSocket**: `wss://rpc.intuition.systems`
+- **WebSocket**: `wss://rpc.intuition.systems/ws`
 - **Explorer**: `https://explorer.intuition.systems/`
 - **Native Token**: $TRUST
 
 ### Intuition Testnet Configuration
 - **Chain ID**: 13579
 - **RPC URL**: `https://testnet.rpc.intuition.systems`
-- **WebSocket**: `wss://testnet.rpc.intuition.systems`
+- **WebSocket**: `wss://testnet.rpc.intuition.systems/ws`
 - **Explorer**: `https://testnet.explorer.intuition.systems/`
 - **Native Token**: $tTRUST
 

--- a/docs/_data/quick-start/network-details.md
+++ b/docs/_data/quick-start/network-details.md
@@ -39,14 +39,14 @@ You can visit the [Intuition Testnet faucet](https://testnet.hub.intuition.syste
 ### Intuition Mainnet Configuration
 - **Chain ID**: 1155
 - **RPC URL**: `https://rpc.intuition.systems`
-- **WebSocket**: `wss://rpc.intuition.systems`
+- **WebSocket**: `wss://rpc.intuition.systems/ws`
 - **Explorer**: `https://explorer.intuition.systems/`
 - **Native Token**: $TRUST
 
 ### Intuition Testnet Configuration
 - **Chain ID**: 13579
 - **RPC URL**: `https://testnet.rpc.intuition.systems`
-- **WebSocket**: `wss://testnet.rpc.intuition.systems`
+- **WebSocket**: `wss://testnet.rpc.intuition.systems/ws`
 - **Explorer**: `https://testnet.explorer.intuition.systems/`
 - **Native Token**: $tTRUST
 


### PR DESCRIPTION
## What

Appends `/ws` to the six bare WebSocket RPC URLs that fail the upgrade handshake, matching the already-correct values on the network reference pages:

- `docs/_data/quick-start/network-details.md` (mainnet + testnet rows)
- `docs/_data/quick-start/deployments.md` (mainnet + testnet rows)
- `docs/_data/intuition-smart-contracts/deployments.md` (mainnet + testnet rows — found by repo-wide sweep)

## Why

The bare hosts answer a WebSocket upgrade with plain HTTP 200; only the `/ws` paths complete the `101 Switching Protocols` handshake. This aligns the remaining tables with the network reference pages, which already use the working form.

## Verification

- Live upgrade probes (HTTP/1.1 + full upgrade headers), run three independent times: bare hosts → 200, both `/ws` endpoints → 101. Note for future probes: `curl` must be forced to `--http1.1` — HTTP/2 negotiation rejects upgrade headers with a false 400.
- Functional JSON-RPC over live WebSocket connections: `eth_chainId` returns `0x483` (1155) on mainnet and `0x350b` (13579) on testnet, matching the documented chain IDs.
- Repo-wide search confirms zero remaining bare occurrences of either RPC WSS host in `docs/`, `src/`, or config; the `wss://*.intuition.sh/v1/graphql` GraphQL subscription endpoints are a different service and intentionally untouched.
- `npm run validate-links`: 276 files, zero broken links. `git diff --check`: clean.
- Independent review pass confirmed the diff is exactly these six line changes with surrounding chain IDs/RPC/explorer claims untouched.
- `static/llms-full.txt` / `llms-medium.txt` still show the old URLs by design — CI regenerates them on merge; they are deliberately not hand-edited here.