### PR TITLE
docs: replace dead GraphQL example fixture with live-verified address

### DIFF
--- a/docs/_data/graphql-api/examples/social-graph.md
+++ b/docs/_data/graphql-api/examples/social-graph.md
@@ -46,7 +46,7 @@ export const socialQueries = [
   }
 }`,
     variables: {
-      address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+      address: '0x88D0aF73508452c1a453356b3Fac26525aEc23A2',
       limit: 20
     }
   }

--- a/docs/_data/graphql-api/examples/subscriptions.md
+++ b/docs/_data/graphql-api/examples/subscriptions.md
@@ -44,7 +44,7 @@ export const subscriptionQueries = [
         initial_value: { created_at: '2024-12-01T00:00:00Z' },
         ordering: 'ASC'
       }],
-      accountId: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+      accountId: '0x88D0aF73508452c1a453356b3Fac26525aEc23A2',
       batchSize: 10
     }
   }

--- a/docs/_data/graphql-api/examples/user-positions.md
+++ b/docs/_data/graphql-api/examples/user-positions.md
@@ -12,6 +12,10 @@ import GraphQLPlaygroundCustom from '@site/src/components/GraphQLPlaygroundCusto
 
 Fetch user positions with aggregate statistics.
 
+This example uses a live-verified account with populated positions; position counts and values change over time.
+
+Account IDs are stored in EIP-55 checksummed form and `_eq` comparisons are case-sensitive — pass the address exactly as checksummed (as shown below), or the query silently returns empty results.
+
 ## Query
 
 export const userPositionQueries = [
@@ -43,7 +47,7 @@ export const userPositionQueries = [
   }
 }`,
     variables: {
-      accountId: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+      accountId: '0x88D0aF73508452c1a453356b3Fac26525aEc23A2',
       limit: 20
     }
   }


### PR DESCRIPTION
## What

Replaces the sample account address in three GraphQL API examples (`user-positions`, `social-graph`, `subscriptions`) — the previous fixture address returns zero positions on live mainnet, so the examples looked broken to first-time readers. Adds two notes to the user-positions example: results change over time, and account IDs are matched case-sensitively in EIP-55 checksummed form.

## Why

A correct query returning an empty array is indistinguishable from a wrong query for someone learning the API. The old address is genuinely inactive (verified in both lowercase and checksummed forms); the replacement address currently holds 1,200+ positions and a populated social graph.

## Verification

- All three documented query shapes run against live mainnet with the new address return populated results (positions count 1204; following count 13; live subscription delivers immediate payloads). The old address returns empty across all three.
- Case-sensitivity note verified live: checksummed form returns data; lowercase/uppercase forms silently return empty with no error — exactly as the note states.
- No fabricated output blocks added; `npm run validate-queries` passes (238 queries, 464 routed validations) and `npm run validate-links` passes.
- Independent review confirmed the diff is exactly three address swaps plus two prose notes, with no in-scope residue of the old address.