### PR TITLE
feat: add a static discovery fallback to the homepage for non-JS clients

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,69 @@
 import { Redirect } from '@docusaurus/router';
 
 export default function Home() {
-  return <Redirect to="/docs" />;
+  return (
+    <>
+      <Redirect to="/docs" />
+      <noscript>
+        <main>
+          <h1>Intuition Documentation</h1>
+          <p>
+            Learn how to build with Intuition&apos;s decentralized knowledge
+            graph, protocol, APIs, and developer tools.
+          </p>
+
+          <nav aria-label="Documentation areas">
+            <h2>Explore the documentation</h2>
+            <ul>
+              <li>
+                <a href="/docs/getting-started/overview">Getting Started</a>
+              </li>
+              <li>
+                <a href="/docs/quick-start/using-the-sdk">Quick Start</a>
+              </li>
+              <li>
+                <a href="/docs/intuition-concepts">Concepts</a>
+              </li>
+              <li>
+                <a href="/docs/intuition-sdk/installation-and-setup">SDK</a>
+              </li>
+              <li>
+                <a href="/docs/graphql-api/overview">GraphQL API</a>
+              </li>
+              <li>
+                <a href="/docs/protocol/getting-started/overview">Protocol</a>
+              </li>
+              <li>
+                <a href="/docs/intuition-smart-contracts">Contracts</a>
+              </li>
+              <li>
+                <a href="/docs/intuition-network">Network</a>
+              </li>
+              <li>
+                <a href="/docs/tutorials/overview">Tutorials</a>
+              </li>
+            </ul>
+          </nav>
+
+          <section aria-labelledby="llm-documentation">
+            <h2 id="llm-documentation">Documentation for language models</h2>
+            <ul>
+              <li>
+                <a href="/llms.txt">llms.txt</a> — a concise index of the
+                documentation.
+              </li>
+              <li>
+                <a href="/llms-medium.txt">llms-medium.txt</a> — a balanced
+                documentation set with additional context.
+              </li>
+              <li>
+                <a href="/llms-full.txt">llms-full.txt</a> — the complete
+                documentation corpus in an LLM-friendly format.
+              </li>
+            </ul>
+          </section>
+        </main>
+      </noscript>
+    </>
+  );
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -54,8 +54,8 @@ export default function Home() {
               </li>
               <li>
                 <a href="/llms-medium.txt">llms-medium.txt</a> — condensed
-                prose summaries of every page, without code samples, sized to
-                fit in a model context window.
+                summaries of every page, a fraction of the size of the full
+                corpus.
               </li>
               <li>
                 <a href="/llms-full.txt">llms-full.txt</a> — the complete

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -22,7 +22,7 @@ export default function Home() {
                 <a href="/docs/quick-start/using-the-sdk">Quick Start</a>
               </li>
               <li>
-                <a href="/docs/intuition-concepts">Concepts</a>
+                <a href="/docs/intuition-concepts/primitives">Concepts</a>
               </li>
               <li>
                 <a href="/docs/intuition-sdk/installation-and-setup">SDK</a>
@@ -53,8 +53,9 @@ export default function Home() {
                 documentation.
               </li>
               <li>
-                <a href="/llms-medium.txt">llms-medium.txt</a> — a balanced
-                documentation set with additional context.
+                <a href="/llms-medium.txt">llms-medium.txt</a> — condensed
+                prose summaries of every page, without code samples, sized to
+                fit in a model context window.
               </li>
               <li>
                 <a href="/llms-full.txt">llms-full.txt</a> — the complete


### PR DESCRIPTION
## Summary

The docs homepage is a client-side redirect — with JavaScript disabled it renders nothing. Crawlers, text browsers, and agents fetching raw HTML get an empty page with no way to discover the documentation.

This adds a `<noscript>` fallback to `src/pages/index.jsx`:

- The existing JS redirect to `/docs` is preserved and unchanged for browsers.
- Non-JS clients now get a static nav: nine entry-point links into the documentation (getting started, concepts, SDK, GraphQL API, protocol, contracts, network, tutorials) plus the three `llms*.txt` artifacts.
- Every link is route-verified against the production build output — including the Concepts entry, which points at a real content page rather than an auto-generated category route.

## Accuracy notes

The three llms artifact descriptions state only verified facts:
- `llms.txt` — a concise index (39 linked entries, no code).
- `llms-medium.txt` — condensed summaries of every page (228/228 eligible source pages), at ~18% of the size of the full corpus.
- `llms-full.txt` — the complete corpus (all 228 page sections present).

No visual change for JS-enabled browsers.