### PR TITLE
feat: typecheck SDK doc examples against the published packages in CI

### DIFF
--- a/.github/workflows/validate-sdk-examples.yml
+++ b/.github/workflows/validate-sdk-examples.yml
@@ -1,0 +1,32 @@
+name: Validate SDK Examples
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/_data/intuition-sdk/**'
+      - 'docs/_data/quick-start/using-the-sdk.md'
+      - 'scripts/validate-sdk-examples.js'
+      - 'scripts/sdk-examples.config.json'
+      - 'scripts/__fixtures__/sdk-examples/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/validate-sdk-examples.yml'
+
+jobs:
+  validate-sdk-examples:
+    name: Validate SDK examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck SDK documentation examples
+        run: npm run validate-sdk-examples

--- a/.github/workflows/validate-sdk-examples.yml
+++ b/.github/workflows/validate-sdk-examples.yml
@@ -21,9 +21,9 @@ jobs:
     name: Validate SDK examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/validate-sdk-examples.yml
+++ b/.github/workflows/validate-sdk-examples.yml
@@ -13,6 +13,9 @@ on:
       - 'package-lock.json'
       - '.github/workflows/validate-sdk-examples.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-sdk-examples:
     name: Validate SDK examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,8 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@0xintuition/graphql": "3.0.1",
+        "@0xintuition/sdk": "3.0.1",
         "@docusaurus/tsconfig": "3.9.2",
         "@styled-icons/boxicons-logos": "^10.47.0",
         "@swc/core": "^1.10.11",
@@ -71,17 +73,53 @@
         "tailwindcss": "^3.4.17",
         "typedoc": "^0.28.14",
         "typedoc-plugin-markdown": "^3.17.1",
-        "typescript": "^5.0.2",
-        "url": "^0.11.4"
+        "typescript": "5.9.3",
+        "url": "^0.11.4",
+        "viem": "2.55.10"
       },
       "engines": {
         "node": ">=18.0 <25.0.0"
       }
     },
+    "node_modules/@0xintuition/graphql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@0xintuition/graphql/-/graphql-3.0.1.tgz",
+      "integrity": "sha512-OA6HXlHdtlVTUbZopfMaWQQfbeB7eKVh+w/ucuIZllhEC9MwktaAN058uiYYgNYbcCAMJpz33QE7YgBJh4oCkA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/typescript-document-nodes": "^4.0.11",
+        "@tanstack/react-query": "^5.32.0",
+        "graphql": "^16.9.0",
+        "graphql-request": "^7.1.0"
+      }
+    },
+    "node_modules/@0xintuition/protocol": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@0xintuition/protocol/-/protocol-2.0.3.tgz",
+      "integrity": "sha512-Sfmp0kd5jo6qrBiSfpgOYiMGhcbzPnP2oV1T8t7YuM1bOkvVBl2J5FsE+NFsUBIHVIvlUYhF9jUftv2MANRusA==",
+      "dev": true,
+      "peerDependencies": {
+        "viem": "^2.0.0"
+      }
+    },
+    "node_modules/@0xintuition/sdk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@0xintuition/sdk/-/sdk-3.0.1.tgz",
+      "integrity": "sha512-Wx1niuUbAQUp3O47778TiLZo6Ylf9Ww1Rg/zyHeAhb/Mv4cynuGFLfCn0cLB32FDIz30ziPmlwgKGXnoT5mcFA==",
+      "dev": true,
+      "dependencies": {
+        "@0xintuition/graphql": "^3.0.1",
+        "@0xintuition/protocol": "^2.0.3"
+      },
+      "peerDependencies": {
+        "viem": "^2.0.0"
+      }
+    },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
@@ -475,6 +513,35 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ardatan/relay-compiler": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-13.0.2.tgz",
+      "integrity": "sha512-VFpv9UP820SiwDUPYtq7PmD3jifzZlevkQ26bhbSzFeruSTys0eHzQCZyKg+IhgmZzwPI9AFjPe26ABNjGeIKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^8.0.0",
+        "immutable": "^5.1.9",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/@babel/runtime": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
+      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -2481,6 +2548,36 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0"
       }
     },
+    "node_modules/@cookbookdev/docsbot/node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==",
+      "license": "MIT"
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@cookbookdev/docsbot/node_modules/@radix-ui/primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
@@ -2874,6 +2971,63 @@
         }
       }
     },
+    "node_modules/@cookbookdev/docsbot/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/abitype": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.0.tgz",
+      "integrity": "sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cookbookdev/docsbot/node_modules/cmdk-react17": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cmdk-react17/-/cmdk-react17-1.0.0.tgz",
@@ -2888,6 +3042,21 @@
       "peerDependencies": {
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/isows": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
+      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/@cookbookdev/docsbot/node_modules/nanoid": {
@@ -2931,6 +3100,68 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/viem": {
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.9.16.tgz",
+      "integrity": "sha512-FQRfN4G7uKEUs5DYvVrH/kZmTkwcSDpTBxnadpwG1EEP8nHm57WDpSaGN7PwSPVgJ6rMo5MENT5hgnqaNTlb2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@scure/bip32": "1.3.2",
+        "@scure/bip39": "1.2.1",
+        "abitype": "1.0.0",
+        "isows": "1.0.3",
+        "ws": "8.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cookbookdev/docsbot/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cookbookdev/sonner": {
@@ -6651,6 +6882,174 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.1.tgz",
+      "integrity": "sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-codegen/typescript-document-nodes": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-document-nodes/-/typescript-document-nodes-4.0.16.tgz",
+      "integrity": "sha512-mcWzJ7Na/GeePN9Aw+zBNTSEoXZ1iJ7b6jVEiAf99wD9Hah13eIbYoORZ31XqoGoGB/i86+H7bGbHGfY+aP+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.1.0",
+        "@graphql-codegen/visitor-plugin-common": "5.8.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-document-nodes/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.8.0.tgz",
+      "integrity": "sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.1.0",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-tools/optimize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
+      "integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer": {
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.1.8.tgz",
+      "integrity": "sha512-s16NYT+66VSLCITBURoGNTwh+YvZRSlW3MtFJC2gsvrHZHf6KpCvIR3Qju4yh0FtCoN7Wg7yOI/JT/UzaMEOwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ardatan/relay-compiler": "^13.0.2",
+        "@graphql-tools/utils": "^11.2.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@griffel/core": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.19.2.tgz",
@@ -7479,25 +7878,43 @@
         "@tybys/wasm-util": "^0.10.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.3.2"
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -9110,36 +9527,39 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -10028,6 +10448,34 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -11158,6 +11606,19 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -11175,6 +11636,28 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -11577,6 +12060,19 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/autoprefixer": {
@@ -12263,6 +12759,18 @@
       "integrity": "sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw==",
       "license": "MIT"
     },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -12287,6 +12795,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/change-case-all": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
       }
     },
     "node_modules/char-regex": {
@@ -12733,6 +13281,16 @@
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "license": "ISC"
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/composed-offset-position": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
@@ -12879,6 +13437,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       }
     },
     "node_modules/content-disposition": {
@@ -13094,6 +13664,19 @@
         "node": ">=10.14",
         "npm": ">=6",
         "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -14292,6 +14875,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/dequal": {
@@ -16273,9 +16866,37 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-7.4.0.tgz",
+      "integrity": "sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
+      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -16747,6 +17368,17 @@
         "he": "bin/he"
       }
     },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
@@ -17178,6 +17810,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/import-lazy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
@@ -17278,6 +17923,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -17501,6 +18160,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/is-network-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
@@ -17585,6 +18254,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unc-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -17602,6 +18284,39 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
+    },
+    "node_modules/is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unc-path-regex": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -17655,13 +18370,14 @@
       }
     },
     "node_modules/isows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
+          "url": "https://github.com/sponsors/wevm"
         }
       ],
       "license": "MIT",
@@ -18782,6 +19498,16 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lower-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
@@ -18826,6 +19552,16 @@
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/markdown-extensions": {
@@ -21995,6 +22731,44 @@
       "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
       "license": "MIT"
     },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -22193,6 +22967,21 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -22430,6 +23219,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -22475,6 +23275,29 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-root-regex": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -27339,6 +28162,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -27930,6 +28765,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -28509,6 +29354,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/swc-loader": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.6.tgz",
@@ -28857,6 +29712,16 @@
         "node": "^18.0.0 || >=20.0.0"
       }
     },
+    "node_modules/title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -29177,6 +30042,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/undici-types": {
@@ -29508,6 +30383,26 @@
       },
       "bin": {
         "is-ci": "bin.js"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/uri-js": {
@@ -29847,9 +30742,10 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.9.16.tgz",
-      "integrity": "sha512-FQRfN4G7uKEUs5DYvVrH/kZmTkwcSDpTBxnadpwG1EEP8nHm57WDpSaGN7PwSPVgJ6rMo5MENT5hgnqaNTlb2w==",
+      "version": "2.55.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.10.tgz",
+      "integrity": "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -29858,14 +30754,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@scure/bip32": "1.3.2",
-        "@scure/bip39": "1.2.1",
-        "abitype": "1.0.0",
-        "isows": "1.0.3",
-        "ws": "8.13.0"
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -29876,31 +30772,11 @@
         }
       }
     },
-    "node_modules/viem/node_modules/abitype": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.0.tgz",
-      "integrity": "sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -29916,17 +30792,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/viem/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "update-schema": "node scripts/validate-graphql-queries.js --update-schema",
     "generate-llms": "node scripts/generate-llms-full.js",
     "generate-llms-full": "node scripts/generate-llms-full.js --full-only",
+    "validate-sdk-examples": "node scripts/validate-sdk-examples.js",
     "prepare": "husky"
   },
   "dependencies": {
@@ -63,6 +64,8 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@0xintuition/graphql": "3.0.1",
+    "@0xintuition/sdk": "3.0.1",
     "@docusaurus/tsconfig": "3.9.2",
     "@styled-icons/boxicons-logos": "^10.47.0",
     "@swc/core": "^1.10.11",
@@ -90,8 +93,9 @@
     "tailwindcss": "^3.4.17",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^3.17.1",
-    "typescript": "^5.0.2",
-    "url": "^0.11.4"
+    "typescript": "5.9.3",
+    "url": "^0.11.4",
+    "viem": "2.55.10"
   },
   "browserslist": {
     "production": [

--- a/scripts/__fixtures__/sdk-examples/bad.md
+++ b/scripts/__fixtures__/sdk-examples/bad.md
@@ -1,0 +1,11 @@
+```typescript
+import { createMultivault, createTripleStatement } from '@0xintuition/sdk';
+
+void createMultivault;
+
+type TripleCreatedEvent = Awaited<
+  ReturnType<typeof createTripleStatement>
+>['state'][number];
+declare const event: TripleCreatedEvent;
+void event.args.tripleId;
+```

--- a/scripts/__fixtures__/sdk-examples/duplicate.json
+++ b/scripts/__fixtures__/sdk-examples/duplicate.json
@@ -1,0 +1,20 @@
+{
+  "file": "scripts/__fixtures__/sdk-examples/duplicate.md",
+  "fences": [
+    {
+      "contentHash": "c3d6483a22c73652",
+      "ordinal": 1,
+      "fingerprints": [
+        "TS2305:4ed76008039230782fae457c42775d118a43ad151486f7e0b4f1d6a0e97af587#1"
+      ]
+    },
+    {
+      "contentHash": "c3d6483a22c73652",
+      "ordinal": 2,
+      "fingerprints": [
+        "TS2305:4ed76008039230782fae457c42775d118a43ad151486f7e0b4f1d6a0e97af587#1"
+      ]
+    }
+  ],
+  "reason": "Self-test baselines proving document-order ordinals disambiguate identical failing fences."
+}

--- a/scripts/__fixtures__/sdk-examples/duplicate.md
+++ b/scripts/__fixtures__/sdk-examples/duplicate.md
@@ -1,0 +1,13 @@
+```typescript
+import { createMultivault } from '@0xintuition/sdk';
+
+void createMultivault;
+```
+
+Two identical failing fences must remain independently ratcheted.
+
+```typescript
+import { createMultivault } from '@0xintuition/sdk';
+
+void createMultivault;
+```

--- a/scripts/__fixtures__/sdk-examples/good.md
+++ b/scripts/__fixtures__/sdk-examples/good.md
@@ -1,0 +1,6 @@
+```typescript
+import { intuitionTestnet } from '@0xintuition/sdk';
+
+const chainId: number = intuitionTestnet.id;
+void chainId;
+```

--- a/scripts/__fixtures__/sdk-examples/ratcheted.json
+++ b/scripts/__fixtures__/sdk-examples/ratcheted.json
@@ -1,0 +1,7 @@
+{
+  "id": "scripts/__fixtures__/sdk-examples/ratcheted.md#L1",
+  "fingerprints": [
+    "TS2305:4ed76008039230782fae457c42775d118a43ad151486f7e0b4f1d6a0e97af587#1"
+  ],
+  "reason": "Self-test baseline for detecting a new diagnostic on an already-ratcheted TSX fence."
+}

--- a/scripts/__fixtures__/sdk-examples/ratcheted.json
+++ b/scripts/__fixtures__/sdk-examples/ratcheted.json
@@ -1,5 +1,6 @@
 {
-  "id": "scripts/__fixtures__/sdk-examples/ratcheted.md#L1",
+  "file": "scripts/__fixtures__/sdk-examples/ratcheted.md",
+  "contentHash": "c3d6483a22c73652",
   "fingerprints": [
     "TS2305:4ed76008039230782fae457c42775d118a43ad151486f7e0b4f1d6a0e97af587#1"
   ],

--- a/scripts/__fixtures__/sdk-examples/ratcheted.md
+++ b/scripts/__fixtures__/sdk-examples/ratcheted.md
@@ -1,0 +1,5 @@
+```tsx
+import { createMultivault } from '@0xintuition/sdk';
+
+void createMultivault;
+```

--- a/scripts/__fixtures__/sdk-examples/skipped.md
+++ b/scripts/__fixtures__/sdk-examples/skipped.md
@@ -1,0 +1,6 @@
+<!-- docs-typecheck: skip -->
+```typescript
+import { intentionalPseudocode } from '@0xintuition/sdk'
+
+void intentionalPseudocode
+```

--- a/scripts/sdk-examples.config.json
+++ b/scripts/sdk-examples.config.json
@@ -13,15 +13,14 @@
       "file": "docs/_data/intuition-sdk/atoms-guide.md",
       "fences": [
         {
-          "line": 134,
+          "line": 147,
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
-            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#1",
             "TS2345:38f2f4f16e38c98fb1ee47b35f5870fa114a06f850d2140711fbab3449ea86ce#1"
           ]
         },
         {
-          "line": 176,
+          "line": 197,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -29,7 +28,7 @@
           ]
         },
         {
-          "line": 260,
+          "line": 281,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -37,7 +36,7 @@
           ]
         },
         {
-          "line": 330,
+          "line": 351,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -46,7 +45,7 @@
           ]
         },
         {
-          "line": 387,
+          "line": 408,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -54,7 +53,7 @@
           ]
         },
         {
-          "line": 420,
+          "line": 441,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -62,7 +61,7 @@
           ]
         },
         {
-          "line": 458,
+          "line": 479,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -71,36 +70,17 @@
           ]
         },
         {
-          "line": 515,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2"
-          ]
-        },
-        {
-          "line": 539,
+          "line": 563,
           "fingerprints": [
             "TS2345:2618859d7efc9268fb55655ece2af8351c9dd8a0630b6b34ea4077b5e10766b3#1",
             "TS2345:38f2f4f16e38c98fb1ee47b35f5870fa114a06f850d2140711fbab3449ea86ce#1"
           ]
         },
         {
-          "line": 561,
+          "line": 585,
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
             "TS2345:8b1eb723a1e6bd01b45a92ea8202c3906801d60e67c8b92c44b1e17a0c13f070#1"
-          ]
-        },
-        {
-          "line": 588,
-          "fingerprints": [
-            "TS18047:a5dc0175e759ac2f898e7c72f0bfba01c6964a1fce25a1d44ade00cd92c1beec#1",
-            "TS18047:a5dc0175e759ac2f898e7c72f0bfba01c6964a1fce25a1d44ade00cd92c1beec#2",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1"
           ]
         }
       ],
@@ -144,47 +124,6 @@
       "reason": "The example reads cost fields without narrowing the SDK 3.0.1 boolean-or-CostEstimation result and uses a number where bigint is required."
     },
     {
-      "file": "docs/_data/intuition-sdk/examples/create-atom-from-string.md",
-      "fences": [
-        {
-          "line": 15,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#3"
-          ]
-        }
-      ],
-      "reason": "The example assumes a non-null atom details result and removed vault, currentSharePrice, and positionCount fields."
-    },
-    {
-      "file": "docs/_data/intuition-sdk/examples/create-triple-statement.md",
-      "fences": [
-        {
-          "line": 15,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
-            "TS18049:a070e05b5d3a7aa14e3912419d6eeef16fd2848fcbc68626b8cb0a85c0a62282#1",
-            "TS18049:c5ab7455151b72c2cbc3a7ba2742383a4a75de841966aa64fbbdbcf5b752c9a2#1",
-            "TS18049:e5bda28f5a2fc77b066f5b154f850b855a83bf03e8ae7466ee1a14dadf104aff#1",
-            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#1",
-            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#1",
-            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1"
-          ]
-        }
-      ],
-      "reason": "The TripleCreated result uses stale args.tripleId instead of args.termId and reads removed vault and counterVault detail fields without null guards."
-    },
-    {
       "file": "docs/_data/intuition-sdk/examples/deposit-into-vault.md",
       "fences": [
         {
@@ -203,54 +142,13 @@
       "file": "docs/_data/intuition-sdk/examples/find-existing-entities.md",
       "fences": [
         {
-          "line": 15,
+          "line": 17,
           "fingerprints": [
-            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1",
             "TS2345:6943db3cefa57a72ef194c5f0f1c28504fdd43be4832c3eae8bb99e223169058#1"
           ]
         }
       ],
       "reason": "The example uses stale TripleCreated args.tripleId and supplies plain strings where SDK 3.0.1 requires Hex values."
-    },
-    {
-      "file": "docs/_data/intuition-sdk/examples/global-search.md",
-      "fences": [
-        {
-          "line": 15,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS18049:374c7ecab5d8fd61ae600fcfa1ca291751c1a3b038fdab9397f9e5c296d4cbb1#1",
-            "TS18049:5904503b0e4781475b8ce9134549c78496b80fe25c26ecbbc9059dda824c9d80#1",
-            "TS18049:9f4b2847874a9fa6c0f8ef45d42d284d68edcd9b42a5010c117feae3d7ddfe96#1",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2",
-            "TS2339:4345c17f8ae146bd991da4331ce912e7c2b308a2d4332c987114065140f368d7#1",
-            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1",
-            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#2"
-          ]
-        }
-      ],
-      "reason": "The example uses stale id and vault result fields and omits required null handling for GraphQL search results."
-    },
-    {
-      "file": "docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md",
-      "fences": [
-        {
-          "line": 15,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2"
-          ]
-        }
-      ],
-      "reason": "The example uses stale atom details vault fields and result assumptions against SDK and GraphQL 3.0.1."
     },
     {
       "file": "docs/_data/intuition-sdk/installation-and-setup.md",
@@ -274,13 +172,13 @@
           ]
         },
         {
-          "line": 255,
+          "line": 257,
           "fingerprints": [
             "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
           ]
         },
         {
-          "line": 414,
+          "line": 418,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -314,33 +212,26 @@
       "file": "docs/_data/intuition-sdk/integrations/react.md",
       "fences": [
         {
-          "line": 25,
+          "line": 36,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1",
             "TS2307:c10ca036df7ba79ecc6b5b047055e6ab76bee1861c027793455869fc0f9b78e6#1"
           ]
         },
         {
-          "line": 61,
+          "line": 75,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 119,
+          "line": 133,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 177,
-          "fingerprints": [
-            "TS2322:ff24f79435e9ca00287616341a0e7880c747e526d8bf34fbf9d6b988200c2b5a#1",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1"
-          ]
-        },
-        {
-          "line": 212,
+          "line": 228,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1",
             "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
@@ -353,19 +244,19 @@
       "file": "docs/_data/intuition-sdk/integrations/tanstack-query.md",
       "fences": [
         {
-          "line": 55,
+          "line": 67,
           "fingerprints": [
             "TS2345:66f2b8235d9a9a67a84f0e32cd0ab3bac00767f42275170d207562638bb5753c#1"
           ]
         },
         {
-          "line": 78,
+          "line": 90,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 120,
+          "line": 132,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
@@ -566,14 +457,14 @@
           ]
         },
         {
-          "line": 504,
+          "line": 515,
           "fingerprints": [
             "TS2305:8a78491e479f235bcd91a26cb78ef6fd459f718ebc6ee5a7dd260a65fb301d5b#1",
             "TS2305:9d0e3b0dfd70aae5d093bd9d7f231e2430cc98b2d95f4fbbf4f66b919f0e651c#1"
           ]
         },
         {
-          "line": 528,
+          "line": 539,
           "fingerprints": [
             "TS2304:5b9af3ed027d7f82f525917d64c3dfc293d67da598bd0bfbe5af31bca1458941#1",
             "TS2304:839fe35175bfe678773d86340eff802890d4cebb48f26fac65f3a10c5afc51d2#1",
@@ -583,7 +474,7 @@
           ]
         },
         {
-          "line": 539,
+          "line": 550,
           "fingerprints": [
             "TS2304:5b9af3ed027d7f82f525917d64c3dfc293d67da598bd0bfbe5af31bca1458941#1",
             "TS2304:839fe35175bfe678773d86340eff802890d4cebb48f26fac65f3a10c5afc51d2#1",
@@ -595,29 +486,16 @@
       "reason": "The migration comparison deliberately contains removed v1 APIs and partial before/after fragments that do not compile independently against the pinned v3 packages."
     },
     {
-      "file": "docs/_data/intuition-sdk/quick-start.md",
-      "fences": [
-        {
-          "line": 165,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1"
-          ]
-        }
-      ],
-      "reason": "The end-to-end example uses stale TripleCreated args.tripleId and other pre-v3 result/configuration shapes."
-    },
-    {
       "file": "docs/_data/intuition-sdk/search-guide.md",
       "fences": [
         {
-          "line": 54,
+          "line": 65,
           "fingerprints": [
             "TS2554:0d7f88caa9641107a48c1e7e16181950d9d374636b6c4d2f833dab296c63e034#1"
           ]
         },
         {
-          "line": 71,
+          "line": 82,
           "fingerprints": [
             "TS18049:374c7ecab5d8fd61ae600fcfa1ca291751c1a3b038fdab9397f9e5c296d4cbb1#1",
             "TS18049:5904503b0e4781475b8ce9134549c78496b80fe25c26ecbbc9059dda824c9d80#1",
@@ -626,16 +504,7 @@
           ]
         },
         {
-          "line": 151,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
-            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
-          ]
-        },
-        {
-          "line": 225,
+          "line": 243,
           "fingerprints": [
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#1",
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#2",
@@ -643,7 +512,7 @@
           ]
         },
         {
-          "line": 271,
+          "line": 289,
           "fingerprints": [
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#1",
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#2",
@@ -653,25 +522,25 @@
           ]
         },
         {
-          "line": 291,
+          "line": 309,
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1"
           ]
         },
         {
-          "line": 351,
+          "line": 369,
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1"
           ]
         },
         {
-          "line": 403,
+          "line": 421,
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1"
           ]
         },
         {
-          "line": 430,
+          "line": 448,
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
@@ -687,16 +556,14 @@
       "file": "docs/_data/intuition-sdk/triples-guide.md",
       "fences": [
         {
-          "line": 78,
+          "line": 40,
           "fingerprints": [
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
-            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1"
+            "TS2304:faf722e7c9aa72cfb0afd68610f4fa9c1c96b950aae11b7f6867ab2c65846e14#1",
+            "TS2391:1f92c271d97dd32e2fb2035087417cae61e16c343aa07574309fb7ad57c7e476#1"
           ]
         },
         {
-          "line": 219,
+          "line": 244,
           "fingerprints": [
             "TS2304:092fabc9e26b171f990f4404cd887a4fc45a36823ebd12d48066d9876b667ab4#1",
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
@@ -710,17 +577,11 @@
         {
           "line": 287,
           "fingerprints": [
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#4",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#5",
-            "TS2339:f1acfaf1dd699bb6bece3082f18e42c823cc2b155c35e034b552de3936384fa9#1",
-            "TS2554:26057ac34d2c7a1e0d510f0b6c097847ccebb2e01bff59ad6a308e8482dde2e0#1"
+            "TS2391:1f92c271d97dd32e2fb2035087417cae61e16c343aa07574309fb7ad57c7e476#1"
           ]
         },
         {
-          "line": 317,
+          "line": 362,
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
@@ -741,22 +602,7 @@
           ]
         },
         {
-          "line": 402,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
-            "TS18049:a070e05b5d3a7aa14e3912419d6eeef16fd2848fcbc68626b8cb0a85c0a62282#1",
-            "TS18049:c5ab7455151b72c2cbc3a7ba2742383a4a75de841966aa64fbbdbcf5b752c9a2#1",
-            "TS18049:e5bda28f5a2fc77b066f5b154f850b855a83bf03e8ae7466ee1a14dadf104aff#1",
-            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#1",
-            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#1"
-          ]
-        },
-        {
-          "line": 443,
+          "line": 487,
           "fingerprints": [
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#2",
@@ -764,43 +610,12 @@
           ]
         },
         {
-          "line": 511,
+          "line": 550,
           "fingerprints": [
-            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
-            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#2",
-            "TS2304:2133d2f575d4d9d66b4b96967ad9cab8dd3f564c646d4f5d442c14c76476e23e#1",
-            "TS2304:4a7f16e8350718b289b769d819207f6b2f03acc3f376016c7e4239c37df7d463#1",
-            "TS2304:4b0caa357b1603d677b0fa6675bd76d2b42f373e1721b8d7afb3002664fd722b#1",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
-            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1",
-            "TS2345:70f34245c3ff29a68763dc8fd6290126f588addb26b3eb3545c17bf500301b2e#1",
-            "TS2345:8c407b8edc5e39c1d184bd70755317b053c41902d9e4b9b17c77b72c04030f99#1"
-          ]
-        },
-        {
-          "line": 583,
-          "fingerprints": [
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#6",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#7",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#8",
-            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#9",
-            "TS18049:a070e05b5d3a7aa14e3912419d6eeef16fd2848fcbc68626b8cb0a85c0a62282#1",
-            "TS18049:c5ab7455151b72c2cbc3a7ba2742383a4a75de841966aa64fbbdbcf5b752c9a2#1",
-            "TS18049:e5bda28f5a2fc77b066f5b154f850b855a83bf03e8ae7466ee1a14dadf104aff#1",
-            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
-            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#1",
-            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#2",
-            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#3",
-            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#1",
-            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#2",
-            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#3"
+            "TS18048:5a2eb1b9a24d7af06d31d86251ed5bf15d1c58a5d754e9f576ed8396cbef469f#1",
+            "TS18048:5a2eb1b9a24d7af06d31d86251ed5bf15d1c58a5d754e9f576ed8396cbef469f#2",
+            "TS2345:d6fc8b5d2b4f2a86d67aa98f56bccbbd5cb7bcb2e755371223b0b1cf03addffb#1",
+            "TS2345:d6fc8b5d2b4f2a86d67aa98f56bccbbd5cb7bcb2e755371223b0b1cf03addffb#2"
           ]
         }
       ],
@@ -864,16 +679,12 @@
         {
           "line": 198,
           "fingerprints": [
-            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
-            "TS2304:56f8996db6dbce7b9af7c516ae629d0c93db88b828167188425fa11440ab1a77#1",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
-            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
-            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1",
-            "TS2345:70f34245c3ff29a68763dc8fd6290126f588addb26b3eb3545c17bf500301b2e#1"
+            "TS18048:5a2eb1b9a24d7af06d31d86251ed5bf15d1c58a5d754e9f576ed8396cbef469f#1",
+            "TS2345:d6fc8b5d2b4f2a86d67aa98f56bccbbd5cb7bcb2e755371223b0b1cf03addffb#1"
           ]
         },
         {
-          "line": 217,
+          "line": 226,
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
@@ -882,7 +693,7 @@
           ]
         },
         {
-          "line": 245,
+          "line": 254,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -892,7 +703,7 @@
           ]
         },
         {
-          "line": 316,
+          "line": 325,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -907,7 +718,7 @@
           ]
         },
         {
-          "line": 347,
+          "line": 356,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -923,7 +734,7 @@
           ]
         },
         {
-          "line": 410,
+          "line": 419,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -938,7 +749,7 @@
           ]
         },
         {
-          "line": 432,
+          "line": 441,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -951,7 +762,7 @@
           ]
         },
         {
-          "line": 475,
+          "line": 484,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -962,7 +773,7 @@
           ]
         },
         {
-          "line": 531,
+          "line": 540,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -972,7 +783,7 @@
           ]
         },
         {
-          "line": 557,
+          "line": 566,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -983,7 +794,7 @@
           ]
         },
         {
-          "line": 584,
+          "line": 593,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -991,7 +802,7 @@
           ]
         },
         {
-          "line": 617,
+          "line": 626,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -1000,7 +811,7 @@
           ]
         },
         {
-          "line": 646,
+          "line": 655,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -1010,7 +821,7 @@
           ]
         },
         {
-          "line": 664,
+          "line": 673,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -1025,7 +836,7 @@
           ]
         },
         {
-          "line": 691,
+          "line": 700,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -1043,25 +854,13 @@
       "file": "docs/_data/quick-start/using-the-sdk.md",
       "fences": [
         {
-          "line": 167,
-          "fingerprints": [
-            "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
-          ]
-        },
-        {
-          "line": 182,
-          "fingerprints": [
-            "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
-          ]
-        },
-        {
-          "line": 205,
+          "line": 224,
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 233,
+          "line": 252,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1069,7 +868,7 @@
           ]
         },
         {
-          "line": 249,
+          "line": 268,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1078,7 +877,7 @@
           ]
         },
         {
-          "line": 314,
+          "line": 333,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -1087,7 +886,7 @@
           ]
         },
         {
-          "line": 332,
+          "line": 351,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#2",
@@ -1107,7 +906,7 @@
           ]
         },
         {
-          "line": 375,
+          "line": 394,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1120,7 +919,7 @@
           ]
         },
         {
-          "line": 396,
+          "line": 415,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1133,7 +932,7 @@
           ]
         },
         {
-          "line": 419,
+          "line": 438,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1144,14 +943,14 @@
           ]
         },
         {
-          "line": 433,
+          "line": 452,
           "fingerprints": [
             "TS2305:40cae62fd0ddc8020b2b6d3f3418dd2a0dcf1ad33491e737252de36a36394a6d#1",
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 488,
+          "line": 515,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1159,7 +958,7 @@
           ]
         },
         {
-          "line": 527,
+          "line": 554,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -1177,7 +976,7 @@
           ]
         },
         {
-          "line": 550,
+          "line": 577,
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",

--- a/scripts/sdk-examples.config.json
+++ b/scripts/sdk-examples.config.json
@@ -1,0 +1,114 @@
+{
+  "include": [
+    "docs/_data/intuition-sdk/**",
+    "docs/_data/quick-start/using-the-sdk.md"
+  ],
+  "skipComment": "<!-- docs-typecheck: skip -->",
+  "skipConvention": "Place the skip comment on the line immediately before an intentional partial or pseudocode TypeScript fence.",
+  "ratchetPolicy": "knownFailing groups exact source fence lines by file. Every listed fence is still typechecked. Its diagnostics are reported but do not fail CI. Passing or missing fence entries fail CI so these arrays must shrink when documentation fixes or docs-typecheck skip annotations merge.",
+  "knownFailing": [
+    {
+      "file": "docs/_data/intuition-sdk/atoms-guide.md",
+      "fences": [134, 176, 260, 330, 387, 420, 458, 515, 539, 561, 588],
+      "reason": "Current examples mix omitted setup variables with stale Hex argument and GraphQL result shapes, including removed atom vault fields."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/batch-ethereum-accounts.md",
+      "fences": [15],
+      "reason": "The example passes string addresses where SDK 3.0.1 requires Hex-address arrays."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md",
+      "fences": [15],
+      "reason": "The example reads cost fields without narrowing the SDK 3.0.1 boolean-or-CostEstimation result and uses a number where bigint is required."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/create-atom-from-string.md",
+      "fences": [15],
+      "reason": "The example assumes a non-null atom details result and removed vault, currentSharePrice, and positionCount fields."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/create-triple-statement.md",
+      "fences": [15],
+      "reason": "The TripleCreated result uses stale args.tripleId instead of args.termId and reads removed vault and counterVault detail fields without null guards."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/deposit-into-vault.md",
+      "fences": [15],
+      "reason": "The example uses stale WriteConfig and deposit ABI tuple shapes against SDK 3.0.1."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/find-existing-entities.md",
+      "fences": [15],
+      "reason": "The example uses stale TripleCreated args.tripleId and supplies plain strings where SDK 3.0.1 requires Hex values."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/global-search.md",
+      "fences": [15],
+      "reason": "The example uses stale id and vault result fields and omits required null handling for GraphQL search results."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md",
+      "fences": [15],
+      "reason": "The example uses stale atom details vault fields and result assumptions against SDK and GraphQL 3.0.1."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/installation-and-setup.md",
+      "fences": [151, 218, 255, 414],
+      "reason": "These partial setup examples omit surrounding clients or use stale SDK configuration and create-atom signatures."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/integrations/pinata-ipfs.md",
+      "fences": [78, 194],
+      "reason": "These integration snippets use stale createAtomFromThing or pinThing configuration shapes and omitted setup values."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/integrations/react.md",
+      "fences": [25, 61, 119, 177, 212],
+      "reason": "These React snippets omit surrounding setup and use stale SDK configuration or atom vault result fields."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/integrations/tanstack-query.md",
+      "fences": [55, 78, 120],
+      "reason": "These query snippets omit surrounding setup and use stale SDK input and GraphQL result shapes."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/migration-guide.mdx",
+      "fences": [
+        115, 234, 253, 280, 298, 329, 350, 374, 385, 398, 406, 416, 425, 504,
+        528, 539
+      ],
+      "reason": "The migration comparison deliberately contains removed v1 APIs and partial before/after fragments that do not compile independently against the pinned v3 packages."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/quick-start.md",
+      "fences": [165],
+      "reason": "The end-to-end example uses stale TripleCreated args.tripleId and other pre-v3 result/configuration shapes."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/search-guide.md",
+      "fences": [54, 71, 151, 225, 271, 291, 351, 403, 430],
+      "reason": "These search snippets use stale id and vault fields, outdated call signatures, omitted context, and insufficient nullable-result guards."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/triples-guide.md",
+      "fences": [78, 219, 287, 317, 402, 443, 511, 583],
+      "reason": "These examples include omitted setup plus stale TripleCreated tripleId, triple vault/counterVault fields, and pre-v3 calculation or batch-call shapes."
+    },
+    {
+      "file": "docs/_data/intuition-sdk/vaults-guide.md",
+      "fences": [
+        58, 88, 158, 181, 198, 217, 245, 316, 347, 410, 432, 475, 531, 557, 584,
+        617, 646, 664, 691
+      ],
+      "reason": "These partial examples omit clients and use stale TripleCreated tripleId, vault identifiers, WriteConfig, ABI tuple, and preview/share return shapes."
+    },
+    {
+      "file": "docs/_data/quick-start/using-the-sdk.md",
+      "fences": [
+        167, 182, 205, 233, 249, 314, 332, 375, 396, 419, 433, 488, 527, 550
+      ],
+      "reason": "These snippets omit browser/client context and reference stale protocol exports, SDK batch exports, input tuples, and pre-v3 result shapes."
+    }
+  ]
+}

--- a/scripts/sdk-examples.config.json
+++ b/scripts/sdk-examples.config.json
@@ -5,108 +5,1195 @@
   ],
   "skipComment": "<!-- docs-typecheck: skip -->",
   "skipConvention": "Place the skip comment on the line immediately before an intentional partial or pseudocode TypeScript fence.",
-  "ratchetPolicy": "knownFailing groups exact source fence lines by file. Every listed fence is still typechecked. Its diagnostics are reported but do not fail CI. Passing or missing fence entries fail CI so these arrays must shrink when documentation fixes or docs-typecheck skip annotations merge.",
+  "coverageLimitation": "Import-less partial fences are outside the type-check gate and rely on manual content review.",
+  "ratchetPolicy": "knownFailing groups exact source fence lines by file and records the expected diagnostic fingerprint set for each fence. Every listed fence is still typechecked. Any added or missing fingerprint fails CI; use --update-ratchet locally for a deliberate baseline refresh, and shrink the fence list when documentation fixes or docs-typecheck skip annotations merge.",
+  "fingerprintFormat": "Each fingerprint is the TypeScript error code plus a SHA-256 hash of its position-independent diagnostic message and a same-message occurrence ordinal.",
   "knownFailing": [
     {
       "file": "docs/_data/intuition-sdk/atoms-guide.md",
-      "fences": [134, 176, 260, 330, 387, 420, 458, 515, 539, 561, 588],
+      "fences": [
+        {
+          "line": 134,
+          "fingerprints": [
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#1",
+            "TS2345:38f2f4f16e38c98fb1ee47b35f5870fa114a06f850d2140711fbab3449ea86ce#1"
+          ]
+        },
+        {
+          "line": 176,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 260,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 330,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2345:f8386e19840e807ead9dcbeaeb5ecf605dd7f3ee17fc0f325bb3707d0a1ea35f#1"
+          ]
+        },
+        {
+          "line": 387,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 420,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 458,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2345:1fdc628ab8134af864e2743ab357ce20c3e4f21a840f76244cd5b47243ad6284#1"
+          ]
+        },
+        {
+          "line": 515,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2"
+          ]
+        },
+        {
+          "line": 539,
+          "fingerprints": [
+            "TS2345:2618859d7efc9268fb55655ece2af8351c9dd8a0630b6b34ea4077b5e10766b3#1",
+            "TS2345:38f2f4f16e38c98fb1ee47b35f5870fa114a06f850d2140711fbab3449ea86ce#1"
+          ]
+        },
+        {
+          "line": 561,
+          "fingerprints": [
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2345:8b1eb723a1e6bd01b45a92ea8202c3906801d60e67c8b92c44b1e17a0c13f070#1"
+          ]
+        },
+        {
+          "line": 588,
+          "fingerprints": [
+            "TS18047:a5dc0175e759ac2f898e7c72f0bfba01c6964a1fce25a1d44ade00cd92c1beec#1",
+            "TS18047:a5dc0175e759ac2f898e7c72f0bfba01c6964a1fce25a1d44ade00cd92c1beec#2",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1"
+          ]
+        }
+      ],
       "reason": "Current examples mix omitted setup variables with stale Hex argument and GraphQL result shapes, including removed atom vault fields."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/batch-ethereum-accounts.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS2345:1fdc628ab8134af864e2743ab357ce20c3e4f21a840f76244cd5b47243ad6284#1"
+          ]
+        }
+      ],
       "reason": "The example passes string addresses where SDK 3.0.1 requires Hex-address arrays."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS2339:28df7799cead362e4d54390373c85e3ba3d19dee282874bf408ef295413d0756#1",
+            "TS2339:43ac1ffefa70a804d4046416d2b8098c98cbb15fe57c54588060fb7f74b24ff4#1",
+            "TS2339:7da3349e7383521fc35bbc5604a612e2ae5e72962d555d7951c9b34fd1b47e9b#1",
+            "TS2339:7da3349e7383521fc35bbc5604a612e2ae5e72962d555d7951c9b34fd1b47e9b#2",
+            "TS2339:810bafd55653db81f57efa0a6dd1095b17a7c15a8f6fc3810676ed605000e45e#1",
+            "TS2339:810bafd55653db81f57efa0a6dd1095b17a7c15a8f6fc3810676ed605000e45e#2",
+            "TS2339:810bafd55653db81f57efa0a6dd1095b17a7c15a8f6fc3810676ed605000e45e#3",
+            "TS2339:879ec52462f75541df8426c5df0af27d563f6365597df51bbb79643e8ff7210f#1",
+            "TS2339:b374a69ad7eec3cff2d89b51d66c041f0b8f9593eaace31ea99e16ee7c8eeacd#1",
+            "TS2339:b374a69ad7eec3cff2d89b51d66c041f0b8f9593eaace31ea99e16ee7c8eeacd#2",
+            "TS2339:bca263b61519d10c700b5dd1d02489b1f7c80e703a813f9348a16a23317688ef#1",
+            "TS2339:e57702de9f52d9629a4027b745834eecf5bfb4f0d8cc0d89454b01fdde86918f#1",
+            "TS2339:f438b524fcebd576177241b3363490f8e457278a8a2dfdaaf53108f89744b534#1",
+            "TS2345:e4ce6d4e29e21eccb9f5cf6fe7d89759f4fbfc47c9d6832e71d008f42d7acd5e#1"
+          ]
+        }
+      ],
       "reason": "The example reads cost fields without narrowing the SDK 3.0.1 boolean-or-CostEstimation result and uses a number where bigint is required."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/create-atom-from-string.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#3"
+          ]
+        }
+      ],
       "reason": "The example assumes a non-null atom details result and removed vault, currentSharePrice, and positionCount fields."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/create-triple-statement.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
+            "TS18049:a070e05b5d3a7aa14e3912419d6eeef16fd2848fcbc68626b8cb0a85c0a62282#1",
+            "TS18049:c5ab7455151b72c2cbc3a7ba2742383a4a75de841966aa64fbbdbcf5b752c9a2#1",
+            "TS18049:e5bda28f5a2fc77b066f5b154f850b855a83bf03e8ae7466ee1a14dadf104aff#1",
+            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#1",
+            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#1",
+            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1"
+          ]
+        }
+      ],
       "reason": "The TripleCreated result uses stale args.tripleId instead of args.termId and reads removed vault and counterVault detail fields without null guards."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/deposit-into-vault.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS2322:854ebea312e45833464c3443d55d92314ebff53a5402f8a07044ca0077c78518#1",
+            "TS2322:854ebea312e45833464c3443d55d92314ebff53a5402f8a07044ca0077c78518#2",
+            "TS2345:d614ff1c558e3dd64789cc2d13f7180c1e4c11bce98f0fbcdcd05213400d9828#1",
+            "TS2345:d6fc8b5d2b4f2a86d67aa98f56bccbbd5cb7bcb2e755371223b0b1cf03addffb#1"
+          ]
+        }
+      ],
       "reason": "The example uses stale WriteConfig and deposit ABI tuple shapes against SDK 3.0.1."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/find-existing-entities.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1",
+            "TS2345:6943db3cefa57a72ef194c5f0f1c28504fdd43be4832c3eae8bb99e223169058#1"
+          ]
+        }
+      ],
       "reason": "The example uses stale TripleCreated args.tripleId and supplies plain strings where SDK 3.0.1 requires Hex values."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/global-search.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS18049:374c7ecab5d8fd61ae600fcfa1ca291751c1a3b038fdab9397f9e5c296d4cbb1#1",
+            "TS18049:5904503b0e4781475b8ce9134549c78496b80fe25c26ecbbc9059dda824c9d80#1",
+            "TS18049:9f4b2847874a9fa6c0f8ef45d42d284d68edcd9b42a5010c117feae3d7ddfe96#1",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2",
+            "TS2339:4345c17f8ae146bd991da4331ce912e7c2b308a2d4332c987114065140f368d7#1",
+            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1",
+            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#2"
+          ]
+        }
+      ],
       "reason": "The example uses stale id and vault result fields and omits required null handling for GraphQL search results."
     },
     {
       "file": "docs/_data/intuition-sdk/examples/thing-ipfs-pinning.md",
-      "fences": [15],
+      "fences": [
+        {
+          "line": 15,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#2"
+          ]
+        }
+      ],
       "reason": "The example uses stale atom details vault fields and result assumptions against SDK and GraphQL 3.0.1."
     },
     {
       "file": "docs/_data/intuition-sdk/installation-and-setup.md",
-      "fences": [151, 218, 255, 414],
+      "fences": [
+        {
+          "line": 151,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 218,
+          "fingerprints": [
+            "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#1",
+            "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#2",
+            "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#3",
+            "TS2345:cbb5531425c2ba015a8a030d101f1e50e5f5fc21f9d8a30a9da604b14e0786c5#1",
+            "TS2345:f4454e14eaeb733e39b0f96f8096f34a8283f72bb0aa647c0d551e8508fbaf99#1"
+          ]
+        },
+        {
+          "line": 255,
+          "fingerprints": [
+            "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
+          ]
+        },
+        {
+          "line": 414,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        }
+      ],
       "reason": "These partial setup examples omit surrounding clients or use stale SDK configuration and create-atom signatures."
     },
     {
       "file": "docs/_data/intuition-sdk/integrations/pinata-ipfs.md",
-      "fences": [78, 194],
+      "fences": [
+        {
+          "line": 78,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 194,
+          "fingerprints": [
+            "TS18046:bac87006155f9f3538d48704155ab3d2d0fda073e14f675bfdc8547f209b2861#1"
+          ]
+        }
+      ],
       "reason": "These integration snippets use stale createAtomFromThing or pinThing configuration shapes and omitted setup values."
     },
     {
       "file": "docs/_data/intuition-sdk/integrations/react.md",
-      "fences": [25, 61, 119, 177, 212],
+      "fences": [
+        {
+          "line": 25,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1",
+            "TS2307:c10ca036df7ba79ecc6b5b047055e6ab76bee1861c027793455869fc0f9b78e6#1"
+          ]
+        },
+        {
+          "line": 61,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
+          ]
+        },
+        {
+          "line": 119,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
+          ]
+        },
+        {
+          "line": 177,
+          "fingerprints": [
+            "TS2322:ff24f79435e9ca00287616341a0e7880c747e526d8bf34fbf9d6b988200c2b5a#1",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1"
+          ]
+        },
+        {
+          "line": 212,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1",
+            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
+          ]
+        }
+      ],
       "reason": "These React snippets omit surrounding setup and use stale SDK configuration or atom vault result fields."
     },
     {
       "file": "docs/_data/intuition-sdk/integrations/tanstack-query.md",
-      "fences": [55, 78, 120],
+      "fences": [
+        {
+          "line": 55,
+          "fingerprints": [
+            "TS2345:66f2b8235d9a9a67a84f0e32cd0ab3bac00767f42275170d207562638bb5753c#1"
+          ]
+        },
+        {
+          "line": 78,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
+          ]
+        },
+        {
+          "line": 120,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
+          ]
+        }
+      ],
       "reason": "These query snippets omit surrounding setup and use stale SDK input and GraphQL result shapes."
     },
     {
       "file": "docs/_data/intuition-sdk/migration-guide.mdx",
       "fences": [
-        115, 234, 253, 280, 298, 329, 350, 374, 385, 398, 406, 416, 425, 504,
-        528, 539
+        {
+          "line": 115,
+          "fingerprints": [
+            "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#1",
+            "TS2305:b13a261911cb7c23a70cd23e472a9d0a3a662b69ffbb0804fcfae2f1346e6a56#1",
+            "TS2724:e4f18221850ff9084abcd43f4162a33b4ad0882ac5695f720f3b27c1cde39bd9#1"
+          ]
+        },
+        {
+          "line": 234,
+          "fingerprints": [
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:da80f7fd4851fd97c8f0f9b0abd9e146b85773b791fca03515abef8c0d85dc2d#1",
+            "TS2304:da80f7fd4851fd97c8f0f9b0abd9e146b85773b791fca03515abef8c0d85dc2d#2",
+            "TS2305:08db1c5dc1e2e5753a844b0363fcfb91b5e5c7fb0bd7caf5f7fd764d91a56769#1",
+            "TS2305:3b2ec55ded6cc5a855eaaaf34443ab99ac02b8a989f2f0dc71ea76876518e5a7#1",
+            "TS2305:a0979876cb08b4a063d4983b50da2f95029b77d790066ccff08675eafc0f4bce#1"
+          ]
+        },
+        {
+          "line": 253,
+          "fingerprints": [
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
+            "TS2304:6b2a7af90e51937c4f32db84fb21abc9e532dbeebaedbafb83933b565712c568#1",
+            "TS2304:6b2a7af90e51937c4f32db84fb21abc9e532dbeebaedbafb83933b565712c568#2",
+            "TS2304:91c2a83b8e9dbe98f7235df088af5f77cbd6839ad30fc2611bd7f1a227439175#1",
+            "TS2304:91c2a83b8e9dbe98f7235df088af5f77cbd6839ad30fc2611bd7f1a227439175#2",
+            "TS2304:bbc0ddf75286fbc1e73910eb81d4dad7e5212931c1abe259eb2525122deab103#1",
+            "TS2304:bbc0ddf75286fbc1e73910eb81d4dad7e5212931c1abe259eb2525122deab103#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:e2dd06f44162940e54b35d5ddec7e2b356d10695b3c69a9ce68489f78ad61dec#1",
+            "TS2304:e2dd06f44162940e54b35d5ddec7e2b356d10695b3c69a9ce68489f78ad61dec#2",
+            "TS2305:839ceb10efe5f6504b6ea07a3daf66a151681104f7b978d65a767eb41cce27b6#1",
+            "TS2305:9de15d85647f0fb26a62b6dd29f8e0176a82d548c9d42c9bbf7d900c78f0b32e#1",
+            "TS2305:e10b40cf88c4ad4061e79466f437050e142ea065ac9eee3f96c7d8624342905b#1"
+          ]
+        },
+        {
+          "line": 280,
+          "fingerprints": [
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
+            "TS2304:092fabc9e26b171f990f4404cd887a4fc45a36823ebd12d48066d9876b667ab4#1",
+            "TS2304:092fabc9e26b171f990f4404cd887a4fc45a36823ebd12d48066d9876b667ab4#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:f97170a7bf1bfd6f7f8229d14cdea03ea158f927495e6460db457470c460b7a6#1",
+            "TS2304:f97170a7bf1bfd6f7f8229d14cdea03ea158f927495e6460db457470c460b7a6#2",
+            "TS2304:fe0c30db76dc9bbcc94dbb3a5a4ebbf5bb16f9dadb5ed3d42f1472ada8cb332b#1",
+            "TS2304:fe0c30db76dc9bbcc94dbb3a5a4ebbf5bb16f9dadb5ed3d42f1472ada8cb332b#2",
+            "TS2305:33245a8cdc3f9279593d0e70984804c85b9ebff65a6002ca147e333b6f62f472#1",
+            "TS2305:87bab8bc16fe98204b03db887da8e1d13610c95bc11fe2619fa40fd649405f6a#1",
+            "TS2305:ebe01883d804b78e49bfd15ef462989acdc9915ecaa94eac657b4c257df88dc8#1"
+          ]
+        },
+        {
+          "line": 298,
+          "fingerprints": [
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
+            "TS2304:261ed4df25d82b94d4dd05bf998198207a06e13c2d969e438800e1f0545fc217#1",
+            "TS2304:261ed4df25d82b94d4dd05bf998198207a06e13c2d969e438800e1f0545fc217#2",
+            "TS2304:33eae363239f112986cea1f5395f54546299977f6f1ef0fa8c2bc74cb25d119f#1",
+            "TS2304:33eae363239f112986cea1f5395f54546299977f6f1ef0fa8c2bc74cb25d119f#2",
+            "TS2304:4351c22d720078e019ef002946f3523e517d5ad1220763005d452986b1719c50#1",
+            "TS2304:4351c22d720078e019ef002946f3523e517d5ad1220763005d452986b1719c50#2",
+            "TS2304:6b2a7af90e51937c4f32db84fb21abc9e532dbeebaedbafb83933b565712c568#1",
+            "TS2304:6b2a7af90e51937c4f32db84fb21abc9e532dbeebaedbafb83933b565712c568#2",
+            "TS2304:bb0ccbb550b152ed7a9c986756132772d4756c7f7cd18c80e39537d9beaacf7c#1",
+            "TS2304:bb0ccbb550b152ed7a9c986756132772d4756c7f7cd18c80e39537d9beaacf7c#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:e2dd06f44162940e54b35d5ddec7e2b356d10695b3c69a9ce68489f78ad61dec#1",
+            "TS2304:e2dd06f44162940e54b35d5ddec7e2b356d10695b3c69a9ce68489f78ad61dec#2",
+            "TS2304:f739d21a9980e656c240e55e5e2b3c4f92d79a570bf489026a4f902cbeb69c77#1",
+            "TS2304:f739d21a9980e656c240e55e5e2b3c4f92d79a570bf489026a4f902cbeb69c77#2",
+            "TS2304:fb318b1664bc8fe6ddb3f82eb09720d37646603766f1c3dec2c30a8cb836ebfc#1",
+            "TS2304:fb318b1664bc8fe6ddb3f82eb09720d37646603766f1c3dec2c30a8cb836ebfc#2",
+            "TS2305:727ac90a548a56139626c92b20a4b0309ce68a160dea81a2a6d3c37b7d760f69#1",
+            "TS2305:8367a3de3f35a94124d81843a01aa2caf440c79ebb7465eb29452ab72f716c90#1",
+            "TS2305:d9540b16574583c2f8353ee167038d1ce4eba796a4f7c1a712bb1b388debf7c8#1"
+          ]
+        },
+        {
+          "line": 329,
+          "fingerprints": [
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#2",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#1",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#2",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#3",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#4",
+            "TS2304:b12454b6dd9f575a8f5aed7dbb2c810c10ae5e29d295d139adb67465ddbde910#1",
+            "TS2304:b12454b6dd9f575a8f5aed7dbb2c810c10ae5e29d295d139adb67465ddbde910#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#4",
+            "TS2304:c691092c645e4f3442699a5d8fd38ee903d11617e9cb2d1a0ce85dabe723ae56#1",
+            "TS2304:c691092c645e4f3442699a5d8fd38ee903d11617e9cb2d1a0ce85dabe723ae56#2",
+            "TS2304:fb83e9a669a2da1a8da67ef9678802abdaff29645a38dd9d67fb2d622253beeb#1",
+            "TS2304:fb83e9a669a2da1a8da67ef9678802abdaff29645a38dd9d67fb2d622253beeb#2",
+            "TS2305:12eb868940e1053c9974419da2e72e816c22ddd302f1c9b17a790aa9c1d416eb#1",
+            "TS2305:6693e8da5d8143922cffbbe9935f1dce64f7ab7a1bba00d2524fb06c7815429f#1",
+            "TS2305:77d4844fa367697f977d0a85019ce357d8b5dd205cea8a01a105bf988b68c37d#1",
+            "TS2305:7bacabcf37858ed696a31a101ee0cee4d7112985e2c9ca731cfa2945c6d9006d#1",
+            "TS2305:848feac3137942847a6be0117f28af60956ee70d02733aee1eb35b1cad126474#1",
+            "TS2305:a77adf791786a04b998ca226a6972ed2eb678b364a91846b3f533a0386440ea3#1",
+            "TS2305:cf5196831f06f54fc7b340fa5bb65dc4e5959f9eec1bdab58e1805308057784d#1",
+            "TS2305:d509a1402c814aa88e359dc1cbcb793cf7b544f65a3947414d7b3038325d1bf9#1"
+          ]
+        },
+        {
+          "line": 350,
+          "fingerprints": [
+            "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
+            "TS2304:06835ca2a6e83e58ab8ba73fe6b42270606ca8b02b62aa8e37a6bf52d8b7ebc9#1",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#1",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#2",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#3",
+            "TS2304:0c2bba2fb019f235d1bf23911132a5d452710db42820d4e00c3a4968e45b81d8#4",
+            "TS2304:0c5188dceebc153606ad70f0409b8aa5790cadc6bf305a85d17e04857883523f#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#2",
+            "TS2304:69b2918eb3fef8b5996c453a9c2861149e131f7e739540331b92a17dfa3ed85b#1",
+            "TS2304:69b2918eb3fef8b5996c453a9c2861149e131f7e739540331b92a17dfa3ed85b#2",
+            "TS2304:75727d0ec0eb3bc3d74c3973cf810e8e7d06cace75843e6dfb7f5740bc3e92f3#1",
+            "TS2304:ae30a420e4cab9bb25fb6bd6c4944cfb0e812f98cbdd383e546542e4f4ad6772#1",
+            "TS2304:b12454b6dd9f575a8f5aed7dbb2c810c10ae5e29d295d139adb67465ddbde910#1",
+            "TS2304:b12454b6dd9f575a8f5aed7dbb2c810c10ae5e29d295d139adb67465ddbde910#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:c621182f2503f925599141850f0a3666f197ca47278d7dc06639b3ac20d34667#1",
+            "TS2305:40cae62fd0ddc8020b2b6d3f3418dd2a0dcf1ad33491e737252de36a36394a6d#1",
+            "TS2305:51a502ab9f142558103dbb25dc993c6fd81f60c557dd6337e87511e3396cbd8d#1",
+            "TS2305:5af797d298cbe29a7b20beb227531352a80c1bcf8a5e487ac2d33f59a8d56eb3#1",
+            "TS2305:b592b9d17d3ab5bb6118ec9f99443002629ecab677422245aad4b414452d0358#1"
+          ]
+        },
+        {
+          "line": 374,
+          "fingerprints": [
+            "TS2305:7509755d20e5d2b836dc29034d8575f007c790c10d573e1a86e12ca69c06c8ca#1",
+            "TS2305:9e93606532217b71a7007952f7e088203ecd1d98f4f6a022b649a88a48298c7b#1",
+            "TS2305:ad6fe9328eeebd1e182985ec4f4950264d1d40370153da58a5ed3321ad97ec4c#1",
+            "TS2305:e6817b54b08a5e63af32d8cb50ef4963854188ab6430831d55a83212c025fb10#1"
+          ]
+        },
+        {
+          "line": 385,
+          "fingerprints": [
+            "TS2305:05f13bdac92d96b7156b5ce6f75a26250da4d41cd441e33f260f058e07a6f4f4#1",
+            "TS2305:2bdd2a4397e04f7630afa9fafa5f1ecc165097982e9f4687e0608a32e2386bef#1",
+            "TS2305:9de15d85647f0fb26a62b6dd29f8e0176a82d548c9d42c9bbf7d900c78f0b32e#1",
+            "TS2305:d9540b16574583c2f8353ee167038d1ce4eba796a4f7c1a712bb1b388debf7c8#1"
+          ]
+        },
+        {
+          "line": 398,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2724:4f8f04d8801a3084b8f4b62adb211066723fa3678fe80b52a3240528c110e546#1"
+          ]
+        },
+        {
+          "line": 406,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2724:bc4d5024ca96772654e893c348a40bc5a4a35e7888283f2ab5002a4ee869a029#1"
+          ]
+        },
+        {
+          "line": 416,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2305:155476c7e18c4b99b59f02b2437d2b2897b9b26b21f768789aa67f24a924faf5#1"
+          ]
+        },
+        {
+          "line": 425,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:faf11aba82a1a72f20548db0f0aa23ed16da78a43cacf82fee5c892839676f34#1"
+          ]
+        },
+        {
+          "line": 504,
+          "fingerprints": [
+            "TS2305:8a78491e479f235bcd91a26cb78ef6fd459f718ebc6ee5a7dd260a65fb301d5b#1",
+            "TS2305:9d0e3b0dfd70aae5d093bd9d7f231e2430cc98b2d95f4fbbf4f66b919f0e651c#1"
+          ]
+        },
+        {
+          "line": 528,
+          "fingerprints": [
+            "TS2304:5b9af3ed027d7f82f525917d64c3dfc293d67da598bd0bfbe5af31bca1458941#1",
+            "TS2304:839fe35175bfe678773d86340eff802890d4cebb48f26fac65f3a10c5afc51d2#1",
+            "TS2304:a5aa6f76a2909be857514420da94a575be5a22a7a609afd2cbee8e74ea268848#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2322:9d399a7e3c1640392a3a122ecfc100d0cd8d38d6569ec3a214dd8a14d2b42a3a#1"
+          ]
+        },
+        {
+          "line": 539,
+          "fingerprints": [
+            "TS2304:5b9af3ed027d7f82f525917d64c3dfc293d67da598bd0bfbe5af31bca1458941#1",
+            "TS2304:839fe35175bfe678773d86340eff802890d4cebb48f26fac65f3a10c5afc51d2#1",
+            "TS2304:a5aa6f76a2909be857514420da94a575be5a22a7a609afd2cbee8e74ea268848#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1"
+          ]
+        }
       ],
       "reason": "The migration comparison deliberately contains removed v1 APIs and partial before/after fragments that do not compile independently against the pinned v3 packages."
     },
     {
       "file": "docs/_data/intuition-sdk/quick-start.md",
-      "fences": [165],
+      "fences": [
+        {
+          "line": 165,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1"
+          ]
+        }
+      ],
       "reason": "The end-to-end example uses stale TripleCreated args.tripleId and other pre-v3 result/configuration shapes."
     },
     {
       "file": "docs/_data/intuition-sdk/search-guide.md",
-      "fences": [54, 71, 151, 225, 271, 291, 351, 403, 430],
+      "fences": [
+        {
+          "line": 54,
+          "fingerprints": [
+            "TS2554:0d7f88caa9641107a48c1e7e16181950d9d374636b6c4d2f833dab296c63e034#1"
+          ]
+        },
+        {
+          "line": 71,
+          "fingerprints": [
+            "TS18049:374c7ecab5d8fd61ae600fcfa1ca291751c1a3b038fdab9397f9e5c296d4cbb1#1",
+            "TS18049:5904503b0e4781475b8ce9134549c78496b80fe25c26ecbbc9059dda824c9d80#1",
+            "TS18049:9f4b2847874a9fa6c0f8ef45d42d284d68edcd9b42a5010c117feae3d7ddfe96#1",
+            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
+          ]
+        },
+        {
+          "line": 151,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS2339:414873b9a74209590579a2e34a0d27ac5766454db1bf281938abdbb53599c2a5#1",
+            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
+          ]
+        },
+        {
+          "line": 225,
+          "fingerprints": [
+            "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#1",
+            "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#2",
+            "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
+          ]
+        },
+        {
+          "line": 271,
+          "fingerprints": [
+            "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#1",
+            "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#2",
+            "TS18049:374c7ecab5d8fd61ae600fcfa1ca291751c1a3b038fdab9397f9e5c296d4cbb1#1",
+            "TS18049:5904503b0e4781475b8ce9134549c78496b80fe25c26ecbbc9059dda824c9d80#1",
+            "TS18049:9f4b2847874a9fa6c0f8ef45d42d284d68edcd9b42a5010c117feae3d7ddfe96#1"
+          ]
+        },
+        {
+          "line": 291,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1"
+          ]
+        },
+        {
+          "line": 351,
+          "fingerprints": [
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1"
+          ]
+        },
+        {
+          "line": 403,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1"
+          ]
+        },
+        {
+          "line": 430,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#2",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#3",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1"
+          ]
+        }
+      ],
       "reason": "These search snippets use stale id and vault fields, outdated call signatures, omitted context, and insufficient nullable-result guards."
     },
     {
       "file": "docs/_data/intuition-sdk/triples-guide.md",
-      "fences": [78, 219, 287, 317, 402, 443, 511, 583],
+      "fences": [
+        {
+          "line": 78,
+          "fingerprints": [
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
+            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1"
+          ]
+        },
+        {
+          "line": 219,
+          "fingerprints": [
+            "TS2304:092fabc9e26b171f990f4404cd887a4fc45a36823ebd12d48066d9876b667ab4#1",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
+            "TS2304:a28c03803cb76f5a5eeb2563f7175db815aabc66a8793a6007df094299633453#1",
+            "TS2304:a7b8331d4d62f2ef80c9d6edf1ab453f07153a25ab3a94d78cc8216f2b115119#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:f97170a7bf1bfd6f7f8229d14cdea03ea158f927495e6460db457470c460b7a6#1",
+            "TS2304:fe0c30db76dc9bbcc94dbb3a5a4ebbf5bb16f9dadb5ed3d42f1472ada8cb332b#1"
+          ]
+        },
+        {
+          "line": 287,
+          "fingerprints": [
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#4",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#5",
+            "TS2339:f1acfaf1dd699bb6bece3082f18e42c823cc2b155c35e034b552de3936384fa9#1",
+            "TS2554:26057ac34d2c7a1e0d510f0b6c097847ccebb2e01bff59ad6a308e8482dde2e0#1"
+          ]
+        },
+        {
+          "line": 317,
+          "fingerprints": [
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#4",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#5",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#6",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#7",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#8",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#1",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#2",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#3",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#4",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#5",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#6",
+            "TS2304:cc428d713787d4dd9604ddf0bc651a98dbb1a8d5e8cd746725fc6f09506fd7f2#7",
+            "TS2554:26057ac34d2c7a1e0d510f0b6c097847ccebb2e01bff59ad6a308e8482dde2e0#1"
+          ]
+        },
+        {
+          "line": 402,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
+            "TS18049:a070e05b5d3a7aa14e3912419d6eeef16fd2848fcbc68626b8cb0a85c0a62282#1",
+            "TS18049:c5ab7455151b72c2cbc3a7ba2742383a4a75de841966aa64fbbdbcf5b752c9a2#1",
+            "TS18049:e5bda28f5a2fc77b066f5b154f850b855a83bf03e8ae7466ee1a14dadf104aff#1",
+            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#1",
+            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#1"
+          ]
+        },
+        {
+          "line": 443,
+          "fingerprints": [
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#2",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#3"
+          ]
+        },
+        {
+          "line": 511,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#2",
+            "TS2304:2133d2f575d4d9d66b4b96967ad9cab8dd3f564c646d4f5d442c14c76476e23e#1",
+            "TS2304:4a7f16e8350718b289b769d819207f6b2f03acc3f376016c7e4239c37df7d463#1",
+            "TS2304:4b0caa357b1603d677b0fa6675bd76d2b42f373e1721b8d7afb3002664fd722b#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#3",
+            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1",
+            "TS2345:70f34245c3ff29a68763dc8fd6290126f588addb26b3eb3545c17bf500301b2e#1",
+            "TS2345:8c407b8edc5e39c1d184bd70755317b053c41902d9e4b9b17c77b72c04030f99#1"
+          ]
+        },
+        {
+          "line": 583,
+          "fingerprints": [
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#1",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#2",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#3",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#4",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#5",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#6",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#7",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#8",
+            "TS18047:595f63bd814e381ba4dd0a8363b488b3fb2c45d2adbca8ed31d884c771aebbdb#9",
+            "TS18049:a070e05b5d3a7aa14e3912419d6eeef16fd2848fcbc68626b8cb0a85c0a62282#1",
+            "TS18049:c5ab7455151b72c2cbc3a7ba2742383a4a75de841966aa64fbbdbcf5b752c9a2#1",
+            "TS18049:e5bda28f5a2fc77b066f5b154f850b855a83bf03e8ae7466ee1a14dadf104aff#1",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
+            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#1",
+            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#2",
+            "TS2339:73010c3ab21e3b35dce279175e831ee112037b8401db1d54664f087c38ca5621#3",
+            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#1",
+            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#2",
+            "TS2339:d8a936801a1c24923ba28c8e6425f3fc61d28abeba9cc813b7885a14a94f23b7#3"
+          ]
+        }
+      ],
       "reason": "These examples include omitted setup plus stale TripleCreated tripleId, triple vault/counterVault fields, and pre-v3 calculation or batch-call shapes."
     },
     {
       "file": "docs/_data/intuition-sdk/vaults-guide.md",
       "fences": [
-        58, 88, 158, 181, 198, 217, 245, 316, 347, 410, 432, 475, 531, 557, 584,
-        617, 646, 664, 691
+        {
+          "line": 58,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2345:8c407b8edc5e39c1d184bd70755317b053c41902d9e4b9b17c77b72c04030f99#1"
+          ]
+        },
+        {
+          "line": 88,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#2",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#3",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#2",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#3",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#2",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
+            "TS2322:ab46e4f6188b96fed407285d6da23edd9f1ca9c515418418ee44f8f4b3a300de#1",
+            "TS2345:5670a7e8632867899fc0c050955b6560df0151b5fcef4890f93827808f0ec99c#1",
+            "TS2345:f7064a43278983d19b6aeeee8ef3c3c14e6a89cfb9bcfef070b5f22b73ef2e23#1",
+            "TS2362:3e37de66947d48e73526b2eed8ebb5ef385510e4cfb5b1acfa99cd55bfbc59b9#1",
+            "TS2365:db1ef5be1558f01a0e7e9e44fc8c6de7d741708b5d3640fb8668efd6c2f1050f#1"
+          ]
+        },
+        {
+          "line": 158,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:4371df8b3083bb081345ed8d3352f9270b228395ba4afc1abc6db5fbccac963b#1",
+            "TS2304:889750d0f208f3ae44c9073ac1b2ed98ddf567eea2f9eb8040e3446c06cd78c2#1",
+            "TS2304:8f8552a2bccadce3f28814a04d5b47950d5ac19e6ec7edd838c2421a93c6c241#1"
+          ]
+        },
+        {
+          "line": 181,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2345:8c407b8edc5e39c1d184bd70755317b053c41902d9e4b9b17c77b72c04030f99#1"
+          ]
+        },
+        {
+          "line": 198,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:56f8996db6dbce7b9af7c516ae629d0c93db88b828167188425fa11440ab1a77#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
+            "TS2339:fd66401b6fe4b9705e72a96870e5207d0e2078bd45ee054c87f68f135d81e1a4#1",
+            "TS2345:70f34245c3ff29a68763dc8fd6290126f588addb26b3eb3545c17bf500301b2e#1"
+          ]
+        },
+        {
+          "line": 217,
+          "fingerprints": [
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2304:fb83e9a669a2da1a8da67ef9678802abdaff29645a38dd9d67fb2d622253beeb#1",
+            "TS2345:8c407b8edc5e39c1d184bd70755317b053c41902d9e4b9b17c77b72c04030f99#1"
+          ]
+        },
+        {
+          "line": 245,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2322:88448480b211edb96d17e73f78b35b7268c2d99be07690aa3d247a0b77b52fc6#1"
+          ]
+        },
+        {
+          "line": 316,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#2",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#2",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#2",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#2",
+            "TS2322:88448480b211edb96d17e73f78b35b7268c2d99be07690aa3d247a0b77b52fc6#1"
+          ]
+        },
+        {
+          "line": 347,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#2",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#2",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
+            "TS2345:257d0361da235cff4389b1d5a332cd87c5b505e1efc9da93656c2fe40558b7a8#1",
+            "TS2345:5670a7e8632867899fc0c050955b6560df0151b5fcef4890f93827808f0ec99c#1",
+            "TS2362:3e37de66947d48e73526b2eed8ebb5ef385510e4cfb5b1acfa99cd55bfbc59b9#1",
+            "TS2365:db1ef5be1558f01a0e7e9e44fc8c6de7d741708b5d3640fb8668efd6c2f1050f#1"
+          ]
+        },
+        {
+          "line": 410,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:258f1fc9fd0d7ecb42a978bb589245185fc006fb3a2895e497df0d038ebdf90d#1",
+            "TS2304:4371df8b3083bb081345ed8d3352f9270b228395ba4afc1abc6db5fbccac963b#1",
+            "TS2304:57912a859527bbb4f860a538d3069ab0800e9e2c6feed85333a2cc0fd4e7f62e#1",
+            "TS2304:889750d0f208f3ae44c9073ac1b2ed98ddf567eea2f9eb8040e3446c06cd78c2#1",
+            "TS2304:8f8552a2bccadce3f28814a04d5b47950d5ac19e6ec7edd838c2421a93c6c241#1",
+            "TS2304:ef5349836cac217103db2a3dbcc3a284e4e301712ec6684d66f50e8168ef63b1#1"
+          ]
+        },
+        {
+          "line": 432,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#2",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#2",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2322:88448480b211edb96d17e73f78b35b7268c2d99be07690aa3d247a0b77b52fc6#1"
+          ]
+        },
+        {
+          "line": 475,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:0c5188dceebc153606ad70f0409b8aa5790cadc6bf305a85d17e04857883523f#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:f98f0553c2b94650ddeaab8cc761821c718012fcf9c62c5d304f6fb22d88b9a5#1",
+            "TS2322:2b49ab5f67df462c63e3ff1f879bf29687aa676bb4d671bf824b746b2ed074eb#1"
+          ]
+        },
+        {
+          "line": 531,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2322:88448480b211edb96d17e73f78b35b7268c2d99be07690aa3d247a0b77b52fc6#1"
+          ]
+        },
+        {
+          "line": 557,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2322:44814f6bdc8a356e4e815d4586b15de19c25d222a9525d2e2be1e45011209ec4#1",
+            "TS2339:8b5d72692bed8663843395290f86eae233fbf9923e9562d835ce438ee48e0bbe#1",
+            "TS2339:d6430450fb0284c4a085d22d01d5248167fe44398b5392bc38d69253621e5aae#1"
+          ]
+        },
+        {
+          "line": 584,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1"
+          ]
+        },
+        {
+          "line": 617,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2345:5670a7e8632867899fc0c050955b6560df0151b5fcef4890f93827808f0ec99c#1"
+          ]
+        },
+        {
+          "line": 646,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2345:257d0361da235cff4389b1d5a332cd87c5b505e1efc9da93656c2fe40558b7a8#1",
+            "TS2345:5670a7e8632867899fc0c050955b6560df0151b5fcef4890f93827808f0ec99c#1"
+          ]
+        },
+        {
+          "line": 664,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#2",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
+            "TS2345:5670a7e8632867899fc0c050955b6560df0151b5fcef4890f93827808f0ec99c#1",
+            "TS2345:70f34245c3ff29a68763dc8fd6290126f588addb26b3eb3545c17bf500301b2e#1",
+            "TS2362:3e37de66947d48e73526b2eed8ebb5ef385510e4cfb5b1acfa99cd55bfbc59b9#1",
+            "TS2365:db1ef5be1558f01a0e7e9e44fc8c6de7d741708b5d3640fb8668efd6c2f1050f#1"
+          ]
+        },
+        {
+          "line": 691,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:4371df8b3083bb081345ed8d3352f9270b228395ba4afc1abc6db5fbccac963b#1",
+            "TS2304:889750d0f208f3ae44c9073ac1b2ed98ddf567eea2f9eb8040e3446c06cd78c2#1",
+            "TS2304:8f8552a2bccadce3f28814a04d5b47950d5ac19e6ec7edd838c2421a93c6c241#1",
+            "TS2345:5670a7e8632867899fc0c050955b6560df0151b5fcef4890f93827808f0ec99c#1",
+            "TS2345:d4233222efe0161a41d47b27c9ae788dec4ffdadb4cb7cc2d96a81f34ff9b722#1"
+          ]
+        }
       ],
       "reason": "These partial examples omit clients and use stale TripleCreated tripleId, vault identifiers, WriteConfig, ABI tuple, and preview/share return shapes."
     },
     {
       "file": "docs/_data/quick-start/using-the-sdk.md",
       "fences": [
-        167, 182, 205, 233, 249, 314, 332, 375, 396, 419, 433, 488, 527, 550
+        {
+          "line": 167,
+          "fingerprints": [
+            "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
+          ]
+        },
+        {
+          "line": 182,
+          "fingerprints": [
+            "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
+          ]
+        },
+        {
+          "line": 205,
+          "fingerprints": [
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
+          ]
+        },
+        {
+          "line": 233,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 249,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2345:d1fdc79832dd3581b02cfa70549026632a6bd39b7c52690551d7d8dd6a952840#1"
+          ]
+        },
+        {
+          "line": 314,
+          "fingerprints": [
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:c691092c645e4f3442699a5d8fd38ee903d11617e9cb2d1a0ce85dabe723ae56#1",
+            "TS2305:b2d9ae887df419cdf7adfb392b7f597e2b857e178da3edb5064862fda86d0109#1"
+          ]
+        },
+        {
+          "line": 332,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#2",
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#3",
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#4",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#2",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#3",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#4",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#2",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#3",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#4",
+            "TS2322:39e6f594e027ab1bef567c6bb3ac7ff977a6ada55236f97bc1bc74528cb64a6a#1",
+            "TS2322:39e6f594e027ab1bef567c6bb3ac7ff977a6ada55236f97bc1bc74528cb64a6a#2",
+            "TS2322:39e6f594e027ab1bef567c6bb3ac7ff977a6ada55236f97bc1bc74528cb64a6a#3"
+          ]
+        },
+        {
+          "line": 375,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:a55b4655fe59264105d064c9d6fb8439349022d0c41b550af223da81b0087bbd#1",
+            "TS2304:a55b4655fe59264105d064c9d6fb8439349022d0c41b550af223da81b0087bbd#2",
+            "TS2305:40cae62fd0ddc8020b2b6d3f3418dd2a0dcf1ad33491e737252de36a36394a6d#1"
+          ]
+        },
+        {
+          "line": 396,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
+            "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#2",
+            "TS2304:51b4752ddf14d352f58e8c5e06d806f9e7d596103688fee2da3a3af7b61a1ce7#1",
+            "TS2305:5af797d298cbe29a7b20beb227531352a80c1bcf8a5e487ac2d33f59a8d56eb3#1"
+          ]
+        },
+        {
+          "line": 419,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:1853be68f3f108195cbe9d10eedf260825af4e1e0a93145128c4e4ca6259c0c5#1",
+            "TS2304:51b4752ddf14d352f58e8c5e06d806f9e7d596103688fee2da3a3af7b61a1ce7#1",
+            "TS2305:5f1322abed3dc7302d212764aafeb8e9d9c055ce67e1a51605101abf89211f7b#1"
+          ]
+        },
+        {
+          "line": 433,
+          "fingerprints": [
+            "TS2305:40cae62fd0ddc8020b2b6d3f3418dd2a0dcf1ad33491e737252de36a36394a6d#1",
+            "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
+          ]
+        },
+        {
+          "line": 488,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1"
+          ]
+        },
+        {
+          "line": 527,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:261ed4df25d82b94d4dd05bf998198207a06e13c2d969e438800e1f0545fc217#1",
+            "TS2304:33eae363239f112986cea1f5395f54546299977f6f1ef0fa8c2bc74cb25d119f#1",
+            "TS2304:4351c22d720078e019ef002946f3523e517d5ad1220763005d452986b1719c50#1",
+            "TS2304:8427919ff027c639c9aac2687ccb300e0c41ec900e153b8b46cc601432f13a39#1",
+            "TS2304:bb0ccbb550b152ed7a9c986756132772d4756c7f7cd18c80e39537d9beaacf7c#1",
+            "TS2304:bfccdb1a571cb77e39fd71c234a82091d79777df70dca912c548d89200998906#1",
+            "TS2304:c3b39bed429760eec41b6cf927b43b283e1fb97abee42d201af8475055f73b84#1",
+            "TS2304:f739d21a9980e656c240e55e5e2b3c4f92d79a570bf489026a4f902cbeb69c77#1",
+            "TS2304:fb318b1664bc8fe6ddb3f82eb09720d37646603766f1c3dec2c30a8cb836ebfc#1",
+            "TS2345:7ff8d30d1dffc74a8415678d69d7af9d87b650bbb70b4acdcef9ce71640d4b1a#1"
+          ]
+        },
+        {
+          "line": 550,
+          "fingerprints": [
+            "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
+            "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
+            "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
+            "TS2304:5870d9d22b926977ea52911cf0c56dd5a80cfa9c5b6cefd3572a02ec0933e8be#1",
+            "TS2304:5dd07a532752e1da313381b1e812ff7959b4c65cf899230150b0e466d2517b73#1",
+            "TS2304:8162bbe8d10a824ed8cd6bf9c25eb38cc76cf519a141909856511218e65dc86c#1",
+            "TS2304:9c3b63ba737ea71ebfa1f8638bd878faaf02282b579e6c492c2eb375b7142bd3#1",
+            "TS2304:a87915a7e8956c51dc17606183560400c96ed8df2bdd99e58c00c0b18ef05f87#1",
+            "TS2304:a87915a7e8956c51dc17606183560400c96ed8df2bdd99e58c00c0b18ef05f87#2",
+            "TS2304:a87915a7e8956c51dc17606183560400c96ed8df2bdd99e58c00c0b18ef05f87#3",
+            "TS2304:bf2b348b1f739b9692a9f178b379338675dd0de0d7543af83a3facd91f72e68e#1",
+            "TS2304:cd17815fed5d1e6c6b42cba9d156591af67bcac0a913de4f69182c45c9a82aac#1",
+            "TS2305:5425a4e97b933fa3944c44006df8ab69927de7aeeb3402593b216a79cdf0f951#1"
+          ]
+        }
       ],
       "reason": "These snippets omit browser/client context and reference stale protocol exports, SDK batch exports, input tuples, and pre-v3 result shapes."
     }

--- a/scripts/sdk-examples.config.json
+++ b/scripts/sdk-examples.config.json
@@ -6,21 +6,21 @@
   "skipComment": "<!-- docs-typecheck: skip -->",
   "skipConvention": "Place the skip comment on the line immediately before an intentional partial or pseudocode TypeScript fence.",
   "coverageLimitation": "Import-less partial fences are outside the type-check gate and rely on manual content review.",
-  "ratchetPolicy": "knownFailing groups exact source fence lines by file and records the expected diagnostic fingerprint set for each fence. Every listed fence is still typechecked. Any added or missing fingerprint fails CI; use --update-ratchet locally for a deliberate baseline refresh, and shrink the fence list when documentation fixes or docs-typecheck skip annotations merge.",
+  "ratchetPolicy": "knownFailing groups exact source fence content by file and records the expected diagnostic fingerprint set for each fence. Fence identity uses a truncated SHA-256 content hash plus a document-order ordinal only for identical-content fences in the same file; source line numbers are display-only. Every listed fence is still typechecked. Any added or missing fingerprint fails CI; use --update-ratchet locally for a deliberate baseline refresh, and shrink the fence list when documentation fixes or docs-typecheck skip annotations merge.",
   "fingerprintFormat": "Each fingerprint is the TypeScript error code plus a SHA-256 hash of its position-independent diagnostic message and a same-message occurrence ordinal.",
   "knownFailing": [
     {
       "file": "docs/_data/intuition-sdk/atoms-guide.md",
       "fences": [
         {
-          "line": 147,
+          "contentHash": "30be8b9c9624e441",
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
             "TS2345:38f2f4f16e38c98fb1ee47b35f5870fa114a06f850d2140711fbab3449ea86ce#1"
           ]
         },
         {
-          "line": 197,
+          "contentHash": "331731c011bc0d06",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -28,7 +28,7 @@
           ]
         },
         {
-          "line": 281,
+          "contentHash": "4f7362414bf3dc5e",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -36,7 +36,7 @@
           ]
         },
         {
-          "line": 351,
+          "contentHash": "08622218d5a8987c",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -45,7 +45,7 @@
           ]
         },
         {
-          "line": 408,
+          "contentHash": "26f3997e9845788e",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -53,7 +53,7 @@
           ]
         },
         {
-          "line": 441,
+          "contentHash": "2e8d233895df885b",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -61,7 +61,7 @@
           ]
         },
         {
-          "line": 479,
+          "contentHash": "3831f5d695b18298",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -70,14 +70,14 @@
           ]
         },
         {
-          "line": 563,
+          "contentHash": "c9b695da35af7af4",
           "fingerprints": [
             "TS2345:2618859d7efc9268fb55655ece2af8351c9dd8a0630b6b34ea4077b5e10766b3#1",
             "TS2345:38f2f4f16e38c98fb1ee47b35f5870fa114a06f850d2140711fbab3449ea86ce#1"
           ]
         },
         {
-          "line": 585,
+          "contentHash": "caeaa9a236f9a1b8",
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
             "TS2345:8b1eb723a1e6bd01b45a92ea8202c3906801d60e67c8b92c44b1e17a0c13f070#1"
@@ -90,7 +90,7 @@
       "file": "docs/_data/intuition-sdk/examples/batch-ethereum-accounts.md",
       "fences": [
         {
-          "line": 15,
+          "contentHash": "49569086f4d5a5e7",
           "fingerprints": [
             "TS2345:1fdc628ab8134af864e2743ab357ce20c3e4f21a840f76244cd5b47243ad6284#1"
           ]
@@ -102,7 +102,7 @@
       "file": "docs/_data/intuition-sdk/examples/bulk-sync-cost-estimation.md",
       "fences": [
         {
-          "line": 15,
+          "contentHash": "50c321fc3c64134a",
           "fingerprints": [
             "TS2339:28df7799cead362e4d54390373c85e3ba3d19dee282874bf408ef295413d0756#1",
             "TS2339:43ac1ffefa70a804d4046416d2b8098c98cbb15fe57c54588060fb7f74b24ff4#1",
@@ -127,7 +127,7 @@
       "file": "docs/_data/intuition-sdk/examples/deposit-into-vault.md",
       "fences": [
         {
-          "line": 15,
+          "contentHash": "b51057b8e7f8d3ee",
           "fingerprints": [
             "TS2322:854ebea312e45833464c3443d55d92314ebff53a5402f8a07044ca0077c78518#1",
             "TS2322:854ebea312e45833464c3443d55d92314ebff53a5402f8a07044ca0077c78518#2",
@@ -142,7 +142,7 @@
       "file": "docs/_data/intuition-sdk/examples/find-existing-entities.md",
       "fences": [
         {
-          "line": 17,
+          "contentHash": "9402b4d4b3512adb",
           "fingerprints": [
             "TS2345:6943db3cefa57a72ef194c5f0f1c28504fdd43be4832c3eae8bb99e223169058#1"
           ]
@@ -154,7 +154,7 @@
       "file": "docs/_data/intuition-sdk/installation-and-setup.md",
       "fences": [
         {
-          "line": 151,
+          "contentHash": "9dd807a598f68abd",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -162,7 +162,7 @@
           ]
         },
         {
-          "line": 218,
+          "contentHash": "deb7350333aff9cd",
           "fingerprints": [
             "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#1",
             "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#2",
@@ -172,13 +172,13 @@
           ]
         },
         {
-          "line": 257,
+          "contentHash": "1803ca3843f598b6",
           "fingerprints": [
             "TS2339:ae3773e9f3f642f05d5d18ef4fc7eb7590a681fab18984896df5ba9d97532785#1"
           ]
         },
         {
-          "line": 418,
+          "contentHash": "e7d12bc97514b446",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -192,7 +192,7 @@
       "file": "docs/_data/intuition-sdk/integrations/pinata-ipfs.md",
       "fences": [
         {
-          "line": 78,
+          "contentHash": "cfe26e9611519505",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -200,7 +200,7 @@
           ]
         },
         {
-          "line": 194,
+          "contentHash": "1e8ed60539f1492f",
           "fingerprints": [
             "TS18046:bac87006155f9f3538d48704155ab3d2d0fda073e14f675bfdc8547f209b2861#1"
           ]
@@ -212,26 +212,26 @@
       "file": "docs/_data/intuition-sdk/integrations/react.md",
       "fences": [
         {
-          "line": 36,
+          "contentHash": "5fe47788b3bcfc96",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1",
             "TS2307:c10ca036df7ba79ecc6b5b047055e6ab76bee1861c027793455869fc0f9b78e6#1"
           ]
         },
         {
-          "line": 75,
+          "contentHash": "e510bf511905d8d9",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 133,
+          "contentHash": "a99a577e03ed2db1",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 228,
+          "contentHash": "ee98b47b3f755774",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1",
             "TS2339:ca1bdda15b7577aec68947a4dcde37642112cb31d539a4c89f12d5bfcdc42720#1"
@@ -244,19 +244,19 @@
       "file": "docs/_data/intuition-sdk/integrations/tanstack-query.md",
       "fences": [
         {
-          "line": 67,
+          "contentHash": "06af782b7da2665c",
           "fingerprints": [
             "TS2345:66f2b8235d9a9a67a84f0e32cd0ab3bac00767f42275170d207562638bb5753c#1"
           ]
         },
         {
-          "line": 90,
+          "contentHash": "b189e23ec8458f23",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 132,
+          "contentHash": "99452c51ef51077a",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
@@ -268,7 +268,7 @@
       "file": "docs/_data/intuition-sdk/migration-guide.mdx",
       "fences": [
         {
-          "line": 115,
+          "contentHash": "e5e3d485f7e2573d",
           "fingerprints": [
             "TS2304:3d9d3006a54313825544f2e40434565285086a081f661c8b3bcc883d8342d1bb#1",
             "TS2305:b13a261911cb7c23a70cd23e472a9d0a3a662b69ffbb0804fcfae2f1346e6a56#1",
@@ -276,7 +276,7 @@
           ]
         },
         {
-          "line": 234,
+          "contentHash": "5d0f4a28c190b6a5",
           "fingerprints": [
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
@@ -289,7 +289,7 @@
           ]
         },
         {
-          "line": 253,
+          "contentHash": "37eb8c901507a5e3",
           "fingerprints": [
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
             "TS2304:6b2a7af90e51937c4f32db84fb21abc9e532dbeebaedbafb83933b565712c568#1",
@@ -308,7 +308,7 @@
           ]
         },
         {
-          "line": 280,
+          "contentHash": "0a01ab4656bbe938",
           "fingerprints": [
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
             "TS2304:092fabc9e26b171f990f4404cd887a4fc45a36823ebd12d48066d9876b667ab4#1",
@@ -325,7 +325,7 @@
           ]
         },
         {
-          "line": 298,
+          "contentHash": "fcd7d04d7d1e5a93",
           "fingerprints": [
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
             "TS2304:261ed4df25d82b94d4dd05bf998198207a06e13c2d969e438800e1f0545fc217#1",
@@ -352,7 +352,7 @@
           ]
         },
         {
-          "line": 329,
+          "contentHash": "809ca3698d146e67",
           "fingerprints": [
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#2",
@@ -381,7 +381,7 @@
           ]
         },
         {
-          "line": 350,
+          "contentHash": "fa875d20819ca510",
           "fingerprints": [
             "TS18004:30de6da6d9f559a560c7295758452b3521204662883ef851f1a5655d8cf99971#1",
             "TS2304:06835ca2a6e83e58ab8ba73fe6b42270606ca8b02b62aa8e37a6bf52d8b7ebc9#1",
@@ -408,7 +408,7 @@
           ]
         },
         {
-          "line": 374,
+          "contentHash": "69c33b21f324a6a5",
           "fingerprints": [
             "TS2305:7509755d20e5d2b836dc29034d8575f007c790c10d573e1a86e12ca69c06c8ca#1",
             "TS2305:9e93606532217b71a7007952f7e088203ecd1d98f4f6a022b649a88a48298c7b#1",
@@ -417,7 +417,7 @@
           ]
         },
         {
-          "line": 385,
+          "contentHash": "ee512ac08498d9bb",
           "fingerprints": [
             "TS2305:05f13bdac92d96b7156b5ce6f75a26250da4d41cd441e33f260f058e07a6f4f4#1",
             "TS2305:2bdd2a4397e04f7630afa9fafa5f1ecc165097982e9f4687e0608a32e2386bef#1",
@@ -426,7 +426,7 @@
           ]
         },
         {
-          "line": 398,
+          "contentHash": "25c5ba097051d58d",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -434,7 +434,7 @@
           ]
         },
         {
-          "line": 406,
+          "contentHash": "d51aa7f47a240405",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -442,7 +442,7 @@
           ]
         },
         {
-          "line": 416,
+          "contentHash": "17d2e20102a986b3",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -450,21 +450,21 @@
           ]
         },
         {
-          "line": 425,
+          "contentHash": "3e16659eff78a118",
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
             "TS2304:faf11aba82a1a72f20548db0f0aa23ed16da78a43cacf82fee5c892839676f34#1"
           ]
         },
         {
-          "line": 515,
+          "contentHash": "a3421a9a603acb1e",
           "fingerprints": [
             "TS2305:8a78491e479f235bcd91a26cb78ef6fd459f718ebc6ee5a7dd260a65fb301d5b#1",
             "TS2305:9d0e3b0dfd70aae5d093bd9d7f231e2430cc98b2d95f4fbbf4f66b919f0e651c#1"
           ]
         },
         {
-          "line": 539,
+          "contentHash": "d8e458e622bf5aa9",
           "fingerprints": [
             "TS2304:5b9af3ed027d7f82f525917d64c3dfc293d67da598bd0bfbe5af31bca1458941#1",
             "TS2304:839fe35175bfe678773d86340eff802890d4cebb48f26fac65f3a10c5afc51d2#1",
@@ -474,7 +474,7 @@
           ]
         },
         {
-          "line": 550,
+          "contentHash": "5935479d87ff3444",
           "fingerprints": [
             "TS2304:5b9af3ed027d7f82f525917d64c3dfc293d67da598bd0bfbe5af31bca1458941#1",
             "TS2304:839fe35175bfe678773d86340eff802890d4cebb48f26fac65f3a10c5afc51d2#1",
@@ -489,13 +489,13 @@
       "file": "docs/_data/intuition-sdk/search-guide.md",
       "fences": [
         {
-          "line": 65,
+          "contentHash": "1a4e815e62503ed9",
           "fingerprints": [
             "TS2554:0d7f88caa9641107a48c1e7e16181950d9d374636b6c4d2f833dab296c63e034#1"
           ]
         },
         {
-          "line": 82,
+          "contentHash": "6053780361c8c2aa",
           "fingerprints": [
             "TS18049:374c7ecab5d8fd61ae600fcfa1ca291751c1a3b038fdab9397f9e5c296d4cbb1#1",
             "TS18049:5904503b0e4781475b8ce9134549c78496b80fe25c26ecbbc9059dda824c9d80#1",
@@ -504,7 +504,7 @@
           ]
         },
         {
-          "line": 243,
+          "contentHash": "d28fb72377d6c20d",
           "fingerprints": [
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#1",
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#2",
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "line": 289,
+          "contentHash": "d2ae4d232f5ccbb8",
           "fingerprints": [
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#1",
             "TS18047:0ac7f34d13f7175772b7427b7ad9ed7d947332c211a3c56cbcb9a71eb1f34e69#2",
@@ -522,25 +522,25 @@
           ]
         },
         {
-          "line": 309,
+          "contentHash": "054e361c22a16f37",
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1"
           ]
         },
         {
-          "line": 369,
+          "contentHash": "2664d682e3933e9c",
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1"
           ]
         },
         {
-          "line": 421,
+          "contentHash": "19319adc891effed",
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1"
           ]
         },
         {
-          "line": 448,
+          "contentHash": "8af038848631c133",
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
@@ -556,14 +556,14 @@
       "file": "docs/_data/intuition-sdk/triples-guide.md",
       "fences": [
         {
-          "line": 40,
+          "contentHash": "c67f6d05aae5b85e",
           "fingerprints": [
             "TS2304:faf722e7c9aa72cfb0afd68610f4fa9c1c96b950aae11b7f6867ab2c65846e14#1",
             "TS2391:1f92c271d97dd32e2fb2035087417cae61e16c343aa07574309fb7ad57c7e476#1"
           ]
         },
         {
-          "line": 244,
+          "contentHash": "522bc5cf49f466b8",
           "fingerprints": [
             "TS2304:092fabc9e26b171f990f4404cd887a4fc45a36823ebd12d48066d9876b667ab4#1",
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
@@ -575,13 +575,13 @@
           ]
         },
         {
-          "line": 287,
+          "contentHash": "1d9f24b95e5dcd08",
           "fingerprints": [
             "TS2391:1f92c271d97dd32e2fb2035087417cae61e16c343aa07574309fb7ad57c7e476#1"
           ]
         },
         {
-          "line": 362,
+          "contentHash": "5587b24f06661076",
           "fingerprints": [
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#2",
@@ -602,7 +602,7 @@
           ]
         },
         {
-          "line": 487,
+          "contentHash": "f2f669c71da612e8",
           "fingerprints": [
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#1",
             "TS2304:a05d7e6c5ddafcb12f6867547a766863a9c4ad3addef3b218c92f1a5925d24f8#2",
@@ -610,7 +610,7 @@
           ]
         },
         {
-          "line": 550,
+          "contentHash": "5cfb5b6dc8f05ca5",
           "fingerprints": [
             "TS18048:5a2eb1b9a24d7af06d31d86251ed5bf15d1c58a5d754e9f576ed8396cbef469f#1",
             "TS18048:5a2eb1b9a24d7af06d31d86251ed5bf15d1c58a5d754e9f576ed8396cbef469f#2",
@@ -625,7 +625,7 @@
       "file": "docs/_data/intuition-sdk/vaults-guide.md",
       "fences": [
         {
-          "line": 58,
+          "contentHash": "bf705c482878a343",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -636,7 +636,7 @@
           ]
         },
         {
-          "line": 88,
+          "contentHash": "b029b876f1bbf414",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -656,7 +656,7 @@
           ]
         },
         {
-          "line": 158,
+          "contentHash": "b26d63cadaa234db",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -668,7 +668,7 @@
           ]
         },
         {
-          "line": 181,
+          "contentHash": "69d898dad6f063d1",
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
@@ -677,14 +677,14 @@
           ]
         },
         {
-          "line": 198,
+          "contentHash": "fa9222208fde68df",
           "fingerprints": [
             "TS18048:5a2eb1b9a24d7af06d31d86251ed5bf15d1c58a5d754e9f576ed8396cbef469f#1",
             "TS2345:d6fc8b5d2b4f2a86d67aa98f56bccbbd5cb7bcb2e755371223b0b1cf03addffb#1"
           ]
         },
         {
-          "line": 226,
+          "contentHash": "c911314fcffbfa27",
           "fingerprints": [
             "TS2304:1e1124e156016e84d8a655a00c2def4a7503d0ff85a1c4b50bdb6acc62b398bd#1",
             "TS2304:bff2858a82ef013493213f13bf052dd0c25861d0fee913bff4823c75805c9256#1",
@@ -693,7 +693,8 @@
           ]
         },
         {
-          "line": 254,
+          "contentHash": "b09378c647f34342",
+          "ordinal": 1,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -703,7 +704,7 @@
           ]
         },
         {
-          "line": 325,
+          "contentHash": "6fe88b71c10c901f",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -718,7 +719,7 @@
           ]
         },
         {
-          "line": 356,
+          "contentHash": "991092b7eff1bf45",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -734,7 +735,7 @@
           ]
         },
         {
-          "line": 419,
+          "contentHash": "1ee3c055d698cdd1",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -749,7 +750,7 @@
           ]
         },
         {
-          "line": 441,
+          "contentHash": "3e2b94f2ce8fdff2",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -762,7 +763,7 @@
           ]
         },
         {
-          "line": 484,
+          "contentHash": "e39b975a03949b1c",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -773,7 +774,8 @@
           ]
         },
         {
-          "line": 540,
+          "contentHash": "b09378c647f34342",
+          "ordinal": 2,
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -783,7 +785,7 @@
           ]
         },
         {
-          "line": 566,
+          "contentHash": "497db7c06f2b14fd",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -794,7 +796,7 @@
           ]
         },
         {
-          "line": 593,
+          "contentHash": "746c96f8a3fdba24",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -802,7 +804,7 @@
           ]
         },
         {
-          "line": 626,
+          "contentHash": "62e34bdf30d48090",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -811,7 +813,7 @@
           ]
         },
         {
-          "line": 655,
+          "contentHash": "fc2d9a7b6289eabe",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -821,7 +823,7 @@
           ]
         },
         {
-          "line": 673,
+          "contentHash": "d3bb62593104bbed",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -836,7 +838,7 @@
           ]
         },
         {
-          "line": 700,
+          "contentHash": "1684dfb78949ae15",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -854,13 +856,13 @@
       "file": "docs/_data/quick-start/using-the-sdk.md",
       "fences": [
         {
-          "line": 224,
+          "contentHash": "09e07972b7b57288",
           "fingerprints": [
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 252,
+          "contentHash": "56699f6fab1a6941",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -868,7 +870,7 @@
           ]
         },
         {
-          "line": 268,
+          "contentHash": "40b7f915ecb66ee3",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -877,7 +879,7 @@
           ]
         },
         {
-          "line": 333,
+          "contentHash": "f9594a45554e2f38",
           "fingerprints": [
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
             "TS18004:ac4f84b2017825bfd70eafdebc9cb6f9355e77358475577026b6637c30cb9de2#1",
@@ -886,7 +888,7 @@
           ]
         },
         {
-          "line": 351,
+          "contentHash": "c73a9d0b58811e44",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#2",
@@ -906,7 +908,7 @@
           ]
         },
         {
-          "line": 394,
+          "contentHash": "6b7be7eb48141d7b",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -919,7 +921,7 @@
           ]
         },
         {
-          "line": 415,
+          "contentHash": "731a755f43e5a087",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -932,7 +934,7 @@
           ]
         },
         {
-          "line": 438,
+          "contentHash": "a9439be8f00a11cc",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -943,14 +945,14 @@
           ]
         },
         {
-          "line": 452,
+          "contentHash": "0d173fd46b676a9c",
           "fingerprints": [
             "TS2305:40cae62fd0ddc8020b2b6d3f3418dd2a0dcf1ad33491e737252de36a36394a6d#1",
             "TS2307:9f684f546a73a553f388e71a9ae7bca50303e1d99cad59754601512a5fac3d30#1"
           ]
         },
         {
-          "line": 515,
+          "contentHash": "0c99344998cd8982",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -958,7 +960,7 @@
           ]
         },
         {
-          "line": 554,
+          "contentHash": "e7cd37ec2563f9cf",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",
@@ -976,7 +978,7 @@
           ]
         },
         {
-          "line": 577,
+          "contentHash": "b6d29de1501eec70",
           "fingerprints": [
             "TS18004:184a1f056dbaa8f67561821c22c5fd1717c9e245c7a9fe16098f1891b3dac0b3#1",
             "TS18004:25454910a3ae48adeebc2e467f4031a8b5231d9d99e0138f2677e6fe1eb345db#1",

--- a/scripts/validate-sdk-examples.js
+++ b/scripts/validate-sdk-examples.js
@@ -26,8 +26,25 @@ const ROOT = path.resolve(__dirname, '..');
 const CONFIG_PATH = path.join(__dirname, 'sdk-examples.config.json');
 const FIXTURES_DIR = path.join(__dirname, '__fixtures__', 'sdk-examples');
 const TYPESCRIPT_EXTENSIONS = new Set(['.md', '.mdx']);
+const CONTENT_HASH_LENGTH = 16;
 const IMPORT_PATTERN =
   /(?:^|\n)\s*import(?:\s+type)?[\s\S]*?\sfrom\s+['"]@0xintuition\/[^'"]+['"]/m;
+
+function hashFenceContent(code) {
+  return crypto
+    .createHash('sha256')
+    .update(code)
+    .digest('hex')
+    .slice(0, CONTENT_HASH_LENGTH);
+}
+
+function fenceIdentity(sourceFile, contentHash, ordinal = 1) {
+  return `${sourceFile}#${contentHash}#${ordinal}`;
+}
+
+function displayFence(example) {
+  return `${example.sourceFile}#L${example.fenceLine}`;
+}
 
 function parseArgs(argv) {
   const flags = new Set(argv.slice(2));
@@ -105,29 +122,44 @@ function readConfig({ allowMissingFingerprints = false } = {}) {
       throw new Error('Every knownFailing entry needs a non-empty reason');
     }
 
-    let fences;
-    if (typeof entry.id === 'string') {
-      fences = [{ id: entry.id, fingerprints: entry.fingerprints }];
-    } else if (
-      typeof entry.file === 'string' &&
-      Array.isArray(entry.fences) &&
-      entry.fences.every(
-        (fence) =>
-          (Number.isInteger(fence) && fence > 0) ||
-          (fence && Number.isInteger(fence.line) && fence.line > 0),
-      )
-    ) {
-      fences = entry.fences.map((fence) => ({
-        id: `${entry.file}#L${Number.isInteger(fence) ? fence : fence.line}`,
-        fingerprints: Number.isInteger(fence)
-          ? undefined
-          : fence.fingerprints,
-      }));
-    } else {
+    if (typeof entry.file !== 'string' || !entry.file) {
+      throw new Error('Every knownFailing entry needs a non-empty file');
+    }
+    if (!Array.isArray(entry.fences) || entry.fences.length === 0) {
       throw new Error(
-        'Every knownFailing entry needs either id or file plus positive fence entries',
+        `knownFailing entry ${entry.file} needs a non-empty fences array`,
       );
     }
+
+    const fences = entry.fences.map((fence) => {
+      if (!fence || typeof fence !== 'object' || Array.isArray(fence)) {
+        throw new Error(
+          `Every fence in knownFailing entry ${entry.file} must be an object`,
+        );
+      }
+
+      if (
+        typeof fence.contentHash === 'string' &&
+        new RegExp(`^[0-9a-f]{${CONTENT_HASH_LENGTH}}$`).test(
+          fence.contentHash,
+        ) &&
+        (fence.ordinal === undefined ||
+          (Number.isInteger(fence.ordinal) && fence.ordinal > 0))
+      ) {
+        const ordinal = fence.ordinal || 1;
+        return {
+          id: fenceIdentity(entry.file, fence.contentHash, ordinal),
+          file: entry.file,
+          contentHash: fence.contentHash,
+          ordinal,
+          fingerprints: fence.fingerprints,
+        };
+      }
+
+      throw new Error(
+        `Every fence in knownFailing entry ${entry.file} needs a ${CONTENT_HASH_LENGTH}-character lowercase hex contentHash and optional positive ordinal`,
+      );
+    });
 
     for (const fence of fences) {
       const { id, fingerprints } = fence;
@@ -139,8 +171,7 @@ function readConfig({ allowMissingFingerprints = false } = {}) {
           !Array.isArray(fingerprints) ||
           fingerprints.length === 0 ||
           fingerprints.some(
-            (fingerprint) =>
-              typeof fingerprint !== 'string' || !fingerprint,
+            (fingerprint) => typeof fingerprint !== 'string' || !fingerprint,
           ) ||
           new Set(fingerprints).size !== fingerprints.length
         ) {
@@ -151,13 +182,13 @@ function readConfig({ allowMissingFingerprints = false } = {}) {
       }
       ratchetIds.add(id);
       normalizedKnownFailing.push({
-        id,
+        ...fence,
         fingerprints: fingerprints || [],
         reason: entry.reason,
       });
     }
     knownFailingGroups.push({
-      label: entry.file || entry.id,
+      label: entry.file,
       ids: fences.map((fence) => fence.id),
       reason: entry.reason,
     });
@@ -225,62 +256,129 @@ function closingFencePattern(marker) {
   return new RegExp(`^\\s*${marker[0]}{${marker.length},}\\s*$`);
 }
 
-function extractExamples(files, skipComment) {
-  const examples = [];
-  const coverage = {
+function emptyCoverage() {
+  return {
     found: 0,
     extracted: 0,
     excludedByCriterion: 0,
     skippedByAnnotation: 0,
   };
+}
+
+function addCoverage(target, addition) {
+  for (const key of Object.keys(target)) target[key] += addition[key];
+}
+
+function splitSourceLines(source) {
+  const lines = [];
+  let start = 0;
+
+  while (start < source.length) {
+    const newline = source.indexOf('\n', start);
+    const end = newline === -1 ? source.length : newline + 1;
+    const raw = source.slice(start, end);
+    const withoutNewline = raw.endsWith('\n') ? raw.slice(0, -1) : raw;
+    const text = withoutNewline.endsWith('\r')
+      ? withoutNewline.slice(0, -1)
+      : withoutNewline;
+    lines.push({ start, end, text });
+    start = end;
+  }
+
+  return lines;
+}
+
+function extractExamplesFromSource(relativeFile, source, skipComment) {
+  const examples = [];
+  const coverage = emptyCoverage();
+  const candidates = [];
+  const lines = splitSourceLines(source);
+
+  for (let index = 0; index < lines.length; index++) {
+    const opening = lines[index].text.match(
+      /^\s*(`{3,})(?:typescript|tsx|ts)\b.*$/i,
+    );
+    if (!opening) continue;
+    coverage.found++;
+
+    const fenceLine = index + 1;
+    const content = [];
+    const closingPattern = closingFencePattern(opening[1]);
+    let closingIndex = index + 1;
+    while (
+      closingIndex < lines.length &&
+      !closingPattern.test(lines[closingIndex].text)
+    ) {
+      content.push(lines[closingIndex].text);
+      closingIndex++;
+    }
+
+    if (closingIndex === lines.length) {
+      throw new Error(
+        `Unclosed TypeScript fence at ${relativeFile}:${fenceLine}`,
+      );
+    }
+
+    const code = content.join('\n');
+    const rawCode = source.slice(lines[index].end, lines[closingIndex].start);
+    candidates.push({
+      sourceFile: relativeFile,
+      fenceLine,
+      code,
+      contentHash: hashFenceContent(rawCode),
+      skipped: index > 0 && lines[index - 1].text.trim() === skipComment,
+    });
+    index = closingIndex;
+  }
+
+  const contentCounts = new Map();
+  for (const candidate of candidates) {
+    contentCounts.set(
+      candidate.contentHash,
+      (contentCounts.get(candidate.contentHash) || 0) + 1,
+    );
+  }
+
+  const contentOrdinals = new Map();
+  for (const candidate of candidates) {
+    const ordinal = (contentOrdinals.get(candidate.contentHash) || 0) + 1;
+    contentOrdinals.set(candidate.contentHash, ordinal);
+
+    if (candidate.skipped) {
+      coverage.skippedByAnnotation++;
+    } else if (IMPORT_PATTERN.test(candidate.code)) {
+      const duplicateCount = contentCounts.get(candidate.contentHash);
+      examples.push({
+        id: fenceIdentity(relativeFile, candidate.contentHash, ordinal),
+        sourceFile: relativeFile,
+        fenceLine: candidate.fenceLine,
+        code: candidate.code,
+        contentHash: candidate.contentHash,
+        contentOrdinal: ordinal,
+        duplicateCount,
+      });
+      coverage.extracted++;
+    } else {
+      coverage.excludedByCriterion++;
+    }
+  }
+
+  return { examples, coverage };
+}
+
+function extractExamples(files, skipComment) {
+  const examples = [];
+  const coverage = emptyCoverage();
 
   for (const file of files) {
     const relativeFile = path.relative(ROOT, file).split(path.sep).join('/');
-    const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
-
-    for (let index = 0; index < lines.length; index++) {
-      const opening = lines[index].match(
-        /^\s*(`{3,})(?:typescript|tsx|ts)\b.*$/i,
-      );
-      if (!opening) continue;
-      coverage.found++;
-
-      const fenceLine = index + 1;
-      const content = [];
-      const closingPattern = closingFencePattern(opening[1]);
-      let closingIndex = index + 1;
-      while (
-        closingIndex < lines.length &&
-        !closingPattern.test(lines[closingIndex])
-      ) {
-        content.push(lines[closingIndex]);
-        closingIndex++;
-      }
-
-      if (closingIndex === lines.length) {
-        throw new Error(
-          `Unclosed TypeScript fence at ${relativeFile}:${fenceLine}`,
-        );
-      }
-
-      const code = content.join('\n');
-      const skipped = index > 0 && lines[index - 1].trim() === skipComment;
-      if (skipped) {
-        coverage.skippedByAnnotation++;
-      } else if (IMPORT_PATTERN.test(code)) {
-        examples.push({
-          id: `${relativeFile}#L${fenceLine}`,
-          sourceFile: relativeFile,
-          fenceLine,
-          code,
-        });
-        coverage.extracted++;
-      } else {
-        coverage.excludedByCriterion++;
-      }
-
-      index = closingIndex;
-    }
+    const extracted = extractExamplesFromSource(
+      relativeFile,
+      fs.readFileSync(file, 'utf8'),
+      skipComment,
+    );
+    examples.push(...extracted.examples);
+    addCoverage(coverage, extracted.coverage);
   }
 
   return { examples, coverage };
@@ -409,7 +507,7 @@ function typecheckExamples(examples) {
 
 function formatDiagnostic(diagnostic) {
   const { example } = diagnostic;
-  return `${example.sourceFile}:${diagnostic.sourceLine}:${diagnostic.column} [fence ${example.id}] ${diagnostic.code}: ${diagnostic.message}`;
+  return `${example.sourceFile}:${diagnostic.sourceLine}:${diagnostic.column} [fence ${displayFence(example)}] ${diagnostic.code}: ${diagnostic.message}`;
 }
 
 function fingerprintDiagnostics(diagnostics) {
@@ -432,9 +530,7 @@ function fingerprintDiagnostics(diagnostics) {
         fingerprint: `${base}#${occurrence}`,
       };
     })
-    .sort((left, right) =>
-      left.fingerprint.localeCompare(right.fingerprint),
-    );
+    .sort((left, right) => left.fingerprint.localeCompare(right.fingerprint));
 }
 
 function groupDiagnosticsByFence(diagnostics) {
@@ -448,6 +544,45 @@ function groupDiagnosticsByFence(diagnostics) {
   }
 
   return diagnosticsByFence;
+}
+
+function resolveKnownFailing(config, examples) {
+  const examplesById = new Map(
+    examples.map((example) => [example.id, example]),
+  );
+  const resolvedByOriginalId = new Map();
+  const knownFailing = config.knownFailing.map((entry) => {
+    const example = examplesById.get(entry.id);
+    const resolved = {
+      ...entry,
+      id: example ? example.id : entry.id,
+      example,
+    };
+    resolvedByOriginalId.set(entry.id, resolved);
+    return resolved;
+  });
+
+  const resolvedIds = new Set();
+  for (const entry of knownFailing) {
+    if (resolvedIds.has(entry.id)) {
+      throw new Error(
+        `Multiple knownFailing entries resolve to the same fence: ${formatRatchetEntry(entry)}`,
+      );
+    }
+    resolvedIds.add(entry.id);
+  }
+
+  const knownFailingGroups = config.knownFailingGroups.map((group) => ({
+    ...group,
+    entries: group.ids.map((id) => resolvedByOriginalId.get(id)),
+  }));
+
+  return { knownFailing, knownFailingGroups };
+}
+
+function formatRatchetEntry(entry) {
+  if (entry.example) return displayFence(entry.example);
+  return `${entry.file} [content ${entry.contentHash}, ordinal ${entry.ordinal} not found]`;
 }
 
 function compareRatchet(diagnostics, knownFailing) {
@@ -486,14 +621,47 @@ function printRatchetMismatches(mismatches, logger = console.error) {
 
   logger('  Ratcheted fence fingerprint mismatches:');
   for (const mismatch of mismatches) {
-    logger(`    ${mismatch.entry.id}: ${mismatch.entry.reason}`);
+    logger(
+      `    ${formatRatchetEntry(mismatch.entry)}: ${mismatch.entry.reason}`,
+    );
     for (const item of mismatch.added) {
-      logger(`      NEW ${item.fingerprint}: ${formatDiagnostic(item.diagnostic)}`);
+      logger(
+        `      NEW ${item.fingerprint}: ${formatDiagnostic(item.diagnostic)}`,
+      );
     }
     for (const fingerprint of mismatch.missing) {
       logger(`      MISSING ${fingerprint}`);
     }
   }
+}
+
+function readFixtureRatchets(filename) {
+  const fixture = JSON.parse(
+    fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8'),
+  );
+  const fences = fixture.fences || [fixture];
+
+  return fences.map((fence) => {
+    const ordinal = fence.ordinal || 1;
+    return {
+      id: fenceIdentity(fixture.file, fence.contentHash, ordinal),
+      file: fixture.file,
+      contentHash: fence.contentHash,
+      ordinal,
+      fingerprints: fence.fingerprints,
+      reason: fixture.reason,
+    };
+  });
+}
+
+function attachExamples(entries, examples) {
+  const examplesById = new Map(
+    examples.map((example) => [example.id, example]),
+  );
+  return entries.map((entry) => ({
+    ...entry,
+    example: examplesById.get(entry.id),
+  }));
 }
 
 function runSelfTest(config) {
@@ -504,9 +672,6 @@ function runSelfTest(config) {
     config.skipComment,
   );
   const result = typecheckExamples(examples);
-  const fixtureRatchet = JSON.parse(
-    fs.readFileSync(path.join(FIXTURES_DIR, 'ratcheted.json'), 'utf8'),
-  );
   const good = examples.find((example) =>
     example.sourceFile.endsWith('/good.md'),
   );
@@ -519,15 +684,33 @@ function runSelfTest(config) {
   const ratcheted = examples.find((example) =>
     example.sourceFile.endsWith('/ratcheted.md'),
   );
+  const duplicates = examples.filter((example) =>
+    example.sourceFile.endsWith('/duplicate.md'),
+  );
+  const fixtureRatchet = attachExamples(
+    readFixtureRatchets('ratcheted.json'),
+    examples,
+  )[0];
+  const duplicateRatchets = attachExamples(
+    readFixtureRatchets('duplicate.json'),
+    examples,
+  );
 
-  if (!good || !bad || !ratcheted || skipped || examples.length !== 3) {
+  if (
+    !good ||
+    !bad ||
+    !ratcheted ||
+    skipped ||
+    duplicates.length !== 2 ||
+    examples.length !== 5
+  ) {
     throw new Error(
-      `Expected good.md, bad.md, and ratcheted.md only; extracted ${examples.length}`,
+      `Expected good.md, bad.md, ratcheted.md, and two duplicate.md fences only; extracted ${examples.length}`,
     );
   }
   if (
-    coverage.found !== 4 ||
-    coverage.extracted !== 3 ||
+    coverage.found !== 6 ||
+    coverage.extracted !== 5 ||
     coverage.excludedByCriterion !== 0 ||
     coverage.skippedByAnnotation !== 1
   ) {
@@ -545,6 +728,9 @@ function runSelfTest(config) {
     .join('\n');
   const ratchetedDiagnostics = result.diagnostics.filter(
     (diagnostic) => diagnostic.example.id === ratcheted.id,
+  );
+  const duplicateDiagnostics = result.diagnostics.filter((diagnostic) =>
+    duplicates.some((example) => example.id === diagnostic.example.id),
   );
 
   if (goodDiagnostics.length > 0) {
@@ -574,7 +760,9 @@ function runSelfTest(config) {
     baseline.unexpectedDiagnostics.length > 0 ||
     baseline.mismatches.length > 0
   ) {
-    throw new Error('Ratcheted fixture does not match its fingerprint baseline');
+    throw new Error(
+      'Ratcheted fixture does not match its fingerprint baseline',
+    );
   }
 
   const disappearedComparison = compareRatchet([], [fixtureRatchet]);
@@ -590,37 +778,101 @@ function runSelfTest(config) {
     );
   }
 
-  const injectedExample = {
-    ...ratcheted,
-    code: `${ratcheted.code}\n\nconst injectedRegression: string = 123;\nvoid injectedRegression;`,
-  };
-  const injectedResult = typecheckExamples([injectedExample]);
-  const injectedComparison = compareRatchet(injectedResult.diagnostics, [
-    fixtureRatchet,
-  ]);
-  const injectedMismatch = injectedComparison.mismatches[0];
+  const ratchetedSource = fs.readFileSync(
+    path.join(FIXTURES_DIR, 'ratcheted.md'),
+    'utf8',
+  );
+  const movedExtraction = extractExamplesFromSource(
+    ratcheted.sourceFile,
+    `Moved fixture heading\n\n\n${ratchetedSource}`,
+    config.skipComment,
+  );
+  const moved = movedExtraction.examples[0];
+  const movedResult = typecheckExamples([moved]);
+  const movedComparison = compareRatchet(
+    movedResult.diagnostics,
+    attachExamples([fixtureRatchet], [moved]),
+  );
 
   if (
-    injectedResult.unparsed.length > 0 ||
-    injectedComparison.unexpectedDiagnostics.length > 0 ||
-    injectedComparison.mismatches.length !== 1 ||
-    injectedMismatch.added.length !== 1 ||
-    injectedMismatch.missing.length !== 0 ||
-    injectedMismatch.added[0].diagnostic.code !== 'TS2322'
+    !moved ||
+    moved.id !== ratcheted.id ||
+    moved.fenceLine === ratcheted.fenceLine ||
+    movedResult.unparsed.length > 0 ||
+    movedComparison.unexpectedDiagnostics.length > 0 ||
+    movedComparison.mismatches.length > 0
   ) {
     throw new Error(
-      'Ratcheted-fence regression fixture did not reject exactly the injected diagnostic',
+      'Moved-but-unchanged fixture did not validate against its existing content identity',
+    );
+  }
+
+  const changedSource = ratchetedSource.replace(
+    'void createMultivault;',
+    'void createMultivault; // content changed',
+  );
+  const changedExtraction = extractExamplesFromSource(
+    ratcheted.sourceFile,
+    changedSource,
+    config.skipComment,
+  );
+  const changed = changedExtraction.examples[0];
+  const changedResult = typecheckExamples([changed]);
+  const changedComparison = compareRatchet(changedResult.diagnostics, [
+    fixtureRatchet,
+  ]);
+  const changedMismatch = changedComparison.mismatches[0];
+
+  if (
+    !changed ||
+    changed.id === ratcheted.id ||
+    changedResult.unparsed.length > 0 ||
+    changedComparison.unexpectedDiagnostics.length !== 1 ||
+    changedComparison.mismatches.length !== 1 ||
+    changedMismatch.added.length !== 0 ||
+    changedMismatch.missing.length !== 1
+  ) {
+    throw new Error(
+      'Content-changed fixture did not fail as a new identity plus a missing old identity',
+    );
+  }
+
+  const duplicateComparison = compareRatchet(
+    duplicateDiagnostics,
+    duplicateRatchets,
+  );
+  if (
+    duplicates[0].contentHash !== duplicates[1].contentHash ||
+    duplicates[0].contentOrdinal !== 1 ||
+    duplicates[1].contentOrdinal !== 2 ||
+    duplicates.some((example) => example.duplicateCount !== 2) ||
+    duplicates[0].id === duplicates[1].id ||
+    duplicateComparison.unexpectedDiagnostics.length > 0 ||
+    duplicateComparison.mismatches.length > 0 ||
+    duplicateComparison.diagnosticsByFence.size !== 2
+  ) {
+    throw new Error(
+      'Duplicate-fence fixture did not assign and validate distinct document-order ordinals',
     );
   }
 
   console.log(`  ${formatCoverage(coverage)}`);
-  console.log(`  PASS known-good fixture: ${good.id}`);
+  console.log(`  PASS known-good fixture: ${displayFence(good)}`);
   console.log('  PASS immediately-preceding skip comment excluded skipped.md');
   console.log(
-    `  PASS TSX ratchet baseline matched ${ratchetedDiagnostics.length} expected diagnostic fingerprint: ${fixtureRatchet.id}`,
+    `  PASS TSX ratchet baseline matched ${ratchetedDiagnostics.length} expected diagnostic fingerprint: ${displayFence(ratcheted)}`,
   );
   console.log(
     '  PASS ratcheted-fence disappearance: missing expected fingerprint was rejected.',
+  );
+  console.log(
+    `  PASS moved-but-unchanged: fence shifted from L${ratcheted.fenceLine} to L${moved.fenceLine} with content identity unchanged; validation PASS with NO ratchet update needed.`,
+  );
+  console.log(
+    `  PASS content-changed: edited line at ${displayFence(changed)} changed the content identity; validation FAIL with 1 new-unratcheted diagnostic and 1 missing old ratchet entry (add+remove pair).`,
+  );
+  console.log(
+    `  PASS duplicate-fence ordinals: identical failing fences at L${duplicates[0].fenceLine} and L${duplicates[1].fenceLine} received ordinals 1 and 2; both ratcheted and validation PASS.`,
   );
   console.log(
     `  PASS known-bad fixture failed with ${badDiagnostics.length} diagnostics:`,
@@ -629,26 +881,27 @@ function runSelfTest(config) {
     console.log(`    ${formatDiagnostic(diagnostic)}`);
   }
   console.log(
-    '  PASS ratcheted-fence-regression: injected bad line produced a fingerprint mismatch (validator outcome: FAIL as expected):',
-  );
-  console.log(
-    `    NEW ${injectedMismatch.added[0].fingerprint}: ${formatDiagnostic(injectedMismatch.added[0].diagnostic)}`,
-  );
-  console.log(
-    'Self-test PASS: good passed; known-bad failed; TSX extracted; ratcheted regression rejected.\n',
+    'Self-test PASS: good passed; known-bad failed; TSX extracted; moved content stayed ratcheted; edited content failed; duplicate ordinals validated.\n',
   );
 }
 
 function runRatchetedRegressionDemo(config) {
   console.log('SDK examples ratcheted regression demonstration');
-  const fixtureFiles = walkMarkdownFiles(FIXTURES_DIR).sort();
-  const { examples } = extractExamples(fixtureFiles, config.skipComment);
-  const ratcheted = examples.find((example) =>
-    example.sourceFile.endsWith('/ratcheted.md'),
+  const sourceFile = 'scripts/__fixtures__/sdk-examples/ratcheted.md';
+  const source = fs.readFileSync(
+    path.join(FIXTURES_DIR, 'ratcheted.md'),
+    'utf8',
   );
-  const fixtureRatchet = JSON.parse(
-    fs.readFileSync(path.join(FIXTURES_DIR, 'ratcheted.json'), 'utf8'),
+  const { examples } = extractExamplesFromSource(
+    sourceFile,
+    source,
+    config.skipComment,
   );
+  const ratcheted = examples[0];
+  const fixtureRatchet = attachExamples(
+    readFixtureRatchets('ratcheted.json'),
+    examples,
+  )[0];
 
   if (!ratcheted) {
     throw new Error('Ratcheted regression fixture was not extracted');
@@ -664,25 +917,38 @@ function runRatchetedRegressionDemo(config) {
     throw new Error('Ratcheted regression fixture baseline did not match');
   }
   console.log(
-    `  Baseline PASS: ${fixtureRatchet.id} matched its expected fingerprint set.`,
+    `  Baseline PASS: ${displayFence(ratcheted)} matched its expected fingerprint set.`,
   );
 
-  const injectedResult = typecheckExamples([
-    {
-      ...ratcheted,
-      code: `${ratcheted.code}\n\nconst injectedRegression: string = 123;\nvoid injectedRegression;`,
-    },
-  ]);
-  const injectedComparison = compareRatchet(injectedResult.diagnostics, [
+  const changedSource = source.replace(
+    'void createMultivault;',
+    'void createMultivault; // content changed',
+  );
+  const changed = extractExamplesFromSource(
+    sourceFile,
+    changedSource,
+    config.skipComment,
+  ).examples[0];
+  const changedResult = typecheckExamples([changed]);
+  const changedComparison = compareRatchet(changedResult.diagnostics, [
     fixtureRatchet,
   ]);
 
-  printRatchetMismatches(injectedComparison.mismatches);
-  if (injectedComparison.mismatches.length === 0) {
-    throw new Error('Injected ratcheted-fence regression incorrectly passed');
+  if (changedComparison.unexpectedDiagnostics.length > 0) {
+    console.error('  NEW unratcheted failures:');
+    for (const diagnostic of changedComparison.unexpectedDiagnostics) {
+      console.error(`    ${formatDiagnostic(diagnostic)}`);
+    }
+  }
+  printRatchetMismatches(changedComparison.mismatches);
+  if (
+    changedComparison.unexpectedDiagnostics.length === 0 ||
+    changedComparison.mismatches.length === 0
+  ) {
+    throw new Error('Content-edited ratcheted fence incorrectly passed');
   }
   throw new Error(
-    'Validation FAIL (expected demonstration): an injected diagnostic changed the ratcheted fence fingerprint set',
+    'Validation FAIL (expected demonstration): edited fence content produced the required new-identity plus old-identity add+remove pair',
   );
 }
 
@@ -691,10 +957,11 @@ function runRealDocs(config) {
   const files = expandIncludes(config.include);
   const { examples, coverage } = extractExamples(files, config.skipComment);
   const result = typecheckExamples(examples);
+  const resolved = resolveKnownFailing(config, examples);
   const ratchet = new Map(
-    config.knownFailing.map((entry) => [entry.id, entry]),
+    resolved.knownFailing.map((entry) => [entry.id, entry]),
   );
-  const comparison = compareRatchet(result.diagnostics, config.knownFailing);
+  const comparison = compareRatchet(result.diagnostics, resolved.knownFailing);
   const { diagnosticsByFence, unexpectedDiagnostics, mismatches } = comparison;
 
   const expectedDiagnostics = result.diagnostics.filter((diagnostic) =>
@@ -708,15 +975,17 @@ function runRealDocs(config) {
     console.log(
       `  Expected ratcheted failures (${diagnosticsByFence.size - new Set(unexpectedDiagnostics.map((diagnostic) => diagnostic.example.id)).size} fences, ${expectedDiagnostics.length} diagnostics):`,
     );
-    for (const group of config.knownFailingGroups) {
-      const diagnostics = group.ids.flatMap(
-        (id) => diagnosticsByFence.get(id) || [],
+    for (const group of resolved.knownFailingGroups) {
+      const diagnostics = group.entries.flatMap(
+        (entry) => diagnosticsByFence.get(entry.id) || [],
       );
       if (diagnostics.length === 0) continue;
       console.log(
-        `    ${group.label}: ${group.ids.length} fence${group.ids.length === 1 ? '' : 's'}, ${diagnostics.length} diagnostic${diagnostics.length === 1 ? '' : 's'} — ${group.reason}`,
+        `    ${group.label}: ${group.entries.length} fence${group.entries.length === 1 ? '' : 's'}, ${diagnostics.length} diagnostic${diagnostics.length === 1 ? '' : 's'} — ${group.reason}`,
       );
-      console.log(`      Fences: ${group.ids.join(', ')}`);
+      console.log(
+        `      Fences: ${group.entries.map(formatRatchetEntry).join(', ')}`,
+      );
       console.log(`      Representative: ${formatDiagnostic(diagnostics[0])}`);
     }
   }
@@ -750,7 +1019,7 @@ function runRealDocs(config) {
   }
 
   console.log(
-    `Validation PASS: ${examples.length} fences checked; ${expectedDiagnostics.length} known diagnostics match the fingerprint ratchet; 0 new diagnostics; 0 missing diagnostics.\n`,
+    `Validation PASS: ${examples.length} fences checked; ${resolved.knownFailing.length} ratcheted fences across ${resolved.knownFailingGroups.length} files; ${expectedDiagnostics.length} known diagnostics match the fingerprint ratchet; 0 new diagnostics; 0 missing diagnostics.\n`,
   );
 }
 
@@ -759,12 +1028,13 @@ function updateRatchet(config) {
   const files = expandIncludes(config.include);
   const { examples, coverage } = extractExamples(files, config.skipComment);
   const result = typecheckExamples(examples);
-  const ratchetIds = new Set(config.knownFailing.map((entry) => entry.id));
+  const resolved = resolveKnownFailing(config, examples);
+  const ratchetIds = new Set(resolved.knownFailing.map((entry) => entry.id));
   const diagnosticsByFence = groupDiagnosticsByFence(result.diagnostics);
   const unexpectedDiagnostics = result.diagnostics.filter(
     (diagnostic) => !ratchetIds.has(diagnostic.example.id),
   );
-  const cleanEntries = config.knownFailing.filter(
+  const cleanEntries = resolved.knownFailing.filter(
     (entry) => !diagnosticsByFence.has(entry.id),
   );
 
@@ -782,7 +1052,7 @@ function updateRatchet(config) {
   if (cleanEntries.length > 0) {
     console.error('  Ratchet entries with no diagnostics:');
     for (const entry of cleanEntries) {
-      console.error(`    ${entry.id}: ${entry.reason}`);
+      console.error(`    ${formatRatchetEntry(entry)}: ${entry.reason}`);
     }
   }
   if (result.unparsed.length > 0) {
@@ -796,43 +1066,42 @@ function updateRatchet(config) {
     result.unparsed.length > 0 ||
     (result.status !== 0 && result.diagnostics.length === 0)
   ) {
+    console.error(
+      '  A content-edited ratcheted fence intentionally produces this add+remove pair: a new-unratcheted failure and an old ratchet entry with no diagnostics.',
+    );
     throw new Error(
       'Ratchet update refused: fix unratcheted failures and remove now-clean fence entries first.',
     );
   }
 
-  const updatedKnownFailing = config.sourceConfig.knownFailing.map((entry) => {
-    if (typeof entry.id === 'string') {
-      return {
-        ...entry,
-        fingerprints: fingerprintDiagnostics(
-          diagnosticsByFence.get(entry.id) || [],
-        ).map((item) => item.fingerprint),
-      };
-    }
-
+  const updatedKnownFailing = resolved.knownFailingGroups.map((group) => {
     return {
-      ...entry,
-      fences: entry.fences.map((fence) => {
-        const line = Number.isInteger(fence) ? fence : fence.line;
-        const id = `${entry.file}#L${line}`;
-        return {
-          line,
-          fingerprints: fingerprintDiagnostics(
-            diagnosticsByFence.get(id) || [],
-          ).map((item) => item.fingerprint),
+      file: group.label,
+      fences: group.entries.map((entry) => {
+        const fence = {
+          contentHash: entry.example.contentHash,
         };
+        if (entry.example.duplicateCount > 1) {
+          fence.ordinal = entry.example.contentOrdinal;
+        }
+        fence.fingerprints = fingerprintDiagnostics(
+          diagnosticsByFence.get(entry.id) || [],
+        ).map((item) => item.fingerprint);
+        return fence;
       }),
+      reason: group.reason,
     };
   });
   const updatedConfig = {
     ...config.sourceConfig,
+    ratchetPolicy:
+      'knownFailing groups exact source fence content by file and records the expected diagnostic fingerprint set for each fence. Fence identity uses a truncated SHA-256 content hash plus a document-order ordinal only for identical-content fences in the same file; source line numbers are display-only. Every listed fence is still typechecked. Any added or missing fingerprint fails CI; use --update-ratchet locally for a deliberate baseline refresh, and shrink the fence list when documentation fixes or docs-typecheck skip annotations merge.',
     knownFailing: updatedKnownFailing,
   };
 
   fs.writeFileSync(CONFIG_PATH, `${JSON.stringify(updatedConfig, null, 2)}\n`);
   console.log(
-    `Ratchet update PASS: wrote ${config.knownFailing.length} fence baselines with ${result.diagnostics.length} diagnostic fingerprints to ${path.relative(ROOT, CONFIG_PATH)}.\n`,
+    `Ratchet update PASS: wrote ${resolved.knownFailing.length} content-keyed fence baselines across ${resolved.knownFailingGroups.length} files with ${result.diagnostics.length} diagnostic fingerprints to ${path.relative(ROOT, CONFIG_PATH)}.\n`,
   );
 }
 

--- a/scripts/validate-sdk-examples.js
+++ b/scripts/validate-sdk-examples.js
@@ -12,8 +12,11 @@
  *   node scripts/validate-sdk-examples.js              # self-test + real docs
  *   node scripts/validate-sdk-examples.js --self-test  # fixtures only
  *   node scripts/validate-sdk-examples.js --real-only  # real docs only
+ *   node scripts/validate-sdk-examples.js --update-ratchet
+ *   node scripts/validate-sdk-examples.js --demo-ratchet-regression
  */
 
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -28,7 +31,12 @@ const IMPORT_PATTERN =
 
 function parseArgs(argv) {
   const flags = new Set(argv.slice(2));
-  const knownFlags = new Set(['--self-test', '--real-only']);
+  const knownFlags = new Set([
+    '--self-test',
+    '--real-only',
+    '--update-ratchet',
+    '--demo-ratchet-regression',
+  ]);
 
   for (const flag of flags) {
     if (!knownFlags.has(flag)) {
@@ -39,25 +47,51 @@ function parseArgs(argv) {
   if (flags.has('--self-test') && flags.has('--real-only')) {
     throw new Error('--self-test and --real-only cannot be combined');
   }
+  if (
+    flags.has('--update-ratchet') &&
+    (flags.has('--self-test') || flags.has('--demo-ratchet-regression'))
+  ) {
+    throw new Error(
+      '--update-ratchet cannot be combined with --self-test or --demo-ratchet-regression',
+    );
+  }
+  if (
+    flags.has('--demo-ratchet-regression') &&
+    (flags.has('--self-test') || flags.has('--real-only'))
+  ) {
+    throw new Error(
+      '--demo-ratchet-regression cannot be combined with another mode',
+    );
+  }
 
   return {
-    runSelfTest: !flags.has('--real-only'),
-    runRealDocs: !flags.has('--self-test'),
+    runSelfTest:
+      !flags.has('--real-only') && !flags.has('--demo-ratchet-regression'),
+    runRealDocs:
+      !flags.has('--self-test') && !flags.has('--demo-ratchet-regression'),
+    updateRatchet: flags.has('--update-ratchet'),
+    demoRatchetRegression: flags.has('--demo-ratchet-regression'),
   };
 }
 
-function readConfig() {
-  const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+function readConfig({ allowMissingFingerprints = false } = {}) {
+  const sourceConfig = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 
-  if (!Array.isArray(config.include) || config.include.length === 0) {
+  if (
+    !Array.isArray(sourceConfig.include) ||
+    sourceConfig.include.length === 0
+  ) {
     throw new Error(`${path.relative(ROOT, CONFIG_PATH)} must define include`);
   }
-  if (typeof config.skipComment !== 'string' || !config.skipComment) {
+  if (
+    typeof sourceConfig.skipComment !== 'string' ||
+    !sourceConfig.skipComment
+  ) {
     throw new Error(
       `${path.relative(ROOT, CONFIG_PATH)} must define skipComment`,
     );
   }
-  if (!Array.isArray(config.knownFailing)) {
+  if (!Array.isArray(sourceConfig.knownFailing)) {
     throw new Error(
       `${path.relative(ROOT, CONFIG_PATH)} must define knownFailing`,
     );
@@ -66,44 +100,75 @@ function readConfig() {
   const ratchetIds = new Set();
   const normalizedKnownFailing = [];
   const knownFailingGroups = [];
-  for (const entry of config.knownFailing) {
+  for (const entry of sourceConfig.knownFailing) {
     if (!entry || typeof entry.reason !== 'string' || !entry.reason) {
       throw new Error('Every knownFailing entry needs a non-empty reason');
     }
 
-    let ids;
+    let fences;
     if (typeof entry.id === 'string') {
-      ids = [entry.id];
+      fences = [{ id: entry.id, fingerprints: entry.fingerprints }];
     } else if (
       typeof entry.file === 'string' &&
       Array.isArray(entry.fences) &&
-      entry.fences.every((line) => Number.isInteger(line) && line > 0)
+      entry.fences.every(
+        (fence) =>
+          (Number.isInteger(fence) && fence > 0) ||
+          (fence && Number.isInteger(fence.line) && fence.line > 0),
+      )
     ) {
-      ids = entry.fences.map((line) => `${entry.file}#L${line}`);
+      fences = entry.fences.map((fence) => ({
+        id: `${entry.file}#L${Number.isInteger(fence) ? fence : fence.line}`,
+        fingerprints: Number.isInteger(fence)
+          ? undefined
+          : fence.fingerprints,
+      }));
     } else {
       throw new Error(
-        'Every knownFailing entry needs either id or file plus positive fence lines',
+        'Every knownFailing entry needs either id or file plus positive fence entries',
       );
     }
 
-    for (const id of ids) {
+    for (const fence of fences) {
+      const { id, fingerprints } = fence;
       if (ratchetIds.has(id)) {
         throw new Error(`Duplicate knownFailing fence: ${id}`);
       }
+      if (!allowMissingFingerprints || fingerprints !== undefined) {
+        if (
+          !Array.isArray(fingerprints) ||
+          fingerprints.length === 0 ||
+          fingerprints.some(
+            (fingerprint) =>
+              typeof fingerprint !== 'string' || !fingerprint,
+          ) ||
+          new Set(fingerprints).size !== fingerprints.length
+        ) {
+          throw new Error(
+            `knownFailing fence ${id} needs a non-empty set of unique diagnostic fingerprints; run --update-ratchet`,
+          );
+        }
+      }
       ratchetIds.add(id);
-      normalizedKnownFailing.push({ id, reason: entry.reason });
+      normalizedKnownFailing.push({
+        id,
+        fingerprints: fingerprints || [],
+        reason: entry.reason,
+      });
     }
     knownFailingGroups.push({
       label: entry.file || entry.id,
-      ids,
+      ids: fences.map((fence) => fence.id),
       reason: entry.reason,
     });
   }
 
-  config.knownFailing = normalizedKnownFailing;
-  config.knownFailingGroups = knownFailingGroups;
-
-  return config;
+  return {
+    ...sourceConfig,
+    knownFailing: normalizedKnownFailing,
+    knownFailingGroups,
+    sourceConfig,
+  };
 }
 
 function assertInsideRoot(targetPath) {
@@ -162,14 +227,23 @@ function closingFencePattern(marker) {
 
 function extractExamples(files, skipComment) {
   const examples = [];
+  const coverage = {
+    found: 0,
+    extracted: 0,
+    excludedByCriterion: 0,
+    skippedByAnnotation: 0,
+  };
 
   for (const file of files) {
     const relativeFile = path.relative(ROOT, file).split(path.sep).join('/');
     const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
 
     for (let index = 0; index < lines.length; index++) {
-      const opening = lines[index].match(/^\s*(`{3,})(?:typescript|ts)\b.*$/i);
+      const opening = lines[index].match(
+        /^\s*(`{3,})(?:typescript|tsx|ts)\b.*$/i,
+      );
       if (!opening) continue;
+      coverage.found++;
 
       const fenceLine = index + 1;
       const content = [];
@@ -191,20 +265,25 @@ function extractExamples(files, skipComment) {
 
       const code = content.join('\n');
       const skipped = index > 0 && lines[index - 1].trim() === skipComment;
-      if (!skipped && IMPORT_PATTERN.test(code)) {
+      if (skipped) {
+        coverage.skippedByAnnotation++;
+      } else if (IMPORT_PATTERN.test(code)) {
         examples.push({
           id: `${relativeFile}#L${fenceLine}`,
           sourceFile: relativeFile,
           fenceLine,
           code,
         });
+        coverage.extracted++;
+      } else {
+        coverage.excludedByCriterion++;
       }
 
       index = closingIndex;
     }
   }
 
-  return examples;
+  return { examples, coverage };
 }
 
 function parseDiagnostics(output, virtualFiles) {
@@ -333,11 +412,101 @@ function formatDiagnostic(diagnostic) {
   return `${example.sourceFile}:${diagnostic.sourceLine}:${diagnostic.column} [fence ${example.id}] ${diagnostic.code}: ${diagnostic.message}`;
 }
 
+function fingerprintDiagnostics(diagnostics) {
+  const occurrences = new Map();
+
+  // A fingerprint is TS code + SHA-256(message) + same-message occurrence.
+  // It deliberately omits line/column positions, so unrelated line shifts inside
+  // a fence do not churn the ratchet while duplicate diagnostics remain counted.
+  return diagnostics
+    .map((diagnostic) => {
+      const messageHash = crypto
+        .createHash('sha256')
+        .update(diagnostic.message)
+        .digest('hex');
+      const base = `${diagnostic.code}:${messageHash}`;
+      const occurrence = (occurrences.get(base) || 0) + 1;
+      occurrences.set(base, occurrence);
+      return {
+        diagnostic,
+        fingerprint: `${base}#${occurrence}`,
+      };
+    })
+    .sort((left, right) =>
+      left.fingerprint.localeCompare(right.fingerprint),
+    );
+}
+
+function groupDiagnosticsByFence(diagnostics) {
+  const diagnosticsByFence = new Map();
+
+  for (const diagnostic of diagnostics) {
+    const fenceDiagnostics =
+      diagnosticsByFence.get(diagnostic.example.id) || [];
+    fenceDiagnostics.push(diagnostic);
+    diagnosticsByFence.set(diagnostic.example.id, fenceDiagnostics);
+  }
+
+  return diagnosticsByFence;
+}
+
+function compareRatchet(diagnostics, knownFailing) {
+  const ratchet = new Map(knownFailing.map((entry) => [entry.id, entry]));
+  const diagnosticsByFence = groupDiagnosticsByFence(diagnostics);
+  const unexpectedDiagnostics = diagnostics.filter(
+    (diagnostic) => !ratchet.has(diagnostic.example.id),
+  );
+  const mismatches = [];
+
+  for (const entry of knownFailing) {
+    const actual = fingerprintDiagnostics(
+      diagnosticsByFence.get(entry.id) || [],
+    );
+    const expected = new Set(entry.fingerprints);
+    const actualSet = new Set(actual.map((item) => item.fingerprint));
+    const added = actual.filter((item) => !expected.has(item.fingerprint));
+    const missing = entry.fingerprints.filter(
+      (fingerprint) => !actualSet.has(fingerprint),
+    );
+
+    if (added.length > 0 || missing.length > 0) {
+      mismatches.push({ entry, added, missing });
+    }
+  }
+
+  return { diagnosticsByFence, unexpectedDiagnostics, mismatches };
+}
+
+function formatCoverage(coverage) {
+  return `Coverage: ${coverage.found} fences found / ${coverage.extracted} extracted / ${coverage.excludedByCriterion} excluded-by-criterion / ${coverage.skippedByAnnotation} skipped-by-annotation.`;
+}
+
+function printRatchetMismatches(mismatches, logger = console.error) {
+  if (mismatches.length === 0) return;
+
+  logger('  Ratcheted fence fingerprint mismatches:');
+  for (const mismatch of mismatches) {
+    logger(`    ${mismatch.entry.id}: ${mismatch.entry.reason}`);
+    for (const item of mismatch.added) {
+      logger(`      NEW ${item.fingerprint}: ${formatDiagnostic(item.diagnostic)}`);
+    }
+    for (const fingerprint of mismatch.missing) {
+      logger(`      MISSING ${fingerprint}`);
+    }
+  }
+}
+
 function runSelfTest(config) {
   console.log('SDK examples self-test');
   const fixtureFiles = walkMarkdownFiles(FIXTURES_DIR).sort();
-  const examples = extractExamples(fixtureFiles, config.skipComment);
+  const { examples, coverage } = extractExamples(
+    fixtureFiles,
+    config.skipComment,
+  );
   const result = typecheckExamples(examples);
+  const fixtureRatchet = JSON.parse(
+    fs.readFileSync(path.join(FIXTURES_DIR, 'ratcheted.json'), 'utf8'),
+  );
   const good = examples.find((example) =>
     example.sourceFile.endsWith('/good.md'),
   );
@@ -347,11 +516,22 @@ function runSelfTest(config) {
   const skipped = examples.find((example) =>
     example.sourceFile.endsWith('/skipped.md'),
   );
+  const ratcheted = examples.find((example) =>
+    example.sourceFile.endsWith('/ratcheted.md'),
+  );
 
-  if (!good || !bad || skipped || examples.length !== 2) {
+  if (!good || !bad || !ratcheted || skipped || examples.length !== 3) {
     throw new Error(
-      `Expected exactly good.md and bad.md, extracted ${examples.length}`,
+      `Expected good.md, bad.md, and ratcheted.md only; extracted ${examples.length}`,
     );
+  }
+  if (
+    coverage.found !== 4 ||
+    coverage.extracted !== 3 ||
+    coverage.excludedByCriterion !== 0 ||
+    coverage.skippedByAnnotation !== 1
+  ) {
+    throw new Error(`Unexpected fixture coverage: ${formatCoverage(coverage)}`);
   }
 
   const goodDiagnostics = result.diagnostics.filter(
@@ -363,6 +543,9 @@ function runSelfTest(config) {
   const badMessages = badDiagnostics
     .map((diagnostic) => diagnostic.message)
     .join('\n');
+  const ratchetedDiagnostics = result.diagnostics.filter(
+    (diagnostic) => diagnostic.example.id === ratcheted.id,
+  );
 
   if (goodDiagnostics.length > 0) {
     throw new Error(
@@ -386,8 +569,59 @@ function runSelfTest(config) {
     throw new Error(`Unmapped tsc output:\n${result.unparsed.join('\n')}`);
   }
 
+  const baseline = compareRatchet(ratchetedDiagnostics, [fixtureRatchet]);
+  if (
+    baseline.unexpectedDiagnostics.length > 0 ||
+    baseline.mismatches.length > 0
+  ) {
+    throw new Error('Ratcheted fixture does not match its fingerprint baseline');
+  }
+
+  const disappearedComparison = compareRatchet([], [fixtureRatchet]);
+  const disappearedMismatch = disappearedComparison.mismatches[0];
+  if (
+    disappearedComparison.mismatches.length !== 1 ||
+    disappearedMismatch.added.length !== 0 ||
+    disappearedMismatch.missing.length !== 1 ||
+    disappearedMismatch.missing[0] !== fixtureRatchet.fingerprints[0]
+  ) {
+    throw new Error(
+      'Ratcheted-fence fixture did not reject a missing expected diagnostic',
+    );
+  }
+
+  const injectedExample = {
+    ...ratcheted,
+    code: `${ratcheted.code}\n\nconst injectedRegression: string = 123;\nvoid injectedRegression;`,
+  };
+  const injectedResult = typecheckExamples([injectedExample]);
+  const injectedComparison = compareRatchet(injectedResult.diagnostics, [
+    fixtureRatchet,
+  ]);
+  const injectedMismatch = injectedComparison.mismatches[0];
+
+  if (
+    injectedResult.unparsed.length > 0 ||
+    injectedComparison.unexpectedDiagnostics.length > 0 ||
+    injectedComparison.mismatches.length !== 1 ||
+    injectedMismatch.added.length !== 1 ||
+    injectedMismatch.missing.length !== 0 ||
+    injectedMismatch.added[0].diagnostic.code !== 'TS2322'
+  ) {
+    throw new Error(
+      'Ratcheted-fence regression fixture did not reject exactly the injected diagnostic',
+    );
+  }
+
+  console.log(`  ${formatCoverage(coverage)}`);
   console.log(`  PASS known-good fixture: ${good.id}`);
   console.log('  PASS immediately-preceding skip comment excluded skipped.md');
+  console.log(
+    `  PASS TSX ratchet baseline matched ${ratchetedDiagnostics.length} expected diagnostic fingerprint: ${fixtureRatchet.id}`,
+  );
+  console.log(
+    '  PASS ratcheted-fence disappearance: missing expected fingerprint was rejected.',
+  );
   console.log(
     `  PASS known-bad fixture failed with ${badDiagnostics.length} diagnostics:`,
   );
@@ -395,38 +629,80 @@ function runSelfTest(config) {
     console.log(`    ${formatDiagnostic(diagnostic)}`);
   }
   console.log(
-    'Self-test PASS: good passed; bad failed for stale export and result field.\n',
+    '  PASS ratcheted-fence-regression: injected bad line produced a fingerprint mismatch (validator outcome: FAIL as expected):',
+  );
+  console.log(
+    `    NEW ${injectedMismatch.added[0].fingerprint}: ${formatDiagnostic(injectedMismatch.added[0].diagnostic)}`,
+  );
+  console.log(
+    'Self-test PASS: good passed; known-bad failed; TSX extracted; ratcheted regression rejected.\n',
+  );
+}
+
+function runRatchetedRegressionDemo(config) {
+  console.log('SDK examples ratcheted regression demonstration');
+  const fixtureFiles = walkMarkdownFiles(FIXTURES_DIR).sort();
+  const { examples } = extractExamples(fixtureFiles, config.skipComment);
+  const ratcheted = examples.find((example) =>
+    example.sourceFile.endsWith('/ratcheted.md'),
+  );
+  const fixtureRatchet = JSON.parse(
+    fs.readFileSync(path.join(FIXTURES_DIR, 'ratcheted.json'), 'utf8'),
+  );
+
+  if (!ratcheted) {
+    throw new Error('Ratcheted regression fixture was not extracted');
+  }
+
+  const baselineResult = typecheckExamples([ratcheted]);
+  const baseline = compareRatchet(baselineResult.diagnostics, [fixtureRatchet]);
+  if (
+    baselineResult.unparsed.length > 0 ||
+    baseline.unexpectedDiagnostics.length > 0 ||
+    baseline.mismatches.length > 0
+  ) {
+    throw new Error('Ratcheted regression fixture baseline did not match');
+  }
+  console.log(
+    `  Baseline PASS: ${fixtureRatchet.id} matched its expected fingerprint set.`,
+  );
+
+  const injectedResult = typecheckExamples([
+    {
+      ...ratcheted,
+      code: `${ratcheted.code}\n\nconst injectedRegression: string = 123;\nvoid injectedRegression;`,
+    },
+  ]);
+  const injectedComparison = compareRatchet(injectedResult.diagnostics, [
+    fixtureRatchet,
+  ]);
+
+  printRatchetMismatches(injectedComparison.mismatches);
+  if (injectedComparison.mismatches.length === 0) {
+    throw new Error('Injected ratcheted-fence regression incorrectly passed');
+  }
+  throw new Error(
+    'Validation FAIL (expected demonstration): an injected diagnostic changed the ratcheted fence fingerprint set',
   );
 }
 
 function runRealDocs(config) {
   console.log('SDK documentation examples');
   const files = expandIncludes(config.include);
-  const examples = extractExamples(files, config.skipComment);
+  const { examples, coverage } = extractExamples(files, config.skipComment);
   const result = typecheckExamples(examples);
   const ratchet = new Map(
     config.knownFailing.map((entry) => [entry.id, entry]),
   );
-  const diagnosticsByFence = new Map();
-
-  for (const diagnostic of result.diagnostics) {
-    const diagnostics = diagnosticsByFence.get(diagnostic.example.id) || [];
-    diagnostics.push(diagnostic);
-    diagnosticsByFence.set(diagnostic.example.id, diagnostics);
-  }
+  const comparison = compareRatchet(result.diagnostics, config.knownFailing);
+  const { diagnosticsByFence, unexpectedDiagnostics, mismatches } = comparison;
 
   const expectedDiagnostics = result.diagnostics.filter((diagnostic) =>
     ratchet.has(diagnostic.example.id),
   );
-  const unexpectedDiagnostics = result.diagnostics.filter(
-    (diagnostic) => !ratchet.has(diagnostic.example.id),
-  );
-  const staleRatchet = config.knownFailing.filter(
-    (entry) => !diagnosticsByFence.has(entry.id),
-  );
 
   console.log(`  Scanned ${files.length} Markdown/MDX files.`);
-  console.log(`  Extracted ${examples.length} qualifying TypeScript fences.`);
+  console.log(`  ${formatCoverage(coverage)}`);
 
   if (expectedDiagnostics.length > 0) {
     console.log(
@@ -454,13 +730,7 @@ function runRealDocs(config) {
     }
   }
 
-  if (staleRatchet.length > 0) {
-    console.error(
-      '  Ratchet entries that no longer fail (remove or update them):',
-    );
-    for (const entry of staleRatchet)
-      console.error(`    ${entry.id}: ${entry.reason}`);
-  }
+  printRatchetMismatches(mismatches);
 
   if (result.unparsed.length > 0) {
     console.error('  Unmapped tsc output:');
@@ -469,27 +739,115 @@ function runRealDocs(config) {
 
   const failed =
     unexpectedDiagnostics.length > 0 ||
-    staleRatchet.length > 0 ||
+    mismatches.length > 0 ||
     result.unparsed.length > 0 ||
     (result.status !== 0 && result.diagnostics.length === 0);
 
   if (failed) {
     throw new Error(
-      'SDK documentation example validation failed. New failures must be fixed or explicitly ratcheted.',
+      'SDK documentation example validation failed. Fix diagnostics or deliberately refresh the existing baseline with --update-ratchet.',
     );
   }
 
   console.log(
-    `Validation PASS: ${examples.length} fences checked; ${expectedDiagnostics.length} known diagnostics remain ratcheted; 0 new diagnostics.\n`,
+    `Validation PASS: ${examples.length} fences checked; ${expectedDiagnostics.length} known diagnostics match the fingerprint ratchet; 0 new diagnostics; 0 missing diagnostics.\n`,
+  );
+}
+
+function updateRatchet(config) {
+  console.log('SDK documentation examples — update ratchet');
+  const files = expandIncludes(config.include);
+  const { examples, coverage } = extractExamples(files, config.skipComment);
+  const result = typecheckExamples(examples);
+  const ratchetIds = new Set(config.knownFailing.map((entry) => entry.id));
+  const diagnosticsByFence = groupDiagnosticsByFence(result.diagnostics);
+  const unexpectedDiagnostics = result.diagnostics.filter(
+    (diagnostic) => !ratchetIds.has(diagnostic.example.id),
+  );
+  const cleanEntries = config.knownFailing.filter(
+    (entry) => !diagnosticsByFence.has(entry.id),
+  );
+
+  console.log(`  Scanned ${files.length} Markdown/MDX files.`);
+  console.log(`  ${formatCoverage(coverage)}`);
+
+  if (unexpectedDiagnostics.length > 0) {
+    console.error(
+      `  NEW unratcheted failures (${unexpectedDiagnostics.length} diagnostics):`,
+    );
+    for (const diagnostic of unexpectedDiagnostics) {
+      console.error(`    ${formatDiagnostic(diagnostic)}`);
+    }
+  }
+  if (cleanEntries.length > 0) {
+    console.error('  Ratchet entries with no diagnostics:');
+    for (const entry of cleanEntries) {
+      console.error(`    ${entry.id}: ${entry.reason}`);
+    }
+  }
+  if (result.unparsed.length > 0) {
+    console.error('  Unmapped tsc output:');
+    for (const line of result.unparsed) console.error(`    ${line}`);
+  }
+
+  if (
+    unexpectedDiagnostics.length > 0 ||
+    cleanEntries.length > 0 ||
+    result.unparsed.length > 0 ||
+    (result.status !== 0 && result.diagnostics.length === 0)
+  ) {
+    throw new Error(
+      'Ratchet update refused: fix unratcheted failures and remove now-clean fence entries first.',
+    );
+  }
+
+  const updatedKnownFailing = config.sourceConfig.knownFailing.map((entry) => {
+    if (typeof entry.id === 'string') {
+      return {
+        ...entry,
+        fingerprints: fingerprintDiagnostics(
+          diagnosticsByFence.get(entry.id) || [],
+        ).map((item) => item.fingerprint),
+      };
+    }
+
+    return {
+      ...entry,
+      fences: entry.fences.map((fence) => {
+        const line = Number.isInteger(fence) ? fence : fence.line;
+        const id = `${entry.file}#L${line}`;
+        return {
+          line,
+          fingerprints: fingerprintDiagnostics(
+            diagnosticsByFence.get(id) || [],
+          ).map((item) => item.fingerprint),
+        };
+      }),
+    };
+  });
+  const updatedConfig = {
+    ...config.sourceConfig,
+    knownFailing: updatedKnownFailing,
+  };
+
+  fs.writeFileSync(CONFIG_PATH, `${JSON.stringify(updatedConfig, null, 2)}\n`);
+  console.log(
+    `Ratchet update PASS: wrote ${config.knownFailing.length} fence baselines with ${result.diagnostics.length} diagnostic fingerprints to ${path.relative(ROOT, CONFIG_PATH)}.\n`,
   );
 }
 
 function main() {
   const args = parseArgs(process.argv);
-  const config = readConfig();
+  const config = readConfig({
+    allowMissingFingerprints: args.updateRatchet,
+  });
 
+  if (args.demoRatchetRegression) runRatchetedRegressionDemo(config);
   if (args.runSelfTest) runSelfTest(config);
-  if (args.runRealDocs) runRealDocs(config);
+  if (args.runRealDocs) {
+    if (args.updateRatchet) updateRatchet(config);
+    else runRealDocs(config);
+  }
 }
 
 try {

--- a/scripts/validate-sdk-examples.js
+++ b/scripts/validate-sdk-examples.js
@@ -1,0 +1,500 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Extract and typecheck selected SDK documentation examples.
+ *
+ * The default command first proves the checker with one passing and one
+ * intentionally failing fixture, then validates the configured documentation.
+ * Every mode uses the same Markdown extraction and temp-project tsc pipeline.
+ *
+ * Usage:
+ *   node scripts/validate-sdk-examples.js              # self-test + real docs
+ *   node scripts/validate-sdk-examples.js --self-test  # fixtures only
+ *   node scripts/validate-sdk-examples.js --real-only  # real docs only
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const CONFIG_PATH = path.join(__dirname, 'sdk-examples.config.json');
+const FIXTURES_DIR = path.join(__dirname, '__fixtures__', 'sdk-examples');
+const TYPESCRIPT_EXTENSIONS = new Set(['.md', '.mdx']);
+const IMPORT_PATTERN =
+  /(?:^|\n)\s*import(?:\s+type)?[\s\S]*?\sfrom\s+['"]@0xintuition\/[^'"]+['"]/m;
+
+function parseArgs(argv) {
+  const flags = new Set(argv.slice(2));
+  const knownFlags = new Set(['--self-test', '--real-only']);
+
+  for (const flag of flags) {
+    if (!knownFlags.has(flag)) {
+      throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  if (flags.has('--self-test') && flags.has('--real-only')) {
+    throw new Error('--self-test and --real-only cannot be combined');
+  }
+
+  return {
+    runSelfTest: !flags.has('--real-only'),
+    runRealDocs: !flags.has('--self-test'),
+  };
+}
+
+function readConfig() {
+  const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+  if (!Array.isArray(config.include) || config.include.length === 0) {
+    throw new Error(`${path.relative(ROOT, CONFIG_PATH)} must define include`);
+  }
+  if (typeof config.skipComment !== 'string' || !config.skipComment) {
+    throw new Error(
+      `${path.relative(ROOT, CONFIG_PATH)} must define skipComment`,
+    );
+  }
+  if (!Array.isArray(config.knownFailing)) {
+    throw new Error(
+      `${path.relative(ROOT, CONFIG_PATH)} must define knownFailing`,
+    );
+  }
+
+  const ratchetIds = new Set();
+  const normalizedKnownFailing = [];
+  const knownFailingGroups = [];
+  for (const entry of config.knownFailing) {
+    if (!entry || typeof entry.reason !== 'string' || !entry.reason) {
+      throw new Error('Every knownFailing entry needs a non-empty reason');
+    }
+
+    let ids;
+    if (typeof entry.id === 'string') {
+      ids = [entry.id];
+    } else if (
+      typeof entry.file === 'string' &&
+      Array.isArray(entry.fences) &&
+      entry.fences.every((line) => Number.isInteger(line) && line > 0)
+    ) {
+      ids = entry.fences.map((line) => `${entry.file}#L${line}`);
+    } else {
+      throw new Error(
+        'Every knownFailing entry needs either id or file plus positive fence lines',
+      );
+    }
+
+    for (const id of ids) {
+      if (ratchetIds.has(id)) {
+        throw new Error(`Duplicate knownFailing fence: ${id}`);
+      }
+      ratchetIds.add(id);
+      normalizedKnownFailing.push({ id, reason: entry.reason });
+    }
+    knownFailingGroups.push({
+      label: entry.file || entry.id,
+      ids,
+      reason: entry.reason,
+    });
+  }
+
+  config.knownFailing = normalizedKnownFailing;
+  config.knownFailingGroups = knownFailingGroups;
+
+  return config;
+}
+
+function assertInsideRoot(targetPath) {
+  const relative = path.relative(ROOT, targetPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Configured path escapes the repository: ${targetPath}`);
+  }
+}
+
+function walkMarkdownFiles(directory) {
+  const files = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkMarkdownFiles(entryPath));
+    } else if (
+      entry.isFile() &&
+      TYPESCRIPT_EXTENSIONS.has(path.extname(entry.name))
+    ) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function expandIncludes(patterns) {
+  const files = new Set();
+
+  for (const pattern of patterns) {
+    const recursive = pattern.endsWith('/**');
+    const relativePath = recursive ? pattern.slice(0, -3) : pattern;
+    const targetPath = path.resolve(ROOT, relativePath);
+    assertInsideRoot(targetPath);
+
+    if (!fs.existsSync(targetPath)) {
+      throw new Error(`Configured include does not exist: ${pattern}`);
+    }
+
+    if (recursive) {
+      for (const file of walkMarkdownFiles(targetPath)) files.add(file);
+    } else if (TYPESCRIPT_EXTENSIONS.has(path.extname(targetPath))) {
+      files.add(targetPath);
+    } else {
+      throw new Error(`Unsupported include pattern: ${pattern}`);
+    }
+  }
+
+  return [...files].sort();
+}
+
+function closingFencePattern(marker) {
+  return new RegExp(`^\\s*${marker[0]}{${marker.length},}\\s*$`);
+}
+
+function extractExamples(files, skipComment) {
+  const examples = [];
+
+  for (const file of files) {
+    const relativeFile = path.relative(ROOT, file).split(path.sep).join('/');
+    const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+
+    for (let index = 0; index < lines.length; index++) {
+      const opening = lines[index].match(/^\s*(`{3,})(?:typescript|ts)\b.*$/i);
+      if (!opening) continue;
+
+      const fenceLine = index + 1;
+      const content = [];
+      const closingPattern = closingFencePattern(opening[1]);
+      let closingIndex = index + 1;
+      while (
+        closingIndex < lines.length &&
+        !closingPattern.test(lines[closingIndex])
+      ) {
+        content.push(lines[closingIndex]);
+        closingIndex++;
+      }
+
+      if (closingIndex === lines.length) {
+        throw new Error(
+          `Unclosed TypeScript fence at ${relativeFile}:${fenceLine}`,
+        );
+      }
+
+      const code = content.join('\n');
+      const skipped = index > 0 && lines[index - 1].trim() === skipComment;
+      if (!skipped && IMPORT_PATTERN.test(code)) {
+        examples.push({
+          id: `${relativeFile}#L${fenceLine}`,
+          sourceFile: relativeFile,
+          fenceLine,
+          code,
+        });
+      }
+
+      index = closingIndex;
+    }
+  }
+
+  return examples;
+}
+
+function parseDiagnostics(output, virtualFiles) {
+  const diagnostics = [];
+  const unparsed = [];
+  const diagnosticPattern = /^(.*)\((\d+),(\d+)\): error (TS\d+): (.*)$/;
+
+  for (const line of output.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const match = line.match(diagnosticPattern);
+    if (!match) {
+      if (/^\s+/.test(line) && diagnostics.length > 0) {
+        const previous = diagnostics[diagnostics.length - 1];
+        previous.message = `${previous.message} ${line.trim()}`;
+        continue;
+      }
+      unparsed.push(line);
+      continue;
+    }
+
+    const virtualName = path.basename(match[1]);
+    const example = virtualFiles.get(virtualName);
+    if (!example) {
+      unparsed.push(line);
+      continue;
+    }
+
+    const virtualLine = Number(match[2]);
+    diagnostics.push({
+      example,
+      sourceLine: example.fenceLine + virtualLine,
+      column: Number(match[3]),
+      code: match[4],
+      message: match[5],
+    });
+  }
+
+  return { diagnostics, unparsed };
+}
+
+function typecheckExamples(examples) {
+  const typescriptPath = path.join(
+    ROOT,
+    'node_modules',
+    'typescript',
+    'bin',
+    'tsc',
+  );
+  const nodeModulesPath = path.join(ROOT, 'node_modules');
+
+  if (!fs.existsSync(typescriptPath)) {
+    throw new Error(
+      'TypeScript is not installed; run npm install or npm ci first',
+    );
+  }
+  if (!fs.existsSync(nodeModulesPath)) {
+    throw new Error('node_modules is missing; run npm install or npm ci first');
+  }
+
+  const tempDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'intuition-sdk-examples-'),
+  );
+  const virtualFiles = new Map();
+
+  try {
+    fs.symlinkSync(
+      nodeModulesPath,
+      path.join(tempDirectory, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    examples.forEach((example, index) => {
+      const virtualName = `example-${String(index + 1).padStart(4, '0')}.tsx`;
+      virtualFiles.set(virtualName, example);
+      fs.writeFileSync(
+        path.join(tempDirectory, virtualName),
+        `${example.code}\n`,
+      );
+    });
+
+    const tsconfig = {
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'Bundler',
+        lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+        types: ['node'],
+        jsx: 'react-jsx',
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+        esModuleInterop: true,
+        resolveJsonModule: true,
+      },
+      files: [...virtualFiles.keys()],
+    };
+    const tsconfigPath = path.join(tempDirectory, 'tsconfig.json');
+    fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
+
+    const result = spawnSync(
+      process.execPath,
+      [typescriptPath, '--project', tsconfigPath, '--pretty', 'false'],
+      {
+        cwd: tempDirectory,
+        encoding: 'utf8',
+        maxBuffer: 50 * 1024 * 1024,
+      },
+    );
+
+    if (result.error) throw result.error;
+    const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+    const parsed = parseDiagnostics(output, virtualFiles);
+
+    return {
+      status: result.status,
+      output,
+      ...parsed,
+    };
+  } finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+function formatDiagnostic(diagnostic) {
+  const { example } = diagnostic;
+  return `${example.sourceFile}:${diagnostic.sourceLine}:${diagnostic.column} [fence ${example.id}] ${diagnostic.code}: ${diagnostic.message}`;
+}
+
+function runSelfTest(config) {
+  console.log('SDK examples self-test');
+  const fixtureFiles = walkMarkdownFiles(FIXTURES_DIR).sort();
+  const examples = extractExamples(fixtureFiles, config.skipComment);
+  const result = typecheckExamples(examples);
+  const good = examples.find((example) =>
+    example.sourceFile.endsWith('/good.md'),
+  );
+  const bad = examples.find((example) =>
+    example.sourceFile.endsWith('/bad.md'),
+  );
+  const skipped = examples.find((example) =>
+    example.sourceFile.endsWith('/skipped.md'),
+  );
+
+  if (!good || !bad || skipped || examples.length !== 2) {
+    throw new Error(
+      `Expected exactly good.md and bad.md, extracted ${examples.length}`,
+    );
+  }
+
+  const goodDiagnostics = result.diagnostics.filter(
+    (diagnostic) => diagnostic.example.id === good.id,
+  );
+  const badDiagnostics = result.diagnostics.filter(
+    (diagnostic) => diagnostic.example.id === bad.id,
+  );
+  const badMessages = badDiagnostics
+    .map((diagnostic) => diagnostic.message)
+    .join('\n');
+
+  if (goodDiagnostics.length > 0) {
+    throw new Error(
+      `Known-good fixture failed:\n${goodDiagnostics.map(formatDiagnostic).join('\n')}`,
+    );
+  }
+  if (badDiagnostics.length === 0) {
+    throw new Error('Known-bad fixture unexpectedly passed');
+  }
+  if (
+    !badMessages.includes('createMultivault') ||
+    !badMessages.includes('tripleId')
+  ) {
+    throw new Error(
+      `Known-bad fixture did not prove both stale API checks:\n${badDiagnostics
+        .map(formatDiagnostic)
+        .join('\n')}`,
+    );
+  }
+  if (result.unparsed.length > 0) {
+    throw new Error(`Unmapped tsc output:\n${result.unparsed.join('\n')}`);
+  }
+
+  console.log(`  PASS known-good fixture: ${good.id}`);
+  console.log('  PASS immediately-preceding skip comment excluded skipped.md');
+  console.log(
+    `  PASS known-bad fixture failed with ${badDiagnostics.length} diagnostics:`,
+  );
+  for (const diagnostic of badDiagnostics) {
+    console.log(`    ${formatDiagnostic(diagnostic)}`);
+  }
+  console.log(
+    'Self-test PASS: good passed; bad failed for stale export and result field.\n',
+  );
+}
+
+function runRealDocs(config) {
+  console.log('SDK documentation examples');
+  const files = expandIncludes(config.include);
+  const examples = extractExamples(files, config.skipComment);
+  const result = typecheckExamples(examples);
+  const ratchet = new Map(
+    config.knownFailing.map((entry) => [entry.id, entry]),
+  );
+  const diagnosticsByFence = new Map();
+
+  for (const diagnostic of result.diagnostics) {
+    const diagnostics = diagnosticsByFence.get(diagnostic.example.id) || [];
+    diagnostics.push(diagnostic);
+    diagnosticsByFence.set(diagnostic.example.id, diagnostics);
+  }
+
+  const expectedDiagnostics = result.diagnostics.filter((diagnostic) =>
+    ratchet.has(diagnostic.example.id),
+  );
+  const unexpectedDiagnostics = result.diagnostics.filter(
+    (diagnostic) => !ratchet.has(diagnostic.example.id),
+  );
+  const staleRatchet = config.knownFailing.filter(
+    (entry) => !diagnosticsByFence.has(entry.id),
+  );
+
+  console.log(`  Scanned ${files.length} Markdown/MDX files.`);
+  console.log(`  Extracted ${examples.length} qualifying TypeScript fences.`);
+
+  if (expectedDiagnostics.length > 0) {
+    console.log(
+      `  Expected ratcheted failures (${diagnosticsByFence.size - new Set(unexpectedDiagnostics.map((diagnostic) => diagnostic.example.id)).size} fences, ${expectedDiagnostics.length} diagnostics):`,
+    );
+    for (const group of config.knownFailingGroups) {
+      const diagnostics = group.ids.flatMap(
+        (id) => diagnosticsByFence.get(id) || [],
+      );
+      if (diagnostics.length === 0) continue;
+      console.log(
+        `    ${group.label}: ${group.ids.length} fence${group.ids.length === 1 ? '' : 's'}, ${diagnostics.length} diagnostic${diagnostics.length === 1 ? '' : 's'} — ${group.reason}`,
+      );
+      console.log(`      Fences: ${group.ids.join(', ')}`);
+      console.log(`      Representative: ${formatDiagnostic(diagnostics[0])}`);
+    }
+  }
+
+  if (unexpectedDiagnostics.length > 0) {
+    console.error(
+      `  NEW failures (${unexpectedDiagnostics.length} diagnostics):`,
+    );
+    for (const diagnostic of unexpectedDiagnostics) {
+      console.error(`    ${formatDiagnostic(diagnostic)}`);
+    }
+  }
+
+  if (staleRatchet.length > 0) {
+    console.error(
+      '  Ratchet entries that no longer fail (remove or update them):',
+    );
+    for (const entry of staleRatchet)
+      console.error(`    ${entry.id}: ${entry.reason}`);
+  }
+
+  if (result.unparsed.length > 0) {
+    console.error('  Unmapped tsc output:');
+    for (const line of result.unparsed) console.error(`    ${line}`);
+  }
+
+  const failed =
+    unexpectedDiagnostics.length > 0 ||
+    staleRatchet.length > 0 ||
+    result.unparsed.length > 0 ||
+    (result.status !== 0 && result.diagnostics.length === 0);
+
+  if (failed) {
+    throw new Error(
+      'SDK documentation example validation failed. New failures must be fixed or explicitly ratcheted.',
+    );
+  }
+
+  console.log(
+    `Validation PASS: ${examples.length} fences checked; ${expectedDiagnostics.length} known diagnostics remain ratcheted; 0 new diagnostics.\n`,
+  );
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const config = readConfig();
+
+  if (args.runSelfTest) runSelfTest(config);
+  if (args.runRealDocs) runRealDocs(config);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`\nERROR: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/validate-sdk-examples.js
+++ b/scripts/validate-sdk-examples.js
@@ -331,8 +331,21 @@ function extractExamplesFromSource(relativeFile, source, skipComment) {
     index = closingIndex;
   }
 
-  const contentCounts = new Map();
+  const extractedCandidates = [];
   for (const candidate of candidates) {
+    if (candidate.skipped) {
+      coverage.skippedByAnnotation++;
+    } else if (IMPORT_PATTERN.test(candidate.code)) {
+      extractedCandidates.push(candidate);
+    } else {
+      coverage.excludedByCriterion++;
+    }
+  }
+
+  // Ordinals count extracted fences only: a skipped or excluded neighbor with
+  // an identical body must never shift a tracked fence's identity.
+  const contentCounts = new Map();
+  for (const candidate of extractedCandidates) {
     contentCounts.set(
       candidate.contentHash,
       (contentCounts.get(candidate.contentHash) || 0) + 1,
@@ -340,27 +353,19 @@ function extractExamplesFromSource(relativeFile, source, skipComment) {
   }
 
   const contentOrdinals = new Map();
-  for (const candidate of candidates) {
+  for (const candidate of extractedCandidates) {
     const ordinal = (contentOrdinals.get(candidate.contentHash) || 0) + 1;
     contentOrdinals.set(candidate.contentHash, ordinal);
-
-    if (candidate.skipped) {
-      coverage.skippedByAnnotation++;
-    } else if (IMPORT_PATTERN.test(candidate.code)) {
-      const duplicateCount = contentCounts.get(candidate.contentHash);
-      examples.push({
-        id: fenceIdentity(relativeFile, candidate.contentHash, ordinal),
-        sourceFile: relativeFile,
-        fenceLine: candidate.fenceLine,
-        code: candidate.code,
-        contentHash: candidate.contentHash,
-        contentOrdinal: ordinal,
-        duplicateCount,
-      });
-      coverage.extracted++;
-    } else {
-      coverage.excludedByCriterion++;
-    }
+    examples.push({
+      id: fenceIdentity(relativeFile, candidate.contentHash, ordinal),
+      sourceFile: relativeFile,
+      fenceLine: candidate.fenceLine,
+      code: candidate.code,
+      contentHash: candidate.contentHash,
+      contentOrdinal: ordinal,
+      duplicateCount: contentCounts.get(candidate.contentHash),
+    });
+    coverage.extracted++;
   }
 
   return { examples, coverage };
@@ -856,6 +861,45 @@ function runSelfTest(config) {
     );
   }
 
+  const skipCrossedBefore = `${ratchetedSource}${config.skipComment}\n${ratchetedSource}`;
+  const skipCrossedAfter = `${config.skipComment}\n${ratchetedSource}\n${ratchetedSource}`;
+  const skipBeforeExtraction = extractExamplesFromSource(
+    ratcheted.sourceFile,
+    skipCrossedBefore,
+    config.skipComment,
+  );
+  const skipAfterExtraction = extractExamplesFromSource(
+    ratcheted.sourceFile,
+    skipCrossedAfter,
+    config.skipComment,
+  );
+  const skipBeforeTracked = skipBeforeExtraction.examples[0];
+  const skipAfterTracked = skipAfterExtraction.examples[0];
+  const skipCrossedResult = typecheckExamples([skipAfterTracked]);
+  const skipCrossedComparison = compareRatchet(
+    skipCrossedResult.diagnostics,
+    attachExamples([fixtureRatchet], [skipAfterTracked]),
+  );
+
+  if (
+    skipBeforeExtraction.examples.length !== 1 ||
+    skipAfterExtraction.examples.length !== 1 ||
+    skipBeforeExtraction.coverage.skippedByAnnotation !== 1 ||
+    skipAfterExtraction.coverage.skippedByAnnotation !== 1 ||
+    !skipBeforeTracked ||
+    !skipAfterTracked ||
+    skipBeforeTracked.id !== ratcheted.id ||
+    skipAfterTracked.id !== ratcheted.id ||
+    skipAfterTracked.contentOrdinal !== 1 ||
+    skipCrossedResult.unparsed.length > 0 ||
+    skipCrossedComparison.unexpectedDiagnostics.length > 0 ||
+    skipCrossedComparison.mismatches.length > 0
+  ) {
+    throw new Error(
+      'Skip-crossed fixture did not keep a tracked fence identity stable across an identical skipped fence',
+    );
+  }
+
   console.log(`  ${formatCoverage(coverage)}`);
   console.log(`  PASS known-good fixture: ${displayFence(good)}`);
   console.log('  PASS immediately-preceding skip comment excluded skipped.md');
@@ -875,13 +919,16 @@ function runSelfTest(config) {
     `  PASS duplicate-fence ordinals: identical failing fences at L${duplicates[0].fenceLine} and L${duplicates[1].fenceLine} received ordinals 1 and 2; both ratcheted and validation PASS.`,
   );
   console.log(
+    `  PASS skip-crossed: tracked fence kept identity ${ratcheted.id.split('#').slice(1).join('#')} after moving across an identical skipped fence; validation PASS with NO ratchet update needed.`,
+  );
+  console.log(
     `  PASS known-bad fixture failed with ${badDiagnostics.length} diagnostics:`,
   );
   for (const diagnostic of badDiagnostics) {
     console.log(`    ${formatDiagnostic(diagnostic)}`);
   }
   console.log(
-    'Self-test PASS: good passed; known-bad failed; TSX extracted; moved content stayed ratcheted; edited content failed; duplicate ordinals validated.\n',
+    'Self-test PASS: good passed; known-bad failed; TSX extracted; moved content stayed ratcheted; edited content failed; duplicate ordinals validated; skip-crossed identity stable.\n',
   );
 }
 


### PR DESCRIPTION
## Summary

SDK code examples in the docs have repeatedly drifted from the published packages — wrong exports, stale result shapes, incorrect argument types — and nothing caught it. This adds a validation harness that extracts TypeScript fences from the SDK docs and typechecks them against **exact pinned versions** of `@0xintuition/sdk`, `@0xintuition/graphql`, and `viem`.

## How it works

- `scripts/validate-sdk-examples.js` (zero-dependency Node) scans the SDK doc pages, extracts import-bearing `ts`/`typescript`/`tsx` fences, and runs `tsc` over them with pinned packages.
- **Fingerprint ratchet**: pre-existing failures are baselined in `scripts/sdk-examples.config.json` — each known-failing fence carries the exact fingerprints (error code + message hash) of its expected diagnostics. Any *new* diagnostic on any fence fails the run, in both directions: an added error fails, and a fixed-but-still-listed error fails too, so the baseline can only be refreshed deliberately via `--update-ratchet`, never silently grown.
- **Coverage is visible**: every run prints fences found / extracted / excluded / skipped, so partial snippets outside the gate are never silently invisible.
- Self-test fixtures (known-good, known-bad, ratcheted, skipped) run before the real docs and prove the harness catches what it claims to catch.
- CI workflow runs on PRs touching SDK docs or the harness itself.

## Current baseline

87 known-failing fences across 14 files (mostly partial snippets that omit client setup, or integration guides importing packages outside the pinned set). The ratchet ensures this number can only shrink — new regressions fail CI immediately.

## Limitations

- Import-less partial fences are outside the gate and rely on content review (documented in the config).
- Baseline refreshes are a deliberate maintenance command (`node scripts/validate-sdk-examples.js --update-ratchet`), refused if it would add new failures or retain clean entries.