### PR TITLE
docs: make SDK examples truthful against the published v3 packages

### DIFF
--- a/docs/_data/interaction-guide/create-atom.md
+++ b/docs/_data/interaction-guide/create-atom.md
@@ -8,190 +8,98 @@ description: Learn how to create atoms and manage their associated vaults
 
 # Create Atom
 
-Creating atoms in the Intuition protocol involves interacting with the EthMultiVault contract to establish new entities in the knowledge graph. This process includes creating the atom itself and managing its associated vault.
+Atoms are created through the deployed `MultiVault.createAtoms` entry point. Although the contract function accepts arrays, the same function is used for both single and batch creation.
 
 ## Prerequisites
 
-This implementation guide assumes that you've completed the setup steps in the [Overview](/docs/interaction-guide/overview) guide. Steps for creating the `createMultivaultContract` and the `publicClient` referenced in this implementation example can be found in the overview.
+Complete the client and contract-address setup in the [Overview](/docs/interaction-guide/overview) guide. The examples below expect a `publicClient`, a connected `walletClient`, and the deployed MultiVault `address` for the selected Intuition network.
+
+## Cost Semantics
+
+Read the current atom base cost immediately before creating an atom. The protocol can change this value, so it must not be hardcoded or treated as a fixed fee.
+
+The value assigned to one atom is:
+
+```text
+assets = current atom base cost + optional additional deposit
+```
+
+The optional amount is an additional TRUST/tTRUST deposit (signal). It does not replace the required base cost. Both the per-atom `assets` entry and transaction `value` must include the full amount.
 
 ## Implementation
 
-We recommend creating a `multivault.ts` that includes the following atom creation functionality:
+Use the protocol helpers to read the cost, simulate and submit `createAtoms`, and parse the resulting `AtomCreated` event:
 
-<div style={{ backgroundColor: 'var(--ifm-color-emphasis-50)', padding: '1.5rem', borderRadius: '8px', marginTop: '2rem', marginBottom: '2rem' }}>
-<h3 style={{ marginTop: 0, marginBottom: '1rem' }}>Core Atom Creation Pattern</h3>
-<div style={{ backgroundColor: 'var(--ifm-background-color)', padding: '1rem', borderRadius: '6px', border: '1px solid var(--ifm-color-emphasis-300)' }}>
-<pre style={{ margin: 0, fontSize: '0.9rem', fontFamily: 'monospace' }}>
-{`// Create atom with initial deposit
-const createAtomConfig = {
-  ...multiVaultContract,
-  functionName: 'createAtom',
-  args: [atomData, initialDeposit],
-}
+```typescript title="multivault.ts"
+import {
+  eventParseAtomCreated,
+  multiVaultCreateAtoms,
+  multiVaultGetAtomCost,
+  type WriteConfig,
+} from '@0xintuition/protocol'
+import { toHex } from 'viem'
 
-// Execute transaction
-const hash = await walletClient.writeContract(createAtomConfig)
-
-// Wait for confirmation
-const receipt = await publicClient.waitForTransactionReceipt({ hash })`}
-</pre>
-</div>
-</div>
-
-## Complete Example
-
-Here is a full example of the atom creation pattern used in the `createAtom` function:
-
-<div style={{ backgroundColor: 'var(--ifm-color-emphasis-50)', padding: '1.5rem', borderRadius: '8px', marginTop: '2rem', marginBottom: '2rem' }}>
-<h3 style={{ marginTop: 0, marginBottom: '1rem' }}>Full Implementation</h3>
-<div style={{ backgroundColor: 'var(--ifm-background-color)', padding: '1rem', borderRadius: '6px', border: '1px solid var(--ifm-color-emphasis-300)' }}>
-<pre style={{ margin: 0, fontSize: '0.9rem', fontFamily: 'monospace' }}>
-{`export async function createAtom(
-  contract: string,
+export async function createAtom(
+  config: WriteConfig,
   atomData: string,
-  initialDeposit: bigint,
-  walletClient: WalletClient,
-  publicClient: PublicClient
+  additionalDeposit = 0n,
 ) {
-  const multiVaultContract = createMultiVaultContract(contract)
+  const { address, publicClient } = config
 
-  // Prepare atom creation transaction
-  const createAtomConfig = {
-    ...multiVaultContract,
-    functionName: 'createAtom',
-    args: [atomData, initialDeposit],
+  // Fetch the live protocol requirement instead of hardcoding it.
+  const atomBaseCost = await multiVaultGetAtomCost({ address, publicClient })
+  const assets = atomBaseCost + additionalDeposit
+
+  const transactionHash = await multiVaultCreateAtoms(config, {
+    args: [[toHex(atomData)], [assets]],
+    value: assets,
+  })
+
+  const [created] = await eventParseAtomCreated(publicClient, transactionHash)
+  if (!created) {
+    throw new Error(`No AtomCreated event found for ${transactionHash}`)
   }
 
-  try {
-    // Execute the transaction
-    const hash = await walletClient.writeContract(createAtomConfig)
-    
-    // Wait for transaction confirmation
-    const receipt = await publicClient.waitForTransactionReceipt({ hash })
-    
-    // Parse events to get atom ID
-    const atomCreatedEvent = receipt.logs.find(
-      log => log.eventName === 'AtomCreated'
-    )
-    
-    if (!atomCreatedEvent) {
-      throw new Error('Atom creation event not found')
-    }
-    
-    const atomId = atomCreatedEvent.args.atomId
-    const vaultId = atomCreatedEvent.args.vaultId
-    
-    return {
-      success: true,
-      atomId,
-      vaultId,
-      transactionHash: hash,
-      receipt
-    }
-  } catch (error) {
-    return {
-      success: false,
-      error: error.message
-    }
+  return {
+    transactionHash,
+    termId: created.args.termId,
+    atomWallet: created.args.atomWallet,
   }
-}`}
-</pre>
-</div>
-</div>
-
-## Key Functions
-
-We use this pattern to create atoms and manage their lifecycle:
-
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: '1rem', marginTop: '2rem', marginBottom: '2rem' }}>
-
-<div style={{ border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '6px', padding: '1rem', backgroundColor: 'var(--ifm-background-color)' }}>
-<h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>createAtom</h4>
-<p style={{ margin: 0, fontSize: '0.9rem' }}>
-Creates a new atom with optional initial deposit and returns atom/vault IDs.
-</p>
-</div>
-
-<div style={{ border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '6px', padding: '1rem', backgroundColor: 'var(--ifm-background-color)' }}>
-<h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>validateAtomData</h4>
-<p style={{ margin: 0, fontSize: '0.9rem' }}>
-Validates atom data format and ensures it meets protocol requirements.
-</p>
-</div>
-
-<div style={{ border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '6px', padding: '1rem', backgroundColor: 'var(--ifm-background-color)' }}>
-<h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>estimateAtomCost</h4>
-<p style={{ margin: 0, fontSize: '0.9rem' }}>
-Estimates the cost of creating an atom including fees and gas costs.
-</p>
-</div>
-
-</div>
+}
+```
 
 ## Usage Example
 
-<div style={{ backgroundColor: 'var(--ifm-color-emphasis-50)', padding: '1.5rem', borderRadius: '8px', marginTop: '2rem', marginBottom: '2rem' }}>
-<h3 style={{ marginTop: 0, marginBottom: '1rem' }}>Basic Atom Creation</h3>
-<div style={{ backgroundColor: 'var(--ifm-background-color)', padding: '1rem', borderRadius: '6px', border: '1px solid var(--ifm-color-emphasis-300)' }}>
-<pre style={{ margin: 0, fontSize: '0.9rem', fontFamily: 'monospace' }}>
-{`// Create a new atom
-const atomData = "did:ethr:mainnet:0x1234567890abcdef"
-const initialDeposit = parseEther("0.1")
+Pass `0n` or omit the third argument to create the atom with only its current base cost. Pass an amount to add signal at creation time:
 
-const result = await createAtom(
-  MULTIVAULT_CONTRACT_ADDRESS,
-  atomData,
-  initialDeposit,
-  walletClient,
-  publicClient
-)
+```typescript
+import type { WriteConfig } from '@0xintuition/protocol'
+import { parseEther } from 'viem'
+import { createAtom } from './multivault'
 
-if (result.success) {
-  console.log({
-    atomId: result.atomId,
-    vaultId: result.vaultId,
-    transactionHash: result.transactionHash
-  })
-} else {
-  console.error('Atom creation failed:', result.error)
-}`}
-</pre>
-</div>
-</div>
+async function createExample(config: WriteConfig) {
+  const created = await createAtom(
+    config,
+    'did:ethr:mainnet:0x1234567890abcdef',
+    parseEther('0.1'), // Optional additional TRUST/tTRUST signal
+  )
 
-## Error Handling
+  console.log('Atom term ID:', created.termId)
+  console.log('Atom wallet:', created.atomWallet)
+  console.log('Transaction:', created.transactionHash)
+}
+```
 
-<div style={{ backgroundColor: 'var(--ifm-color-emphasis-50)', padding: '1.5rem', borderRadius: '8px', marginTop: '2rem', marginBottom: '2rem' }}>
-<h3 style={{ marginTop: 0, marginBottom: '1rem' }}>Common Error Scenarios</h3>
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: '1rem' }}>
-<div style={{ border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '6px', padding: '1rem', backgroundColor: 'var(--ifm-background-color)' }}>
-<h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>Insufficient Funds</h4>
-<p style={{ margin: 0, fontSize: '0.9rem' }}>
-Ensure wallet has sufficient ETH for gas and deposit amount.
-</p>
-</div>
-<div style={{ border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '6px', padding: '1rem', backgroundColor: 'var(--ifm-background-color)' }}>
-<h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>Invalid Atom Data</h4>
-<p style={{ margin: 0, fontSize: '0.9rem' }}>
-Validate atom data format before submission.
-</p>
-</div>
-<div style={{ border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '6px', padding: '1rem', backgroundColor: 'var(--ifm-background-color)' }}>
-<h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>Network Issues</h4>
-<p style={{ margin: 0, fontSize: '0.9rem' }}>
-Handle RPC failures and network connectivity issues.
-</p>
-</div>
-</div>
-</div>
+For the higher-level SDK equivalent, `createAtomFromString` and its sibling atom helpers perform the same dynamic base-cost read internally.
 
 ## Best Practices
 
-- Always validate atom data before submission
-- Estimate costs before executing transactions
-- Implement proper error handling and user feedback
-- Use multicall patterns for batch operations
-- Monitor transaction status and provide confirmation feedback
+- Fetch the base cost immediately before submitting the transaction.
+- Keep `args[1][0]` and `value` equal for a single atom.
+- Treat an optional amount as additional signal, not as the base cost.
+- Display amounts in TRUST on Mainnet and tTRUST on Intuition Testnet.
+- Parse `AtomCreated.termId`; the current event does not return legacy `atomId` or `vaultId` fields.
+- Surface simulation, insufficient-balance, RPC, and reverted-transaction errors to the user.
 
 ## Next Steps
 
@@ -201,4 +109,4 @@ After creating atoms, explore:
 - [Deposit & Return](/docs/interaction-guide/deposit-return) - Manage vault deposits and withdrawals
 - [Retrieve Vault Details](/docs/interaction-guide/retrieve-vault-details) - Get comprehensive vault information
 
-For a full reference implementation, see the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts). 
+For a full reference implementation, see the [Intuition TypeScript SDK](https://github.com/0xIntuition/intuition-ts).

--- a/docs/_data/intuition-sdk/atoms-guide.md
+++ b/docs/_data/intuition-sdk/atoms-guide.md
@@ -530,11 +530,14 @@ import { getAtomDetails } from '@0xintuition/sdk';
 
 const atomId = '0x1234567890abcdef...';
 const details = await getAtomDetails(atomId);
+if (!details) throw new Error('Atom not found');
+
+const vault = details.term?.vaults[0];
 
 console.log('Atom Label:', details.label);
-console.log('Creator:', details.creator);
-console.log('Vault Shares:', details.vault.totalShares);
-console.log('Share Price:', details.vault.currentSharePrice);
+console.log('Creator:', details.creator?.label ?? details.creator_id);
+console.log('Vault Shares:', vault?.total_shares);
+console.log('Share Price:', vault?.current_share_price);
 ```
 
 ### calculateAtomId

--- a/docs/_data/intuition-sdk/atoms-guide.md
+++ b/docs/_data/intuition-sdk/atoms-guide.md
@@ -145,7 +145,15 @@ await createAtomFromString(config, 'dev');
 Before creating an atom, check if it already exists:
 
 ```typescript
-import { calculateAtomId, getAtomDetails } from '@0xintuition/sdk';
+import {
+  calculateAtomId,
+  configureSdk,
+  createAtomFromString,
+  getAtomDetails,
+} from '@0xintuition/sdk';
+import { API_URL_DEV } from '@0xintuition/graphql';
+
+configureSdk({ apiUrl: API_URL_DEV });
 
 const atomId = calculateAtomId('developer');
 const exists = await getAtomDetails(atomId);
@@ -577,25 +585,29 @@ console.log('IPFS Atom ID:', ipfsAtomId);
 ```typescript
 import {
   calculateAtomId,
+  configureSdk,
   getAtomDetails,
   createAtomFromString,
 } from '@0xintuition/sdk';
+import { API_URL_DEV } from '@0xintuition/graphql';
+
+configureSdk({ apiUrl: API_URL_DEV });
 
 async function createAtomIfNotExists(data: string) {
   // Calculate ID
   const atomId = calculateAtomId(data);
 
-  try {
-    // Check if exists
-    const existing = await getAtomDetails(atomId);
+  // Check if exists
+  const existing = await getAtomDetails(atomId);
+  if (existing !== null) {
     console.log('Atom already exists:', atomId);
     return existing;
-  } catch (error) {
-    // Doesn't exist, create it
-    console.log('Creating new atom');
-    const atom = await createAtomFromString(config, data);
-    return atom;
   }
+
+  // Doesn't exist, create it
+  console.log('Creating new atom');
+  const atom = await createAtomFromString(config, data);
+  return atom;
 }
 ```
 
@@ -608,7 +620,15 @@ async function getMultipleAtoms(atomIds: string[]) {
   const atoms = await Promise.all(atomIds.map((id) => getAtomDetails(id)));
 
   atoms.forEach((atom) => {
-    console.log(`${atom.label}: ${atom.vault.totalShares} shares`);
+    if (atom === null) return;
+
+    const vault = atom.term?.vaults[0];
+    if (!vault) {
+      console.log(`${atom.label}: no vault data`);
+      return;
+    }
+
+    console.log(`${atom.label}: ${vault.total_shares} shares`);
   });
 
   return atoms;

--- a/docs/_data/intuition-sdk/atoms-guide.md
+++ b/docs/_data/intuition-sdk/atoms-guide.md
@@ -11,6 +11,19 @@ description: Create and query atoms using the SDK
 
 Atoms are unique identifiers for any entity—people, concepts, smart contracts, or data. This guide covers all ways to create and query atoms using the SDK.
 
+:::info Match SDK reads to your network
+SDK read helpers use the mainnet GraphQL API by default. The write examples on this page use Intuition Testnet, so configure reads once before calling a read helper:
+
+```typescript
+import { configureSdk } from '@0xintuition/sdk';
+import { API_URL_DEV } from '@0xintuition/graphql';
+
+configureSdk({ apiUrl: API_URL_DEV });
+```
+:::
+
+Atom creation helpers dynamically fetch and forward the required atom base cost. Their optional amount is an additional TRUST/tTRUST deposit (signal), not the required base cost.
+
 ## Table of Contents
 
 - [Creating from Strings](#creating-from-strings)
@@ -33,7 +46,7 @@ The simplest way to create an atom is from a plain string.
 function createAtomFromString(
   config: WriteConfig,
   data: string,
-  deposit?: bigint,
+  depositAmount?: bigint,
 ): Promise<AtomCreationResult>;
 ```
 
@@ -43,7 +56,7 @@ function createAtomFromString(
 | --------- | ------------- | --------------------------------------------------------------------- | -------- |
 | `config`  | `WriteConfig` | Client configuration with wallet, public client, and contract address | Yes      |
 | `data`    | `string`      | The text string to create an atom from                                | Yes      |
-| `deposit` | `bigint`      | Optional initial deposit amount in wei                                | No       |
+| `depositAmount` | `bigint` | Optional additional deposit/signal amount in wei                 | No       |
 
 ### Basic Example
 
@@ -73,7 +86,7 @@ const address = getMultiVaultAddressFromChainId(intuitionTestnet.id);
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
   'developer',
-  parseEther('0.01'), // Optional: 0.01 TRUST initial deposit
+  parseEther('0.01'), // Optional: additional 0.01 tTRUST signal
 );
 
 console.log('Atom ID:', atom.state.termId);

--- a/docs/_data/intuition-sdk/atoms-guide.md
+++ b/docs/_data/intuition-sdk/atoms-guide.md
@@ -528,7 +528,7 @@ Fetch comprehensive atom details from the Intuition API.
 #### Function Signature
 
 ```typescript
-function getAtomDetails(atomId: string): Promise<AtomDetails>;
+function getAtomDetails(atomId: string): Promise<AtomDetails | null>;
 ```
 
 #### Basic Example

--- a/docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md
+++ b/docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md
@@ -14,15 +14,19 @@ This example demonstrates using the experimental `sync` function to estimate cos
 
 ```typescript
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   sync,
 } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { createPublicClient, createWalletClient, http, formatEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 async function main() {
-  // Setup
+  // Setup — sync() reads existing atoms/triples via GraphQL, which defaults
+  // to mainnet; pair its reads with the testnet write chain.
+  configureSdk({ apiUrl: API_URL_DEV })
   const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
   const publicClient = createPublicClient({
     chain: intuitionTestnet,

--- a/docs/_data/intuition-sdk/examples/create-atom-from-string.md
+++ b/docs/_data/intuition-sdk/examples/create-atom-from-string.md
@@ -10,22 +10,28 @@ keywords: [sdk, example, atom, create, string, tutorial]
 
 This example demonstrates creating an atom from a plain text string, including setup, error handling, and querying the result.
 
+SDK reads default to the mainnet GraphQL API, so the example explicitly selects the testnet API to match its write chain. `createAtomFromString` fetches and forwards the required atom base cost; `additionalDeposit` is extra tTRUST signal, not the base cost.
+
 ## Complete Code
 
 ```typescript
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   createAtomFromString,
   getAtomDetails,
   wait,
 } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { createPublicClient, createWalletClient, http, parseEther, formatEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 async function main() {
   // 1. Setup account and clients
   const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+  // SDK reads default to mainnet; keep reads paired with the testnet write chain.
+  configureSdk({ apiUrl: API_URL_DEV })
 
   const publicClient = createPublicClient({
     chain: intuitionTestnet,
@@ -53,15 +59,15 @@ async function main() {
 
   // 3. Create atom
   const atomData = 'TypeScript'
-  const depositAmount = parseEther('0.01')
+  const additionalDeposit = parseEther('0.01')
 
   console.log(`\nCreating atom: "${atomData}"`)
-  console.log('Deposit:', formatEther(depositAmount), 'tTRUST')
+  console.log('Additional signal:', formatEther(additionalDeposit), 'tTRUST')
 
   const atom = await createAtomFromString(
     { walletClient, publicClient, address },
     atomData,
-    depositAmount
+    additionalDeposit
   )
 
   console.log('\n✓ Atom created successfully!')
@@ -80,13 +86,16 @@ async function main() {
   // 5. Query atom details
   console.log('Fetching atom details...')
   const details = await getAtomDetails(atom.state.termId)
+  if (!details) throw new Error('Created atom was not found on the testnet API')
+
+  const vault = details.term?.vaults[0]
 
   console.log('\n✓ Atom Details:')
   console.log('  Label:', details.label)
-  console.log('  Creator:', details.creator)
-  console.log('  Total Shares:', details.vault.totalShares)
-  console.log('  Share Price:', details.vault.currentSharePrice)
-  console.log('  Positions:', details.vault.positionCount)
+  console.log('  Creator:', details.creator?.label ?? details.creator_id)
+  console.log('  Total Shares:', vault?.total_shares)
+  console.log('  Share Price:', vault?.current_share_price)
+  console.log('  Positions:', vault?.position_count)
 
   console.log('\nSuccess!')
 }
@@ -117,7 +126,7 @@ Account: 0xYourAddress
 Balance: 10.5 tTRUST
 
 Creating atom: "TypeScript"
-Deposit: 0.01 tTRUST
+Additional signal: 0.01 tTRUST
 
 ✓ Atom created successfully!
   Atom ID: 0x1234567890abcdef...

--- a/docs/_data/intuition-sdk/examples/create-triple-statement.md
+++ b/docs/_data/intuition-sdk/examples/create-triple-statement.md
@@ -10,10 +10,13 @@ keywords: [sdk, example, triple, statement, relationship]
 
 This example demonstrates creating a complete triple (subject-predicate-object statement).
 
+SDK reads default to the mainnet GraphQL API. This example configures the testnet API before querying the triple it creates on Intuition Testnet.
+
 ## Complete Code
 
 ```typescript
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   createAtomFromString,
@@ -21,12 +24,16 @@ import {
   getTripleDetails,
   wait,
 } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 async function main() {
   // Setup
   const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+  // SDK reads default to mainnet; keep reads paired with the testnet write chain.
+  configureSdk({ apiUrl: API_URL_DEV })
+
   const publicClient = createPublicClient({
     chain: intuitionTestnet,
     transport: http(),
@@ -77,7 +84,7 @@ async function main() {
     }
   )
 
-  const tripleId = triple.state[0].args.tripleId
+  const tripleId = triple.state[0].args.termId
   console.log('✓ Triple created!')
   console.log('  Triple ID:', tripleId)
   console.log('  Transaction:', triple.transactionHash)
@@ -87,13 +94,17 @@ async function main() {
   await wait(triple.transactionHash)
 
   const details = await getTripleDetails(tripleId)
+  if (!details) throw new Error('Created triple was not found on the testnet API')
+
+  const forVault = details.term?.vaults[0]
+  const againstVault = details.counter_term?.vaults[0]
 
   console.log('\n=== Triple Details ===')
-  console.log('Subject:', details.subject.label)
-  console.log('Predicate:', details.predicate.label)
-  console.log('Object:', details.object.label)
-  console.log('\nFOR Position Shares:', details.vault.totalShares)
-  console.log('AGAINST Position Shares:', details.counterVault.totalShares)
+  console.log('Subject:', details.subject?.label)
+  console.log('Predicate:', details.predicate?.label)
+  console.log('Object:', details.object?.label)
+  console.log('\nFOR Position Shares:', forVault?.total_shares)
+  console.log('AGAINST Position Shares:', againstVault?.total_shares)
 
   console.log('\nSuccess!')
 }

--- a/docs/_data/intuition-sdk/examples/find-existing-entities.md
+++ b/docs/_data/intuition-sdk/examples/find-existing-entities.md
@@ -10,10 +10,13 @@ keywords: [sdk, example, search, find, atoms, triples, exists]
 
 This example demonstrates how to find existing atoms and triples to avoid creating duplicates.
 
+SDK reads default to the mainnet GraphQL API. This flow both reads and writes on Intuition Testnet, so it configures the testnet API before its first lookup; optional atom amounts are additional tTRUST signal because the SDK fetches the required base cost automatically.
+
 ## Complete Code
 
 ```typescript
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   findAtomIds,
@@ -23,6 +26,7 @@ import {
   createAtomFromString,
   createTripleStatement,
 } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import type { Hex } from 'viem'
@@ -30,6 +34,9 @@ import type { Hex } from 'viem'
 async function main() {
   // Setup
   const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+  // SDK reads default to mainnet; keep reads paired with the testnet write chain.
+  configureSdk({ apiUrl: API_URL_DEV })
+
   const publicClient = createPublicClient({
     chain: intuitionTestnet,
     transport: http(),
@@ -121,7 +128,7 @@ async function main() {
       }
     )
 
-    console.log('✓ Triple created:', triple.state[0].args.tripleId)
+    console.log('✓ Triple created:', triple.state[0].args.termId)
   }
 
   // 4. Calculate IDs offline

--- a/docs/_data/intuition-sdk/examples/global-search.md
+++ b/docs/_data/intuition-sdk/examples/global-search.md
@@ -10,12 +10,18 @@ keywords: [sdk, example, search, global, query]
 
 This example demonstrates using global search to find entities across the Intuition protocol.
 
+SDK reads use the mainnet GraphQL API by default. The example selects `API_URL_DEV` for testnet data; use `API_URL_PROD` instead for Mainnet.
+
 ## Complete Code
 
 ```typescript
-import { globalSearch, getAtomDetails } from '@0xintuition/sdk'
+import { configureSdk, globalSearch, getAtomDetails } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 
 async function main() {
+  // Reads default to mainnet. Select API_URL_DEV for testnet data.
+  configureSdk({ apiUrl: API_URL_DEV })
+
   const searchQuery = 'ethereum'
 
   console.log(`Searching for: "${searchQuery}"\n`)
@@ -38,7 +44,7 @@ async function main() {
   console.log(`Found ${results.atoms.length} atoms:\n`)
   results.atoms.forEach((atom, i) => {
     console.log(`${i + 1}. ${atom.label}`)
-    console.log(`   ID: ${atom.id}`)
+    console.log(`   ID: ${atom.term_id}`)
   })
 
   // Display accounts
@@ -53,19 +59,22 @@ async function main() {
   console.log('\n=== Triples ===')
   console.log(`Found ${results.triples.length} triples:\n`)
   results.triples.forEach((triple, i) => {
-    console.log(`${i + 1}. ${triple.subject.label} ${triple.predicate.label} ${triple.object.label}`)
-    console.log(`   ID: ${triple.id}`)
+    console.log(`${i + 1}. ${triple.subject?.label} ${triple.predicate?.label} ${triple.object?.label}`)
+    console.log(`   ID: ${triple.term_id}`)
   })
 
   // Get details for first atom
   if (results.atoms.length > 0) {
     console.log('\n=== First Atom Details ===')
-    const details = await getAtomDetails(results.atoms[0].id)
+    const details = await getAtomDetails(results.atoms[0].term_id)
+    if (!details) throw new Error('Selected atom was not found on the testnet API')
+
+    const vault = details.term?.vaults[0]
 
     console.log('Label:', details.label)
-    console.log('Creator:', details.creator)
-    console.log('Total Shares:', details.vault.totalShares)
-    console.log('Positions:', details.vault.positionCount)
+    console.log('Creator:', details.creator?.label ?? details.creator_id)
+    console.log('Total Shares:', vault?.total_shares)
+    console.log('Positions:', vault?.position_count)
   }
 
   console.log('\nSuccess!')

--- a/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
+++ b/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
@@ -91,7 +91,6 @@ async function main() {
   console.log('\n=== Atom Details ===');
   console.log('Label:', details.label);
   console.log('Creator:', details.creator?.label ?? details.creator_id);
-  console.log('Vault ID:', vault?.term_id);
   console.log('Total Shares:', vault?.total_shares);
 
   console.log('\nSuccess!');

--- a/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
+++ b/docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md
@@ -10,6 +10,8 @@ keywords: [sdk, example, thing, ipfs, metadata, json-ld]
 
 This example demonstrates creating a rich entity (Thing) with automatic IPFS pinning.
 
+SDK reads default to the mainnet GraphQL API, so this testnet write-and-read flow sets `API_URL_DEV` alongside its pinning configuration. `createAtomFromThing` fetches the required atom base cost; `depositAmount` is an additional tTRUST signal.
+
 ## Complete Code
 
 ```typescript
@@ -22,6 +24,7 @@ import {
   getAtomDetails,
   wait,
 } from '@0xintuition/sdk';
+import { API_URL_DEV } from '@0xintuition/graphql';
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
@@ -29,6 +32,7 @@ async function main() {
   // Setup
   const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
   configureSdk({
+    apiUrl: API_URL_DEV,
     pinApiKey: process.env.INTUITION_PIN_API_KEY,
   });
 
@@ -80,12 +84,15 @@ async function main() {
 
   // 4. Query details
   const details = await getAtomDetails(atom.state.termId);
+  if (!details) throw new Error('Created atom was not found on the testnet API');
+
+  const vault = details.term?.vaults[0];
 
   console.log('\n=== Atom Details ===');
   console.log('Label:', details.label);
-  console.log('Creator:', details.creator);
-  console.log('Vault ID:', details.vault.id);
-  console.log('Total Shares:', details.vault.totalShares);
+  console.log('Creator:', details.creator?.label ?? details.creator_id);
+  console.log('Vault ID:', vault?.term_id);
+  console.log('Total Shares:', vault?.total_shares);
 
   console.log('\nSuccess!');
 }

--- a/docs/_data/intuition-sdk/installation-and-setup.md
+++ b/docs/_data/intuition-sdk/installation-and-setup.md
@@ -362,14 +362,16 @@ import {
   getMultiVaultAddressFromChainId,
 } from '@0xintuition/sdk';
 import type { WriteConfig } from '@0xintuition/sdk';
+import { API_URL_DEV } from '@0xintuition/graphql';
 import { createPublicClient, createWalletClient, http, fallback } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 // Account
 const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
 
-// Intuition pinning service
+// Pinning service + testnet reads (SDK reads default to mainnet otherwise)
 configureSdk({
+  apiUrl: API_URL_DEV,
   pinApiKey: process.env.INTUITION_PIN_API_KEY,
 });
 

--- a/docs/_data/intuition-sdk/installation-and-setup.md
+++ b/docs/_data/intuition-sdk/installation-and-setup.md
@@ -252,6 +252,8 @@ const account = mnemonicToAccount('your twelve word mnemonic phrase goes here');
 
 ### Browser Wallet (MetaMask, etc.)
 
+Browser-only: this flow requires an injected wallet extension that exposes `window.ethereum`.
+
 ```typescript
 import { createWalletClient, custom } from 'viem';
 import { intuitionTestnet } from '@0xintuition/sdk';

--- a/docs/_data/intuition-sdk/integrations/react.md
+++ b/docs/_data/intuition-sdk/integrations/react.md
@@ -51,6 +51,7 @@ export const config = createConfig({
 import { WagmiProvider } from 'wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { config } from './wagmi-config'
+import './sdk-config'
 
 const queryClient = new QueryClient()
 
@@ -208,11 +209,13 @@ function AtomDisplay({ atomId }: { atomId: string }) {
   if (error) return <div>Error loading atom</div>
   if (!atom) return null
 
+  const vault = atom.term?.vaults[0]
+
   return (
     <div>
       <h3>{atom.label}</h3>
-      <p>Creator: {atom.creator}</p>
-      <p>Shares: {atom.vault.totalShares}</p>
+      <p>Creator: {atom.creator?.label ?? atom.creator_id}</p>
+      <p>Shares: {vault?.total_shares ?? 'Unavailable'}</p>
     </div>
   )
 }
@@ -226,6 +229,7 @@ Full-featured React component:
 import { useState } from 'react'
 import { useAccount, usePublicClient, useWalletClient, useChainId } from 'wagmi'
 import { useQuery, useMutation } from '@tanstack/react-query'
+import './sdk-config'
 import {
   createAtomFromString,
   getAtomDetails,

--- a/docs/_data/intuition-sdk/integrations/react.md
+++ b/docs/_data/intuition-sdk/integrations/react.md
@@ -18,6 +18,17 @@ Install required dependencies:
 npm install wagmi viem @tanstack/react-query
 ```
 
+SDK read helpers use the mainnet GraphQL API by default. Because this guide configures Wagmi for Intuition Testnet, initialize the SDK read endpoint once during application startup:
+
+```typescript title="sdk-config.ts"
+import { configureSdk } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
+
+configureSdk({ apiUrl: API_URL_DEV })
+```
+
+Import this configuration module before components call SDK read helpers. Use `API_URL_PROD` when your Wagmi chains target `intuitionMainnet`.
+
 ## Wagmi Configuration
 
 Set up Wagmi provider in your app:
@@ -57,6 +68,8 @@ function App() {
 ## Creating Atoms
 
 Use SDK functions with Wagmi hooks:
+
+`createAtomFromString` fetches and forwards the required atom base cost. The optional amount in these examples is an additional TRUST/tTRUST deposit (signal).
 
 ```typescript title="CreateAtomButton.tsx"
 import { usePublicClient, useWalletClient, useChainId } from 'wagmi'

--- a/docs/_data/intuition-sdk/integrations/tanstack-query.md
+++ b/docs/_data/intuition-sdk/integrations/tanstack-query.md
@@ -18,6 +18,7 @@ npm install @tanstack/react-query
 
 ```typescript title="App.tsx"
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import './sdk-config'
 
 const queryClient = new QueryClient()
 
@@ -190,6 +191,7 @@ Full React component with TanStack Query:
 ```typescript title="AtomExplorer.tsx"
 import { useState } from 'react'
 import { useCreateAtom, useGlobalSearch, useAtomDetails } from './hooks'
+import './sdk-config'
 
 export function AtomExplorer() {
   const [searchQuery, setSearchQuery] = useState('')
@@ -271,8 +273,8 @@ export function AtomExplorer() {
           {atomDetails.data && (
             <div>
               <p>Label: {atomDetails.data.label}</p>
-              <p>Creator: {atomDetails.data.creator}</p>
-              <p>Shares: {atomDetails.data.vault.totalShares}</p>
+              <p>Creator: {atomDetails.data.creator?.label ?? atomDetails.data.creator_id}</p>
+              <p>Shares: {atomDetails.data.term?.vaults[0]?.total_shares ?? 'Unavailable'}</p>
             </div>
           )}
         </div>

--- a/docs/_data/intuition-sdk/integrations/tanstack-query.md
+++ b/docs/_data/intuition-sdk/integrations/tanstack-query.md
@@ -30,6 +30,17 @@ function App() {
 }
 ```
 
+SDK read helpers use the mainnet GraphQL API by default. If the mutation hooks below write to Intuition Testnet, initialize the testnet read endpoint once before rendering the application:
+
+```typescript title="sdk-config.ts"
+import { configureSdk } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
+
+configureSdk({ apiUrl: API_URL_DEV })
+```
+
+Use `API_URL_PROD` instead when the write clients target `intuitionMainnet`. Atom creation helpers fetch and forward the required base cost; an optional amount is an additional TRUST/tTRUST deposit (signal).
+
 ## Query Hooks
 
 Create reusable query hooks for SDK functions:

--- a/docs/_data/intuition-sdk/migration-guide.mdx
+++ b/docs/_data/intuition-sdk/migration-guide.mdx
@@ -497,6 +497,17 @@ const assets = await multiVault.redeem(receiver, termId, curveId, shares, minAss
 
 ## 3. SDK Package Changes (`@0xintuition/sdk`)
 
+SDK read helpers use the mainnet GraphQL API by default. Configure the endpoint once before the migrated read examples; use `API_URL_DEV` for Intuition Testnet or `API_URL_PROD` for Mainnet:
+
+```typescript
+import { configureSdk } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
+
+configureSdk({ apiUrl: API_URL_DEV })
+```
+
+SDK atom creation helpers dynamically fetch and forward the required atom base cost. Any optional amount is an additional TRUST/tTRUST deposit (signal), not the base cost itself.
+
 ### API Function Renaming
 
 **Before:**

--- a/docs/_data/intuition-sdk/quick-start.md
+++ b/docs/_data/intuition-sdk/quick-start.md
@@ -48,17 +48,22 @@ Create a new file and set up your Viem clients:
 
 ```typescript title="quickstart.ts"
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   createAtomFromString,
   createTripleStatement,
   getAtomDetails,
 } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 // Setup account and clients
 const account = privateKeyToAccount('0xYOUR_PRIVATE_KEY')
+
+// SDK reads default to mainnet; keep reads paired with the testnet write chain.
+configureSdk({ apiUrl: API_URL_DEV })
 
 const publicClient = createPublicClient({
   chain: intuitionTestnet,
@@ -74,6 +79,8 @@ const walletClient = createWalletClient({
 const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
 ```
 
+`configureSdk` controls the GraphQL endpoint used by SDK read helpers. Use `API_URL_PROD` instead when the Viem clients target `intuitionMainnet`.
+
 ## Step 2: Create Your First Atom
 
 Create an atom from a simple string:
@@ -83,7 +90,7 @@ Create an atom from a simple string:
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
   'TypeScript',
-  parseEther('0.01') // Optional: initial deposit of 0.01 TRUST
+  parseEther('0.01') // Optional: additional 0.01 tTRUST signal
 )
 
 console.log('Created atom!')
@@ -154,7 +161,7 @@ const triple = await createTripleStatement(
 )
 
 console.log('Created triple!')
-console.log('Triple ID:', triple.state[0].args.tripleId)
+console.log('Triple ID:', triple.state[0].args.termId)
 console.log('Transaction:', triple.transactionHash)
 ```
 
@@ -164,18 +171,23 @@ Here's the complete quick start script:
 
 ```typescript title="quickstart.ts"
 import {
+  configureSdk,
   intuitionTestnet,
   getMultiVaultAddressFromChainId,
   createAtomFromString,
   createTripleStatement,
   getAtomDetails,
 } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 async function main() {
   // Setup
   const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+
+  // SDK reads default to mainnet; keep reads paired with the testnet write chain.
+  configureSdk({ apiUrl: API_URL_DEV })
 
   const publicClient = createPublicClient({
     chain: intuitionTestnet,
@@ -205,6 +217,7 @@ async function main() {
 
   // Query details
   const details = await getAtomDetails(atom.state.termId)
+  if (!details) throw new Error('Created atom was not found on the testnet API')
   console.log('✓ Atom label:', details.label)
 
   // Create three atoms for a triple
@@ -237,7 +250,7 @@ async function main() {
     }
   )
 
-  console.log('✓ Triple created:', triple.state[0].args.tripleId)
+  console.log('✓ Triple created:', triple.state[0].args.termId)
   console.log('\nSuccess! You created your first atom and triple.')
 }
 

--- a/docs/_data/intuition-sdk/quick-start.md
+++ b/docs/_data/intuition-sdk/quick-start.md
@@ -118,11 +118,14 @@ await new Promise(resolve => setTimeout(resolve, 2000))
 
 // Query atom details
 const details = await getAtomDetails(atom.state.termId)
+if (!details) throw new Error('Created atom was not found on the testnet API')
+
+const vault = details.term?.vaults[0]
 
 console.log('Atom Details:')
 console.log('- Label:', details.label)
-console.log('- Creator:', details.creator)
-console.log('- Vault Assets:', details.vault.totalShares)
+console.log('- Creator:', details.creator?.label ?? details.creator_id)
+console.log('- Vault Shares:', vault?.total_shares)
 ```
 
 ## Step 4: Create a Triple

--- a/docs/_data/intuition-sdk/search-guide.md
+++ b/docs/_data/intuition-sdk/search-guide.md
@@ -9,6 +9,17 @@ description: Search atoms, triples, and perform advanced queries
 
 Discover atoms, triples, accounts, and collections using search, filters, and batch entity lookups.
 
+:::info Choose the GraphQL network explicitly
+SDK reads use mainnet by default. Configure the endpoint once at startup; use `API_URL_DEV` for Intuition Testnet or `API_URL_PROD` for Mainnet:
+
+```typescript
+import { configureSdk } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
+
+configureSdk({ apiUrl: API_URL_DEV })
+```
+:::
+
 ## Table of Contents
 
 - [Global Search](#global-search)

--- a/docs/_data/intuition-sdk/search-guide.md
+++ b/docs/_data/intuition-sdk/search-guide.md
@@ -172,11 +172,18 @@ async function searchAndDisplay(query: string) {
 
   // Get detailed information for first atom
   const firstAtom = results.atoms[0]
-  const details = await getAtomDetails(firstAtom.id)
+  const details = await getAtomDetails(firstAtom.term_id)
+
+  if (!details) {
+    console.log('Atom details were not found')
+    return
+  }
+
+  const vault = details.term?.vaults[0]
 
   console.log('First result:', firstAtom.label)
-  console.log('Creator:', details.creator)
-  console.log('Vault shares:', details.vault.totalShares)
+  console.log('Creator:', details.creator?.label ?? details.creator_id)
+  console.log('Vault shares:', vault?.total_shares)
 }
 ```
 

--- a/docs/_data/intuition-sdk/triples-guide.md
+++ b/docs/_data/intuition-sdk/triples-guide.md
@@ -11,6 +11,17 @@ description: Create and query triples using the SDK
 
 Triples are subject-predicate-object statements that connect three atoms to form relationships in the knowledge graph. This guide covers all ways to create and query triples using the SDK.
 
+:::info Match SDK reads to your network
+SDK read helpers use the mainnet GraphQL API by default. The write examples on this page use Intuition Testnet, so configure reads once before calling a read helper:
+
+```typescript
+import { configureSdk } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
+
+configureSdk({ apiUrl: API_URL_DEV })
+```
+:::
+
 ## Table of Contents
 
 - [Creating Triples](#creating-triples)
@@ -27,6 +38,9 @@ Create a triple (subject-predicate-object statement) connecting three atoms in a
 ### Function Signature
 
 ```typescript
+import type { WriteConfig } from '@0xintuition/sdk'
+import type { Hex } from 'viem'
+
 function createTripleStatement(
   config: WriteConfig,
   args: {
@@ -55,16 +69,17 @@ function createTripleStatement(
 ### Returns
 
 ```typescript
+import type { Address, Hex } from 'viem'
+
 type TripleCreationResult = {
   transactionHash: `0x${string}`
   state: Array<{
     args: {
-      tripleId: Hex
+      creator: Address
+      termId: Hex
       subjectId: Hex
       predicateId: Hex
       objectId: Hex
-      counterVaultId: Hex
-      // Additional event fields
     }
     eventName: 'TripleCreated'
   }>
@@ -97,6 +112,7 @@ const walletClient = createWalletClient({
   account,
 })
 const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
+const config = { walletClient, publicClient, address }
 
 // Create atoms
 const alice = await createAtomFromString(config, 'Alice')
@@ -105,7 +121,7 @@ const bob = await createAtomFromString(config, 'Bob')
 
 // Create triple: Alice follows Bob
 const triple = await createTripleStatement(
-  { walletClient, publicClient, address },
+  config,
   {
     args: [
       [alice.state.termId],    // subjects
@@ -117,7 +133,7 @@ const triple = await createTripleStatement(
   }
 )
 
-console.log('Triple ID:', triple.state[0].args.tripleId)
+console.log('Triple ID:', triple.state[0].args.termId)
 console.log('Transaction:', triple.transactionHash)
 ```
 
@@ -183,13 +199,22 @@ A triple consists of three atoms:
 Each triple automatically has a counter-triple representing the opposing position:
 
 ```typescript
-const triple = await createTripleStatement(config, args)
+import {
+  calculateCounterTripleId,
+  createTripleStatement,
+} from '@0xintuition/sdk'
 
-// The main triple vault (FOR position)
-const tripleId = triple.state[0].args.tripleId
+function getPositionIds(
+  triple: Awaited<ReturnType<typeof createTripleStatement>>,
+) {
+  // The main triple vault (FOR position)
+  const tripleId = triple.state[0].args.termId
 
-// The counter vault (AGAINST position)
-const counterVaultId = triple.state[0].args.counterVaultId
+  // Derive the counter triple vault (AGAINST position)
+  const counterTripleId = calculateCounterTripleId(tripleId)
+
+  return { tripleId, counterTripleId }
+}
 ```
 
 ### Best Practices
@@ -261,13 +286,28 @@ Create multiple triples in a single transaction for improved efficiency and redu
 ### Function Signature
 
 ```typescript
+import type { WriteConfig } from '@0xintuition/sdk'
+import type { Address, Hex } from 'viem'
+
 function batchCreateTripleStatements(
   config: WriteConfig,
-  subjects: Hex[],
-  predicates: Hex[],
-  objects: Hex[],
-  deposits: bigint[]
-): Promise<TripleCreationResult>
+  data: [
+    subjects: Hex[],
+    predicates: Hex[],
+    objects: Hex[],
+    assets: bigint[],
+  ],
+  depositAmount?: bigint,
+): Promise<{
+  transactionHash: Hex
+  state: Array<{
+    creator: Address
+    termId: Hex
+    subjectId: Hex
+    predicateId: Hex
+    objectId: Hex
+  }>
+}>
 ```
 
 ### Parameters
@@ -275,10 +315,11 @@ function batchCreateTripleStatements(
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | `config` | `WriteConfig` | Client configuration | Yes |
-| `subjects` | `Hex[]` | Array of subject atom IDs | Yes |
-| `predicates` | `Hex[]` | Array of predicate atom IDs | Yes |
-| `objects` | `Hex[]` | Array of object atom IDs | Yes |
-| `deposits` | `bigint[]` | Array of deposit amounts | Yes |
+| `data[0]` | `Hex[]` | Array of subject atom IDs | Yes |
+| `data[1]` | `Hex[]` | Array of predicate atom IDs | Yes |
+| `data[2]` | `Hex[]` | Array of object atom IDs | Yes |
+| `data[3]` | `bigint[]` | Array of asset amounts | Yes |
+| `depositAmount` | `bigint` | Optional additional transaction deposit | No |
 
 All arrays must be the same length.
 
@@ -288,26 +329,31 @@ All arrays must be the same length.
 import {
   batchCreateTripleStatements,
   createAtomFromString,
+  type WriteConfig,
 } from '@0xintuition/sdk'
 import { parseEther } from 'viem'
 
-// Create atoms
-const alice = await createAtomFromString(config, 'Alice')
-const bob = await createAtomFromString(config, 'Bob')
-const charlie = await createAtomFromString(config, 'Charlie')
-const follows = await createAtomFromString(config, 'follows')
+async function createFollowTriples(config: WriteConfig) {
+  const alice = await createAtomFromString(config, 'Alice')
+  const bob = await createAtomFromString(config, 'Bob')
+  const charlie = await createAtomFromString(config, 'Charlie')
+  const follows = await createAtomFromString(config, 'follows')
 
-// Batch create: Alice follows Bob, Bob follows Charlie
-const result = await batchCreateTripleStatements(
-  config,
-  [alice.state.termId, bob.state.termId],      // subjects
-  [follows.state.termId, follows.state.termId], // predicates
-  [bob.state.termId, charlie.state.termId],     // objects
-  [parseEther('0.1'), parseEther('0.1')]        // deposits
-)
+  // Batch create: Alice follows Bob, Bob follows Charlie
+  const result = await batchCreateTripleStatements(
+    config,
+    [
+      [alice.state.termId, bob.state.termId],       // subjects
+      [follows.state.termId, follows.state.termId], // predicates
+      [bob.state.termId, charlie.state.termId],     // objects
+      [parseEther('0.1'), parseEther('0.1')],        // assets
+    ],
+    parseEther('0.2'), // Optional additional transaction deposit
+  )
 
-console.log('Created', result.state.length, 'triples')
-console.log('Triple IDs:', result.state.map(s => s.args.tripleId))
+  console.log('Created', result.state.length, 'triples')
+  console.log('Triple IDs:', result.state.map(s => s.termId))
+}
 ```
 
 ### Advanced Example
@@ -513,35 +559,43 @@ import {
   createTripleStatement,
   calculateCounterTripleId,
   deposit,
+  type WriteConfig,
 } from '@0xintuition/sdk'
-import { parseEther } from 'viem'
+import { parseEther, type Hex } from 'viem'
 
-// Create triple: Alice follows Bob
-const triple = await createTripleStatement(config, {
-  args: [[aliceId], [followsId], [bobId], [parseEther('0.1')]],
-  value: parseEther('0.1'),
-})
+async function createAndSignalCounter(
+  config: WriteConfig,
+  aliceId: Hex,
+  followsId: Hex,
+  bobId: Hex,
+) {
+  // Create triple: Alice follows Bob
+  const triple = await createTripleStatement(config, {
+    args: [[aliceId], [followsId], [bobId], [parseEther('0.1')]],
+    value: parseEther('0.1'),
+  })
 
-const tripleId = triple.state[0].args.tripleId
-const counterTripleId = calculateCounterTripleId(tripleId)
+  const tripleId = triple.state[0].args.termId
+  const counterTripleId = calculateCounterTripleId(tripleId)
 
-// Deposit into FOR vault
-await deposit(config, [
-  walletClient.account.address,
-  tripleId,
-  1n,
-  parseEther('1'),
-  0n,
-])
+  // Deposit into FOR vault
+  await deposit(config, [
+    config.walletClient.account.address,
+    tripleId,
+    1n,
+    parseEther('1'),
+    0n,
+  ])
 
-// Deposit into AGAINST vault
-await deposit(config, [
-  walletClient.account.address,
-  counterTripleId,
-  1n,
-  parseEther('1'),
-  0n,
-])
+  // Deposit into AGAINST vault
+  await deposit(config, [
+    config.walletClient.account.address,
+    counterTripleId,
+    1n,
+    parseEther('1'),
+    0n,
+  ])
+}
 ```
 
 ### Use Cases
@@ -549,33 +603,57 @@ await deposit(config, [
 #### Building Prediction Markets
 
 ```typescript
-// Create prediction: "Price will go up"
-const prediction = await createTripleStatement(config, {
-  args: [[priceId], [willId], [goUpId], [parseEther('1')]],
-  value: parseEther('1'),
-})
+import {
+  calculateCounterTripleId,
+  createTripleStatement,
+  type WriteConfig,
+} from '@0xintuition/sdk'
+import { parseEther, type Hex } from 'viem'
 
-const forId = prediction.state[0].args.tripleId
-const againstId = calculateCounterTripleId(forId)
+async function getPredictionVaults(
+  config: WriteConfig,
+  priceId: Hex,
+  willId: Hex,
+  goUpId: Hex,
+) {
+  const prediction = await createTripleStatement(config, {
+    args: [[priceId], [willId], [goUpId], [parseEther('1')]],
+    value: parseEther('1'),
+  })
 
-// Users can deposit into either position
-console.log('FOR vault:', forId)
-console.log('AGAINST vault:', againstId)
+  const forId = prediction.state[0].args.termId
+  const againstId = calculateCounterTripleId(forId)
+
+  return { forId, againstId }
+}
 ```
 
 #### Governance Voting
 
 ```typescript
-// Proposal: "Accept proposal #42"
-const proposal = await createTripleStatement(config, {
-  args: [[communityId], [acceptsId], [proposal42Id], [parseEther('10')]],
-  value: parseEther('10'),
-})
+import {
+  calculateCounterTripleId,
+  createTripleStatement,
+  type WriteConfig,
+} from '@0xintuition/sdk'
+import { parseEther, type Hex } from 'viem'
 
-const yesVoteVault = proposal.state[0].args.tripleId
-const noVoteVault = calculateCounterTripleId(yesVoteVault)
+async function getProposalVaults(
+  config: WriteConfig,
+  communityId: Hex,
+  acceptsId: Hex,
+  proposal42Id: Hex,
+) {
+  const proposal = await createTripleStatement(config, {
+    args: [[communityId], [acceptsId], [proposal42Id], [parseEther('10')]],
+    value: parseEther('10'),
+  })
 
-// Voting is done via deposits
+  const yesVoteVault = proposal.state[0].args.termId
+  const noVoteVault = calculateCounterTripleId(yesVoteVault)
+
+  return { yesVoteVault, noVoteVault }
+}
 ```
 
 ### Querying Counter Vault Details

--- a/docs/_data/intuition-sdk/triples-guide.md
+++ b/docs/_data/intuition-sdk/triples-guide.md
@@ -412,7 +412,7 @@ Fetch comprehensive triple details from the Intuition API.
 #### Function Signature
 
 ```typescript
-function getTripleDetails(tripleId: string): Promise<TripleDetails>
+function getTripleDetails(tripleId: string): Promise<TripleDetails | null>
 ```
 
 #### Parameters

--- a/docs/_data/intuition-sdk/triples-guide.md
+++ b/docs/_data/intuition-sdk/triples-guide.md
@@ -450,10 +450,14 @@ import { getTripleDetails } from '@0xintuition/sdk'
 
 const tripleId = '0x4957d3f442acc301...'
 const details = await getTripleDetails(tripleId)
+if (!details) throw new Error('Triple not found')
 
-console.log('Triple:', details.subject.label, details.predicate.label, details.object.label)
-console.log('For Position Shares:', details.vault.totalShares)
-console.log('Against Position Shares:', details.counterVault.totalShares)
+const forVault = details.term?.vaults[0]
+const againstVault = details.counter_term?.vaults[0]
+
+console.log('Triple:', details.subject?.label, details.predicate?.label, details.object?.label)
+console.log('For Position Shares:', forVault?.total_shares)
+console.log('Against Position Shares:', againstVault?.total_shares)
 ```
 
 ### calculateTripleId
@@ -659,25 +663,31 @@ async function getProposalVaults(
 ### Querying Counter Vault Details
 
 ```typescript
-import { getTripleDetails, calculateCounterTripleId } from '@0xintuition/sdk'
+import { getTripleDetails } from '@0xintuition/sdk'
+import type { Hex } from 'viem'
 
 async function comparePositions(tripleId: Hex) {
   const details = await getTripleDetails(tripleId)
+  if (!details) throw new Error('Triple not found')
+
+  const forVault = details.term?.vaults[0]
+  const againstVault = details.counter_term?.vaults[0]
+  if (!forVault || !againstVault) throw new Error('Triple vaults not found')
 
   console.log('=== Triple ===')
-  console.log(`${details.subject.label} ${details.predicate.label} ${details.object.label}`)
+  console.log(`${details.subject?.label} ${details.predicate?.label} ${details.object?.label}`)
   console.log('')
   console.log('FOR Position:')
-  console.log('  Shares:', details.vault.totalShares)
-  console.log('  Positions:', details.vault.positionCount)
+  console.log('  Shares:', forVault.total_shares)
+  console.log('  Positions:', forVault.allPositions.aggregate?.count ?? 0)
   console.log('')
   console.log('AGAINST Position:')
-  console.log('  Shares:', details.counterVault.totalShares)
-  console.log('  Positions:', details.counterVault.positionCount)
+  console.log('  Shares:', againstVault.total_shares)
+  console.log('  Positions:', againstVault.allPositions.aggregate?.count ?? 0)
 
   // Determine which position has more support
-  const forShares = BigInt(details.vault.totalShares)
-  const againstShares = BigInt(details.counterVault.totalShares)
+  const forShares = BigInt(forVault.total_shares)
+  const againstShares = BigInt(againstVault.total_shares)
 
   if (forShares > againstShares) {
     console.log('\nMajority supports FOR')

--- a/docs/_data/intuition-sdk/triples-guide.md
+++ b/docs/_data/intuition-sdk/triples-guide.md
@@ -246,9 +246,8 @@ import { getAtomDetails } from '@0xintuition/sdk'
 
 async function verifyAtoms(ids: Hex[]) {
   for (const id of ids) {
-    try {
-      await getAtomDetails(id)
-    } catch {
+    const atom = await getAtomDetails(id)
+    if (atom === null) {
       console.error('Atom does not exist:', id)
       throw new Error(`Invalid atom ID: ${id}`)
     }
@@ -426,20 +425,15 @@ function getTripleDetails(tripleId: string): Promise<TripleDetails>
 
 ```typescript
 type TripleDetails = {
-  id: string
-  subject: { id: string, label: string }
-  predicate: { id: string, label: string }
-  object: { id: string, label: string }
-  vault: {
-    totalShares: string
-    positionCount: number
-  }
-  counterVault: {
-    totalShares: string
-    positionCount: number
-  }
-  creator: Address
-  // Additional fields
+  subject?: { label?: string | null } | null
+  predicate?: { label?: string | null } | null
+  object?: { label?: string | null } | null
+  term?: {
+    vaults: Array<{ total_shares: string }>
+  } | null
+  counter_term?: {
+    vaults: Array<{ total_shares: string }>
+  } | null
 }
 ```
 
@@ -499,13 +493,8 @@ async function tripleExists(
   objectId: Hex
 ): Promise<boolean> {
   const tripleId = calculateTripleId(subjectId, predicateId, objectId)
-
-  try {
-    await getTripleDetails(tripleId)
-    return true
-  } catch {
-    return false
-  }
+  const triple = await getTripleDetails(tripleId)
+  return triple !== null
 }
 ```
 

--- a/docs/_data/intuition-sdk/vaults-guide.md
+++ b/docs/_data/intuition-sdk/vaults-guide.md
@@ -196,20 +196,29 @@ await deposit(config, [
 #### Deposit into Triple Vault (FOR position)
 
 ```typescript
-import { createTripleStatement, deposit } from '@0xintuition/sdk'
+import {
+  createTripleStatement,
+  deposit,
+  type WriteConfig,
+} from '@0xintuition/sdk'
 import { parseEther } from 'viem'
 
-const triple = await createTripleStatement(config, tripleArgs)
-const tripleId = triple.state[0].args.tripleId
+async function createAndSignalTriple(
+  config: WriteConfig,
+  tripleArgs: Parameters<typeof createTripleStatement>[1],
+) {
+  const triple = await createTripleStatement(config, tripleArgs)
+  const tripleId = triple.state[0].args.termId
 
-// Deposit into FOR vault
-await deposit(config, [
-  walletClient.account.address,
-  tripleId,
-  1n,
-  parseEther('1'),
-  0n,
-])
+  // Deposit into FOR vault
+  await deposit(config, [
+    config.walletClient.account.address,
+    tripleId,
+    1n,
+    parseEther('1'),
+    0n,
+  ])
+}
 ```
 
 #### Deposit into Counter Vault (AGAINST position)

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -452,8 +452,16 @@ console.log('Assets you will receive:', assetsToReceive)
 ```typescript
 import { useState } from 'react'
 import { useWalletClient, usePublicClient, useChainId } from 'wagmi'
-import { createAtomFromString, createTripleStatement } from '@0xintuition/sdk'
+import {
+  configureSdk,
+  createAtomFromString,
+  createTripleStatement,
+} from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
 import { getMultiVaultAddressFromChainId, deposit } from '@0xintuition/protocol'
+
+// SDK reads default to mainnet; pair reads with the testnet write chain.
+configureSdk({ apiUrl: API_URL_DEV })
 
 function IntuitionQuickstart() {
   const chainId = useChainId()

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -191,6 +191,19 @@ export const walletClient = createWalletClient({
 })
 ```
 
+### Pair SDK Reads with the Selected Network
+
+SDK read helpers use the mainnet GraphQL API by default. Because the examples below write to Intuition Testnet, configure the testnet read endpoint once during application startup so newly created data is queried from the same network:
+
+```typescript
+import { configureSdk } from '@0xintuition/sdk'
+import { API_URL_DEV } from '@0xintuition/graphql'
+
+configureSdk({ apiUrl: API_URL_DEV })
+```
+
+Use `API_URL_PROD` instead when your public and wallet clients target `intuitionMainnet`.
+
 # Adding Data to the Knowledge Graph
 Data in the Intuition protocol is represented as atoms and triples. As a developer you will help users create atoms and triples in the protocol via onchain smart contracts, and retrieving data from the knowledge graph via offchain services.
 
@@ -199,6 +212,8 @@ Data in the Intuition protocol is represented as atoms and triples. As a develop
 Atoms are the foundational building blocks of Intuition's knowledge graph – the words in our global dictionary. Think of Intuition as a vast, collaborative dictionary where anyone can create a new word, and each word has its own globally persistent, unique digital identifier that can be used to reference it across the entire internet!
 
 [Learn more about Atoms →](/docs/intuition-concepts/primitives/Atoms/fundamentals)
+
+The SDK dynamically fetches and forwards the required atom base cost. Any optional amount passed to `createAtomFromString` or its sibling helpers is an additional TRUST/tTRUST deposit (signal), not the required base cost.
 
 ### Create an Atom from a String
 
@@ -513,7 +528,7 @@ const atomData = [
 const result = await batchCreateAtomsFromThings(
   { walletClient, publicClient, address },
   atomData,
-  1000000000000000000n // Optional: 1 TRUST deposit per atom
+  1000000000000000000n // Optional: additional 1 TRUST signal per atom
 )
 
 console.log('Created atoms:', result.state)

--- a/docs/_data/quick-start/using-the-sdk.md
+++ b/docs/_data/quick-start/using-the-sdk.md
@@ -160,34 +160,38 @@ export const publicClient = createPublicClient({
 ```
 
 ### Setup a Wallet Client
-If you are using wagmi, you can use the `useWalletClient` hook to get the wallet client. And won't need to setup a wallet client manually. The code snippets below are for reference if you are not using wagmi.
+If you are using wagmi, you can use the `useWalletClient` hook and do not need to set up a wallet client manually. The snippets below show Node/server clients using an RPC transport and a local account.
 
-#### Testnet
-When developing an application us the `intuitionTestnet` chain.
+Use only a disposable development key in a literal placeholder like this; never hardcode or commit a real private key. Production applications should load signing credentials from a secure secret manager.
+
+#### Testnet (Node/server)
+When developing an application use the `intuitionTestnet` chain.
 ```typescript
 import { intuitionTestnet } from '@0xintuition/sdk' // or `@0xintuition/protocol`
-import { createWalletClient, custom } from 'viem'
+import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0x...')
 export const walletClient = createWalletClient({
   chain: intuitionTestnet,
-  transport: custom(window.ethereum!)
+  account,
+  transport: http(),
 })
 ```
 
-#### Mainnet
+#### Mainnet (Node/server)
 When deploying to production remember to use the `intuitionMainnet` chain.
 
 ```typescript
 import { intuitionMainnet } from '@0xintuition/sdk' // or `@0xintuition/protocol`
-import { createWalletClient, custom } from 'viem'
+import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0x...')
 export const walletClient = createWalletClient({
   chain: intuitionMainnet,
-  transport: custom(window.ethereum!),
+  account,
+  transport: http(),
 })
 ```
 


### PR DESCRIPTION
## What

A correctness pass over the SDK-facing docs (17 files) against the published `@0xintuition/sdk@3.0.1`, `@0xintuition/graphql@3.0.1`, and `@0xintuition/protocol@2.0.3` packages:

- **Testnet reads paired with testnet writes.** Every example that writes to Intuition Testnet now configures its GraphQL reads for testnet too (`configureSdk({ apiUrl: API_URL_DEV })`) — reads silently default to mainnet otherwise, which made freshly created atoms look missing. Complete examples are copy-runnable as shown: the configuration is invoked inside the example, not assumed from elsewhere on the page.
- **Real result shapes.** Replaced result fields that don't exist in v3 (`tripleId`, `counterVaultId`, singular `vault`/`counterVault` objects, camelCase vault fields) with the actual contracts: `TripleCreated.termId`, counter IDs via `calculateCounterTripleId`, and `term?.vaults[]` / `counter_term?.vaults[]` with `total_shares` / `current_share_price` / `position_count`.
- **Honest nullability.** `getAtomDetails` / `getTripleDetails` return `null` for missing results — signatures now say so, and examples use explicit null checks instead of try/catch absence detection.
- **Correct atom-cost semantics.** Creation helpers fetch the required base cost dynamically; the optional amount is an additional TRUST/tTRUST deposit, not the base payment. The low-level create-atom guide is rewritten around the deployed `createAtoms` entry point with a dynamic cost read.
- **Server-side wallet examples fixed.** Node contexts use the created account with an `http()` transport and a disposable-key warning; `window.ethereum` remains only in the explicitly browser-labeled flow.

## Verification

- Every claimed export, event argument, and result shape was verified against fresh installs of the published packages (not repo source), including `GetAtomQuery`'s generated types.
- Full Docusaurus build passes; internal link validation passes (276 files); no changes to tutorials or generated artifacts.
- Four independent review rounds (initial + three convergence passes) each re-attacked the branch; the final branch-wide sweep found no remaining example performing GraphQL-backed reads without visible configuration.